### PR TITLE
feat(v0.4.2): Pi-signed force-release closes the v0.3.1 un-pair gap

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -441,6 +441,22 @@ class SupabaseClient:
             "signature":     signature_b64,
         })
 
+    def release_pi_signed(
+        self,
+        pi_public_key_b64: str,
+        timestamp: int,
+        signature_b64: str,
+    ) -> tuple[int, dict]:
+        """Force-release the printer row in Supabase using a Pi-signed
+        request. Server verifies the signature against pi_public_key and
+        deletes the row regardless of owner. Used by MOONGATE_RESET_OWNER
+        so a wiped-app user can re-pair from a fresh anon UID."""
+        return self._post("/release-printer", {
+            "pi_public_key": pi_public_key_b64,
+            "timestamp":     timestamp,
+            "signature":     signature_b64,
+        })
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # HeartbeatLoop
@@ -691,22 +707,23 @@ class MoongatePlugin:
             logger.error("run_gcode failed: %s", exc)
 
     async def _klipper_reset_owner(self) -> None:
-        """MOONGATE_RESET_OWNER macro entry point. Wipes the local owner
-        binding so the printer can be re-paired. Does not delete the remote
-        printer row — Supabase's 6-week inactivity sweep handles that, or
-        the user can do it manually."""
-        had_owner = self.owner is not None
+        """MOONGATE_RESET_OWNER macro entry point. Wipes local owner binding
+        AND attempts a Pi-signed force-release of the cloud row so a fresh
+        app install (new anon UID) can re-pair without bouncing off
+        'already_paired'. Closes the v0.3.1 un-pair gap."""
         prior_pid = self.owner.printer_id[:8] if self.owner else None
-        self._wipe_owner()
+        had_owner, cloud_status = await self._do_factory_reset()
 
         await asyncio.sleep(0.3)
         if had_owner:
-            msg = f"M118 Moongate: owner state wiped (was {prior_pid}…)"
+            local_msg = f"M118 Moongate: owner state wiped (was {prior_pid}…)"
         else:
-            msg = "M118 Moongate: no owner state (already unpaired)"
+            local_msg = "M118 Moongate: no owner state (already unpaired)"
+        cloud_msg = self._cloud_status_m118(cloud_status)
         script = "\n".join([
             "M118 ============================================",
-            msg,
+            local_msg,
+            cloud_msg,
             "M118 Run MOONGATE_PAIR to re-pair.",
             "M118 ============================================",
         ])
@@ -715,6 +732,48 @@ class MoongatePlugin:
             await klippy_apis.run_gcode(script)
         except Exception as exc:
             logger.error("run_gcode failed: %s", exc)
+
+    async def _do_factory_reset(self) -> tuple[bool, int]:
+        """Shared reset path used by the macro and the HTTP endpoint:
+        wipe local owner.json + try to release the cloud row. Returns
+        (had_owner_before, cloud_release_status). cloud_status is the
+        HTTP code from the Pi-signed POST, with 0 meaning "network
+        error / no answer at all"."""
+        had_owner = self.owner is not None
+        self._wipe_owner()
+        # urllib in SupabaseClient is sync; off-load to a thread so the
+        # asyncio loop is free for other work (matters because the macro
+        # runs inline on Moonraker's loop).
+        loop = asyncio.get_event_loop()
+        cloud_status = await loop.run_in_executor(None, self._release_in_cloud)
+        return had_owner, cloud_status
+
+    def _release_in_cloud(self) -> int:
+        """Sign + POST a release request. Returns the HTTP status.
+        0 means the request didn't reach Supabase at all (DNS, offline)."""
+        ts        = int(time.time())
+        pk_b64    = self.device.public_key_b64
+        canonical = f"moongate-release\n{pk_b64}\n{ts}".encode()
+        sig_b64   = self.device.sign_b64(canonical)
+
+        status, body = self.sb.release_pi_signed(pk_b64, ts, sig_b64)
+        if status == 200:
+            logger.info("Cloud row released for pi_pubkey=%s...", pk_b64[:8])
+        elif status == 0:
+            logger.warning("Cloud release skipped: network unavailable (%s)", body)
+        else:
+            logger.warning("Cloud release returned HTTP %s: %s", status, body)
+        return status
+
+    @staticmethod
+    def _cloud_status_m118(status: int) -> str:
+        """Turn an HTTP status from _release_in_cloud into a one-line
+        M118 message for the Mainsail console."""
+        if status == 200:
+            return "M118 Cloud row released."
+        if status == 0:
+            return "M118 Cloud release skipped — network unavailable."
+        return f"M118 Cloud release failed — HTTP {status}."
 
     def _wipe_owner(self) -> None:
         self.owner = None
