### PR TITLE
fix(install/uninstall): robust against curl|bash and divergent clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ On first launch the app will ask you to add a printer.
 To completely remove Moongate from your Pi, SSH in and run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/klipper-plugin/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/klipper-plugin/uninstall.sh | MOONGATE_YES=1 bash
 ```
+
+(`MOONGATE_YES=1` skips the confirmation prompt, which can't be answered interactively when piping through `bash`. Omit it if you download the script first.)
 
 This removes:
 - The `moongate-tunnel` and `moongate-authproxy` systemd services

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -74,18 +74,19 @@ if [[ -d "$MOONGATE_DIR/.git" ]]; then
     CURRENT_BRANCH="$(git -C "$MOONGATE_DIR" branch --show-current 2>/dev/null || echo unknown)"
     if [[ "$CURRENT_BRANCH" == "master" ]]; then
         info "Repo on master — pulling latest..."
-        # Robust update: a `git pull --ff-only` can fail fatally with
-        # "refusing to merge unrelated histories" when the local clone has
-        # commits that share no ancestor with origin/master (e.g. an older
-        # fork, or a prior upstream force-push). set -e would then abort
-        # the installer mid-way. Fall back to re-cloning fresh, preserving
-        # the broken clone for forensic inspection.
+        # Robust update: `git pull --ff-only` can fail fatally for several
+        # reasons — divergent history (force-push upstream), dirty working
+        # tree (CRLF conversion, manual edits), untracked files that would
+        # be overwritten, or local commits ahead of master. set -e would
+        # then abort the installer mid-way. Fall back to re-cloning fresh,
+        # preserving the broken clone for forensic inspection. (Git's own
+        # error message printed above tells the user the specific cause.)
         if git -C "$MOONGATE_DIR" fetch origin master \
             && git -C "$MOONGATE_DIR" merge --ff-only origin/master; then
             success "Repository updated."
         else
             BROKEN_DIR="${MOONGATE_DIR}.broken-$(date +%Y%m%d-%H%M%S)"
-            warn "Local clone can't fast-forward to origin/master (divergent history)."
+            warn "Local clone can't fast-forward to origin/master (see git error above)."
             warn "Moving aside to $BROKEN_DIR and re-cloning fresh."
             mv "$MOONGATE_DIR" "$BROKEN_DIR"
             git clone --depth=1 "$MOONGATE_REPO" "$MOONGATE_DIR"

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -74,8 +74,23 @@ if [[ -d "$MOONGATE_DIR/.git" ]]; then
     CURRENT_BRANCH="$(git -C "$MOONGATE_DIR" branch --show-current 2>/dev/null || echo unknown)"
     if [[ "$CURRENT_BRANCH" == "master" ]]; then
         info "Repo on master — pulling latest..."
-        git -C "$MOONGATE_DIR" pull --ff-only
-        success "Repository updated."
+        # Robust update: a `git pull --ff-only` can fail fatally with
+        # "refusing to merge unrelated histories" when the local clone has
+        # commits that share no ancestor with origin/master (e.g. an older
+        # fork, or a prior upstream force-push). set -e would then abort
+        # the installer mid-way. Fall back to re-cloning fresh, preserving
+        # the broken clone for forensic inspection.
+        if git -C "$MOONGATE_DIR" fetch origin master \
+            && git -C "$MOONGATE_DIR" merge --ff-only origin/master; then
+            success "Repository updated."
+        else
+            BROKEN_DIR="${MOONGATE_DIR}.broken-$(date +%Y%m%d-%H%M%S)"
+            warn "Local clone can't fast-forward to origin/master (divergent history)."
+            warn "Moving aside to $BROKEN_DIR and re-cloning fresh."
+            mv "$MOONGATE_DIR" "$BROKEN_DIR"
+            git clone --depth=1 "$MOONGATE_REPO" "$MOONGATE_DIR"
+            success "Repository re-cloned. Old clone preserved at $BROKEN_DIR"
+        fi
     else
         warn "Repo on branch '$CURRENT_BRANCH' (not master) — skipping git pull."
         warn "Run 'git pull' manually if you intended to update."

--- a/klipper-plugin/uninstall.sh
+++ b/klipper-plugin/uninstall.sh
@@ -2,7 +2,9 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Moongate uninstaller
 # Run on your Klipper Pi:
-#   curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/klipper-plugin/uninstall.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/klipper-plugin/uninstall.sh | MOONGATE_YES=1 bash
+# or, with an interactive confirmation prompt:
+#   curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/klipper-plugin/uninstall.sh -o /tmp/u.sh && bash /tmp/u.sh
 #
 # Removes the plugin, tunnel service, repo clone, and all config data.
 # Does NOT remove cloudflared itself (it may be used by other services).
@@ -13,6 +15,7 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC
 info()    { echo -e "${BLUE}[moongate]${NC} $*"; }
 success() { echo -e "${GREEN}[moongate]${NC} $*"; }
 warn()    { echo -e "${YELLOW}[moongate]${NC} $*"; }
+die()     { echo -e "${RED}[moongate] ERROR:${NC} $*" >&2; exit 1; }
 
 MOONGATE_DIR="${MOONGATE_DIR:-$HOME/moongate}"
 MOONRAKER_DIR="${MOONRAKER_DIR:-$HOME/moonraker}"
@@ -38,7 +41,21 @@ echo ""
 echo "And RESTORE (from ~/.config/moongate/v0.4-backup/ if present):"
 echo "  • moonraker.conf — back to pre-v0.4 (Moonraker bound to 0.0.0.0)"
 echo ""
-read -r -p "Continue? [y/N] " confirm
+# Honor explicit non-interactive confirmation (env var or flag) before the
+# TTY check. Required for `curl ... | bash` because bash's stdin is the
+# script content — `read` can't reach the user's keyboard, so an interactive
+# prompt would silently abort.
+if [[ "${MOONGATE_YES:-}" == "1" ]] || [[ "${1:-}" == "-y" ]] || [[ "${1:-}" == "--yes" ]]; then
+    confirm=y
+elif [[ -t 0 ]]; then
+    read -r -p "Continue? [y/N] " confirm
+else
+    die "Cannot prompt for confirmation (stdin is not a terminal).
+To run via curl|bash, set MOONGATE_YES=1:
+    curl -fsSL <url> | MOONGATE_YES=1 bash
+Or download first and run with -y:
+    curl -fsSL <url> -o /tmp/u.sh && bash /tmp/u.sh -y"
+fi
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     echo "Aborted."
     exit 0
@@ -62,6 +79,16 @@ if [[ -f /etc/systemd/system/moongate-tunnel.service ]]; then
     sudo rm -f /etc/systemd/system/moongate-tunnel.service
     sudo systemctl daemon-reload
     success "moongate-tunnel service removed"
+fi
+
+# Kill any lingering cloudflared process — guarantees a fresh tunnel URL on
+# the next install. systemctl stop reaps the managed PID, but a manually-
+# started cloudflared (or one orphaned from a half-finished prior install)
+# would survive otherwise and hold the existing URL.
+if pgrep -f "cloudflared tunnel" >/dev/null 2>&1; then
+    pkill -f "cloudflared tunnel" 2>/dev/null || true
+    sleep 1
+    success "Killed lingering cloudflared tunnel process(es)"
 fi
 
 # Tunnel log


### PR DESCRIPTION
## Summary

Three issues found while diagnosing a user-reported `v0.2.x → v0.4.0` upgrade failure on a BTT-CB1.

### 1. Uninstall silently aborted under `curl ... | bash`
The confirmation prompt uses `read -r -p`, but bash's stdin in that pipeline is the script content (not a TTY) — so `read` can't get a real answer and `$confirm` is never `y`. User saw `Aborted.` and was stuck.

**Fix:** Detect non-TTY stdin and honor `MOONGATE_YES=1` env var or `-y` / `--yes` flag. Otherwise exit with a clear error message naming the supported invocations.

### 2. Install aborted with "refusing to merge unrelated histories"
When the local `~/moongate` clone shares no common ancestor with `origin/master` (e.g. force-replaced upstream history — the BTT-CB1 had master at `492eb6c`, currently unreachable), `git pull --ff-only` fails fatally. `set -e` then kills the installer mid-way, leaving an inconsistent state.

**Fix:** When the fast-forward fails (any cause), move the broken clone aside to `~/moongate.broken-<timestamp>` and `git clone` fresh. The plugin clone is treated as disposable infrastructure; any local edits are preserved in the broken dir for inspection.

### 3. Uninstall defensively kills cloudflared
`systemctl stop moongate-tunnel` normally reaps the cloudflared process, but an orphan started outside systemd (or one from a half-finished prior install) would survive and hold the existing Quick Tunnel URL. Now `pkill -f \"cloudflared tunnel\"` after the systemctl stop — guarantees a fresh URL on the next install.

### Docs
README and `uninstall.sh` header updated to document `MOONGATE_YES=1` for the curl|bash uninstall path.

## Test plan

- [x] `bash -n` clean on both install.sh and uninstall.sh
- [x] Verified all four confirmation paths in uninstall.sh: interactive TTY, `MOONGATE_YES=1`, `-y`, `--yes`, and non-TTY rejection produces clear actionable die message
- [x] Verified full v0.2.11 → v0.4.0 upgrade on 192.168.1.251 (Voron 2.4 / aarch64 / Kalico): uninstall ran clean, fresh install completed with new tunnel URL (`consciousness-hon-cio-walnut.trycloudflare.com`, was `discussion-expressed-debate-feof`), all four services active, auth proxy 401-gating intact
- [ ] User to verify: re-running the failing install on the BTT-CB1 with these fixes recovers cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)