### PR TITLE
feat(v0.4.2): poke heartbeat on MOONGATE_PAIR — sub-second pair-to-live

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -480,6 +480,10 @@ class HeartbeatLoop:
         self.on_unpaired = on_unpaired_cb
         self._task: Optional[asyncio.Task] = None
         self._last_url_reported: Optional[str] = None
+        # Created in _run() so it binds to the running loop. None until
+        # the loop has started; request_immediate_send() is a no-op in
+        # that window.
+        self._poke_event: Optional[asyncio.Event] = None
 
     def start(self) -> None:
         if self._task is None or self._task.done():
@@ -493,15 +497,33 @@ class HeartbeatLoop:
     async def _run(self) -> None:
         # First heartbeat after a brief delay so cloudflared has time to come up
         await asyncio.sleep(5)
+        self._poke_event = asyncio.Event()
         while True:
             try:
                 self._send_one()
             except Exception as exc:
                 logger.warning("Heartbeat iteration crashed: %s", exc)
+            # Wait for either the scheduled interval OR a poke from
+            # MOONGATE_PAIR. Poke wakes the loop early so the cloud sees
+            # the current tunnel URL before the user's app calls
+            # /printer-access, instead of the user waiting up to
+            # `interval` seconds in "Starting up..." tile state.
             try:
-                await asyncio.sleep(self.interval)
+                await asyncio.wait_for(self._poke_event.wait(), timeout=self.interval)
+                self._poke_event.clear()
+                logger.debug("Heartbeat poked — sending early")
+            except asyncio.TimeoutError:
+                pass  # Normal interval elapsed
             except asyncio.CancelledError:
                 return
+
+    def request_immediate_send(self) -> None:
+        """Wake the heartbeat loop to send NOW instead of waiting for the
+        next scheduled interval. Idempotent — calling repeatedly between
+        sends collapses into a single early send. No-op until the loop
+        has started (the first 5 s post-boot)."""
+        if self._poke_event is not None:
+            self._poke_event.set()
 
     def _send_one(self) -> None:
         tunnel = _get_tunnel_url()
@@ -659,6 +681,13 @@ class MoongatePlugin:
         """MOONGATE_PAIR macro entry point."""
         pending = self._start_pairing()
         await asyncio.sleep(0.3)
+
+        if pending is not None:
+            # User is now actively waiting to scan. Kick the heartbeat so
+            # the cloud has a fresh tunnel URL by the time their app calls
+            # /printer-access — saves up to `heartbeat_interval_seconds`
+            # (5 min default) of "Starting up..." tile state.
+            self.heartbeat.request_immediate_send()
 
         if pending is None:
             script = "\n".join([


### PR DESCRIPTION
## Why

Steady-state heartbeat interval is **300 s** ([moongate_standalone.py#L80](https://github.com/PEEKYPAUL/Moongate/blob/master/klipper-plugin/moongate_standalone.py#L80)) — perfect for noticing tunnel URL changes between Pi restarts, terrible for a user who's actively pairing. Today's session hit the worst-case scenario: pair → cloud row exists with no tunnel URL → app's `/printer-access` returns "starting up" → user stares at the tile for up to 5 minutes until the next scheduled heartbeat lands. Real reported pain.

## What changed

- `HeartbeatLoop` grows a `request_immediate_send()` method backed by an `asyncio.Event` that the run loop awaits in place of the plain `asyncio.sleep(interval)`. `wait_for(..., timeout=interval)` returns on either signal — steady-state cadence unchanged.
- `_klipper_pair` calls `request_immediate_send()` right after a successful `_start_pairing()`, parallel with the M118 QR display. By the time the user scans, the cloud already has the tunnel URL.
- Idempotent (multiple pokes collapse to one extra send) and safe before the loop binds the event to the running loop (no-op).

## Verified on .251 (Voron 2.4)

```
MOONGATE_PAIR fired at:    21:02:24.196 UTC
Cloud last_seen updated:   21:02:25.526 UTC  (+1.3 s)
Without poke, next would:  21:06:39 UTC      (+4 m 15 s)
```

## Test plan

- [x] `python3 -m py_compile` clean on the updated plugin
- [x] Deployed to 192.168.1.251 and restarted Moonraker — service active
- [x] Triggered `MOONGATE_PAIR` via Moonraker gcode API
- [x] `printers.last_seen` updated 1.3 s after the trigger (verified via supabase db query)
- [ ] User end-to-end re-pair test (optional — the timing was tight enough that the previous "few minutes" pain is gone by construction)

## What's NOT in this PR

- Doesn't touch the steady-state heartbeat interval (300 s stays as default).
- Doesn't add other poke triggers (cloudflared URL rotation, owner change). Easy to add later if the symptom shows up elsewhere; until then, the pair flow was the only acute reported pain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)