@@ -903,12 +962,17 @@ class MoongatePlugin:
 
     async def _handle_reset_owner(self, webrequest: Any) -> dict:
         """LAN-only owner reset (no token required by design; LAN access is
-        a stronger signal than a JWT for recovery)."""
+        a stronger signal than a JWT for recovery). Same semantics as the
+        MOONGATE_RESET_OWNER macro: wipes local owner.json AND attempts
+        a Pi-signed force-release of the cloud row."""
         if not self._is_lan_request(webrequest):
             raise self.server.error("Reset must be triggered from the local LAN", 403)
-        had_owner = self.owner is not None
-        self._wipe_owner()
-        return {"ok": True, "had_owner": had_owner}
+        had_owner, cloud_status = await self._do_factory_reset()
+        return {
+            "ok":           True,
+            "had_owner":    had_owner,
+            "cloud_status": cloud_status,
+        }
 
     # ── Webcam + chamber discovery (kept from v0.2.x) ─────────────────────────
 

--- a/supabase/functions/release-printer/index.ts
+++ b/supabase/functions/release-printer/index.ts
@@ -1,23 +1,24 @@
 // POST /functions/v1/release-printer
 //
-// Called by the app when the user taps "Remove printer". Deletes the printer
-// row in Supabase so the Pi can be re-paired. Idempotent: returns 200 even
-// if the row is already gone.
+// Two auth modes, distinguished by request body shape:
 //
-// Caller MUST present a Supabase JWT in the Authorization header.
-// Ownership is enforced inside the RPC; non-owners get an indistinguishable
-// 404 response.
+//   1. User-JWT (app's "Remove printer"):
+//        Authorization: Bearer <supabase jwt>
+//        body: { "printer_id": "<uuid>" }
+//      Ownership enforced inside release_printer RPC; non-owners get 404.
 //
-// Request body:
-//   { "printer_id": "<uuid>" }
+//   2. Pi-signed force-release (Pi's MOONGATE_RESET_OWNER):
+//        body: { "pi_public_key": "<b64>", "timestamp": <unix>, "signature": "<b64>" }
+//      Pi signs canonical payload with its Ed25519 device key; signature
+//      proves physical access. Deletes the row regardless of current owner,
+//      so a fresh app install can re-pair without 'already_paired'.
 //
-// Response 200:
-//   { "ok": true }
+// Idempotent in both modes. 200 even if the row was already gone.
 //
 // Errors:
 //   400 — malformed body
-//   401 — no/invalid JWT
-//   404 — printer exists but not owned by caller (constant shape)
+//   401 — user mode: missing/invalid JWT; Pi mode: bad signature or replay window
+//   404 — user mode only: printer exists but caller isn't the owner (constant shape)
 //   500 — internal
 
 import { handleCorsPreflight } from "../_shared/cors.ts";
@@ -26,21 +27,88 @@ import {
   methodNotAllowed, internalError,
 } from "../_shared/responses.ts";
 import { adminClient, getUserFromRequest } from "../_shared/supabaseClients.ts";
+import { verifyEd25519, base64ToBytes } from "../_shared/cryptoUtils.ts";
+
+const REPLAY_WINDOW_SECONDS = 60;
 
 Deno.serve(async (req) => {
   const preflight = handleCorsPreflight(req);
   if (preflight) return preflight;
   if (req.method !== "POST") return methodNotAllowed();
 
-  const user = await getUserFromRequest(req);
-  if (!user) return unauthorized();
-
-  let body: { printer_id?: unknown };
+  let body: {
+    printer_id?:    unknown;
+    pi_public_key?: unknown;
+    timestamp?:     unknown;
+    signature?:     unknown;
+  };
   try {
     body = await req.json();
   } catch {
     return badRequest("invalid_json");
   }
+
+  // Body shape discriminates the auth mode. Presence of pi_public_key
+  // selects the Pi-signed path; anything else falls through to user-JWT.
+  if (body.pi_public_key !== undefined) {
+    return await handlePiSignedRelease(body);
+  }
+  return await handleUserRelease(req, body);
+});
+
+async function handlePiSignedRelease(body: {
+  pi_public_key?: unknown;
+  timestamp?:     unknown;
+  signature?:     unknown;
+}): Promise<Response> {
+  const piPubKey  = body.pi_public_key;
+  const timestamp = body.timestamp;
+  const signature = body.signature;
+
+  if (typeof piPubKey  !== "string") return badRequest("pi_public_key required");
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    return badRequest("timestamp required (unix seconds)");
+  }
+  if (typeof signature !== "string") return badRequest("signature required");
+
+  try {
+    const pkBytes = base64ToBytes(piPubKey);
+    if (pkBytes.length !== 32) return badRequest("pi_public_key must decode to 32 bytes");
+  } catch {
+    return badRequest("invalid pi_public_key base64");
+  }
+
+  // Replay window — mirrors printer-heartbeat (±60s on server clock).
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > REPLAY_WINDOW_SECONDS) {
+    return unauthorized();
+  }
+
+  // Canonical payload matches what the Pi plugin signs in _release_in_cloud.
+  // Domain-separated from heartbeat by the first line ("moongate-release"
+  // vs "moongate-heartbeat") so a captured heartbeat signature can't be
+  // replayed as a release.
+  const canonical = `moongate-release\n${piPubKey}\n${timestamp}`;
+  const message   = new TextEncoder().encode(canonical);
+  const ok        = await verifyEd25519(piPubKey, signature, message);
+  if (!ok) return unauthorized();
+
+  const db = adminClient();
+  const { error } = await db.rpc("release_printer_by_pubkey", {
+    p_pi_public_key: piPubKey,
+  });
+  if (error) {
+    console.error("release_printer_by_pubkey rpc error", error);
+    return internalError();
+  }
+  return jsonResponse({ ok: true });
+}
+
+async function handleUserRelease(req: Request, body: {
+  printer_id?: unknown;
+}): Promise<Response> {
+  const user = await getUserFromRequest(req);
+  if (!user) return unauthorized();
 
   const printerId = body.printer_id;
   if (typeof printerId !== "string" || printerId.length === 0) {
@@ -68,4 +136,4 @@ Deno.serve(async (req) => {
     default:
       return notFound();
   }
-});
+}

--- a/supabase/migrations/20260528210000_pi_signed_release.sql
+++ b/supabase/migrations/20260528210000_pi_signed_release.sql
@@ -1,0 +1,40 @@
+-- Moongate v0.4.2 — Pi-signed force-release path.
+--
+-- Closes the v0.3.1 gap that MOONGATE_RESET_OWNER could only ever clean
+-- *local* state. When a user wipes the app (loses their anon UID), the
+-- cloud row stays owned by an unreachable user. The next pair attempt from
+-- a fresh anon UID then hits 'already_paired' from claim_printer, and the
+-- only recovery was manual SQL (which we did twice today).
+--
+-- With this migration the Pi itself can release the cloud row by signing
+-- a request with its existing Ed25519 device key. The signature proves
+-- physical access to the Pi — strong enough authority to force-delete
+-- the row regardless of who owns it. The Edge Function performs the
+-- verification before calling this RPC.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.release_printer_by_pubkey(
+  p_pi_public_key text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Idempotent. The row may already be gone; the Pi might be retrying
+  -- after a transient error, or the user may have triggered the app-side
+  -- release flow first.
+  DELETE FROM printers          WHERE pi_public_key = p_pi_public_key;
+  DELETE FROM enrollment_tokens WHERE pi_public_key = p_pi_public_key;
+  RETURN 'ok';
+END;
+$$;
+
+COMMENT ON FUNCTION public.release_printer_by_pubkey IS
+  'Called by Edge Function release-printer on the Pi-signed force-release path. Authentication happens before the RPC call (Ed25519 signature verified against pi_public_key); this RPC is just the delete.';
+
+REVOKE EXECUTE ON FUNCTION public.release_printer_by_pubkey(text) FROM PUBLIC;
+
+COMMIT;


### PR DESCRIPTION
## Why

`MOONGATE_RESET_OWNER` previously only wiped local `owner.json`. If a user later wiped the app (losing their Supabase anon UID), the cloud row stayed orphaned with the no-longer-reachable owner, and any fresh re-pair attempt bounced off `claim_printer` with `already_paired`. We hit this twice today; the only recovery was manual SQL via the dashboard.

After this PR, a user who wipes their app can just `MOONGATE_RESET_OWNER` on the Pi and immediately `MOONGATE_PAIR` cleanly — no SQL.

## Design

The Pi already has an Ed25519 device key that signs heartbeats. The same key signs a release request; the server treats the signature as proof of physical access and force-deletes the row regardless of who currently owns it.

**Canonical payload signed by Pi:**
```
"moongate-release\n" + pi_public_key + "\n" + timestamp
```

First line domain-separates from `"moongate-heartbeat\n..."` so a captured heartbeat signature can't be replayed as a release. ±60s replay window on `timestamp`, same as heartbeat.

## Changes

### Migration `20260528210000_pi_signed_release.sql`
- New RPC `release_printer_by_pubkey(p_pi_public_key text)` — admin-only (`SECURITY DEFINER`), no ownership check, idempotent. The Edge Function performs signature verification before invoking it.

### `release-printer` Edge Function
- Two auth modes in one endpoint, discriminated by request body shape:
  - **User-JWT** (existing): `Authorization: Bearer <jwt>` + `{ printer_id }` — unchanged.
  - **Pi-signed** (new): no Authorization header, `{ pi_public_key, timestamp, signature }`. Verifies signature against the canonical payload, deletes via the new RPC.

### Plugin `moongate_standalone.py`
- New `SupabaseClient.release_pi_signed()` method.
- New `_do_factory_reset()` helper shared by both reset paths: wipes local `owner.json` then attempts the Pi-signed release via `_release_in_cloud()`.
- `MOONGATE_RESET_OWNER` macro: console output now reports cloud release status ("Cloud row released" / "skipped — network unavailable" / "failed — HTTP N"). Local wipe always succeeds; cloud is best-effort.
- LAN-only HTTP endpoint `/server/moongate/reset-owner` uses the same helper; response now includes `cloud_status`.

## Test plan

- [x] `python3 -m py_compile` clean on the updated plugin
- [ ] Deploy migration + Edge Function to remote
- [ ] Deploy updated plugin to 192.168.1.251 (scp + Moonraker restart)
- [ ] Pair .251 with a fresh anon UID (already done — see `b88da66c-...` row)
- [ ] Run `MOONGATE_RESET_OWNER` on .251 console; expect M118 \"Cloud row released.\"
- [ ] Query Supabase: confirm `b88da66c-...` row is gone
- [ ] Run `MOONGATE_PAIR` + scan QR with the app; expect successful re-pair with new owner row (no `already_paired` bounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)