### PR TITLE
chore: remove unused `os` import to green ruff

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -31,7 +31,6 @@ import base64
 import hashlib
 import json
 import logging
-import os
 import random
 import re
 import string


### PR DESCRIPTION
## Summary

One-line: drop `import os` from [klipper-plugin/moongate_standalone.py:34](https://github.com/PEEKYPAUL/Moongate/blob/master/klipper-plugin/moongate_standalone.py#L34). The import has been unused since before the v0.4 release, and the `Moonraker plugin lint` CI job has been failing on this F401 across recent merges (including the v0.4.0 release commit and PR #3).

Verified zero `os.` references in the file via grep before removing.

## Test plan

- [x] Single-line removal, no runtime change
- [x] Grep confirmed no `os.` usages
- [ ] CI `Moonraker plugin lint` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)