### PR TITLE
docs: refresh README + setup + troubleshooting + architecture for v0.4.2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -212,7 +212,7 @@ CI only fires on `master`. Feature branches (like `v0.4-secure-remote`) don't bu
 
 ### Pairing (manual code path)
 
-If no second device is handy, the `GATE-XXXX-XXXX` code shown in the Klipper console can be typed into the app's pair screen instead of scanning. The rest of the flow is the same — code in, claim out, owner.json written, tile spins up.
+If the phone's camera doesn't work (permission denied, hardware fault, can't focus on the QR), the `GATE-XXXX-XXXX` code shown in the Klipper console can be typed into the app's pair screen instead of scanning — two 4-digit boxes with a numpad. The rest of the flow is the same: code in (no `pi_public_key` sent — the server uses the one already on the enrollment row), claim out, owner.json written, tile spins up.
 
 ### Status poll (every 4 s per tile)
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ At the end you'll see output like:
 
 ### Step 2 — Install the app
 
-**Latest public release: v0.2.29.** The next release — **v0.4.0** — is what this README describes; it's in final testing on the `v0.4-secure-remote` branch and will land here when it merges to master.
+**Latest public release: v0.4.2.**
 
-**[⬇ Download Moongate-v0.2.29.apk](https://github.com/PEEKYPAUL/Moongate/raw/master/APK/Moongate-v0.2.29.apk)** and install it on your Android phone.
+**[⬇ Download Moongate-v0.4.2.apk](https://github.com/PEEKYPAUL/Moongate/raw/master/APK/Moongate-v0.4.2.apk)** and install it on your Android phone.
 
 > Android only for now. Tap the link above to download directly to your phone.
 > Enable **Install from unknown sources** for your browser or file manager before installing.
@@ -112,7 +112,7 @@ On first launch the app will ask you to add a printer.
 3. In the Moongate app, tap **+** → **Scan QR** and point your camera at the QR code
 4. Done — your printer appears in the dashboard
 
-**No second device handy?** You can also type the code shown in the Klipper console (`GATE-XXXX-XXXX`) directly into the app.
+**No working camera on your phone?** Type the **GATE code** shown in the Klipper console (`GATE-XXXX-XXXX`) directly into the app's Add Printer screen — two 4-digit boxes with a numpad. No scan needed.
 
 > Pairing is LAN-only by design — your phone and the device showing the QR both need to be on the same WiFi as the Pi. The QR carries only the info needed to set up the cloud association; from that point on, the app finds your printer over LAN or tunnel automatically, no URL to remember and nothing for you to share.
 
@@ -193,7 +193,7 @@ The drawer scrolls — two captures to show everything.
 ```
 moongate/
 ├── APK/                    # Pre-built release APKs + version manifest
-│   ├── Moongate-v0.2.29.apk
+│   ├── Moongate-v0.4.2.apk
 │   ├── Moongate-latest.apk
 │   └── latest_version.json
 ├── docs/

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -100,14 +100,13 @@ If your own app is getting 401s from the tunnel side (status tile is stuck offli
 
 - Grant camera permission when prompted, or via **Settings → Apps → Moongate → Permissions → Camera**.
 - The QR scanner only works in **release** builds with the ProGuard rules in [`mobile/android/app/proguard-rules.pro`](mobile/android/app/proguard-rules.pro). Debug builds also work; R8 doesn't run in debug.
-- If the camera opens but fails to read the code: try the manual code path instead. Tap **+ → Enter Code** and type the `GATE-XXXX-XXXX` from the Klipper console.
+- If the camera opens but fails to read the code: type the **GATE code** instead. Tap **+** to open Add Printer; the two 4-digit boxes for the `GATE-XXXX-XXXX` code shown in the Klipper console are right below the Scan QR button (numpad keyboard).
 
 ## Pairing fails / "already paired" error
 
-If you previously paired this Pi but un-paired without going through `Dashboard → Remove printer`:
+In **v0.4.2+** the recovery is one macro: `MOONGATE_RESET_OWNER` on the Pi (Klipper console) wipes the local owner record **and** releases the cloud-side association (the Pi signs the release request with its own device key — same key it already uses for heartbeats). Then `MOONGATE_PAIR` and pair again from any app install.
 
-- The cloud-side association may still exist. Run `MOONGATE_RESET_OWNER` on the Pi (Klipper console) to clear the local owner record, then `MOONGATE_PAIR` and re-scan.
-- v0.3.1+ should handle this automatically — `claim_printer` is idempotent for the same anonymous user, so re-pairing with the same app install just works.
+Before v0.4.2 the cloud row could be orphaned by a fresh app install (new anonymous identity), which would cause `already_paired` on re-pair. That's gone now — the Pi can clean up its own cloud row without the original app being reachable.
 
 ## Tunnel URL leakage — what's actually exposed in v0.4?
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -51,7 +51,7 @@ At the end you'll see:
 
 Download the latest APK from the [APK folder](https://github.com/PEEKYPAUL/Moongate/tree/master/APK) and install it on your phone.
 
-> Latest public release: v0.2.29. The v0.4.0 release described in the rest of this guide is in final testing and ships when [`v0.4-secure-remote`](https://github.com/PEEKYPAUL/Moongate/tree/v0.4-secure-remote) merges to master.
+> Latest public release: **v0.4.2** — the version this guide describes.
 
 ---
 
@@ -65,7 +65,7 @@ Download the latest APK from the [APK folder](https://github.com/PEEKYPAUL/Moong
 
 > The pair page is **LAN-only** in v0.4 by design. Visiting the equivalent URL over the Cloudflare tunnel returns 401 — pairing intentionally requires being on the same network as the Pi, so leaking the tunnel URL can't be used to pair an attacker's device.
 
-**No second device handy?** Type the code shown in the Klipper console (`GATE-XXXX-XXXX`) directly into the app. Tap **+** → **Enter Code** instead of **Scan QR**.
+**No working camera on your phone?** Type the **GATE code** shown in the Klipper console (`GATE-XXXX-XXXX`) directly into the app. Tap **+** to open Add Printer — the GATE code section sits right below the Scan QR button with two 4-digit boxes and a numpad.
 
 ---
 


### PR DESCRIPTION
## Why

Two reasons for this sweep:

1. **Drift from the v0.4 docs rewrite.** README + setup-guide still said *Latest public release: v0.2.29* and pointed at the `v0.4-secure-remote` branch as "final testing" — but v0.4.0 shipped two days ago, v0.4.1 yesterday, v0.4.2 today.
2. **v0.4.2 user-facing changes.** New numpad UI on the manual GATE-code entry (per-user feedback noted "No second device handy?" was a confusing way to describe a camera-failure fallback); MOONGATE_RESET_OWNER now releases the cloud row via Pi-signed force-release (TROUBLESHOOTING's "already_paired" recipe was stale).

## Changes

- **README** + **docs/setup-guide.md**: "Latest public release" v0.2.29 → v0.4.2; drop the "v0.4.0 in final testing" callout.
- **README** + **docs/setup-guide.md** + **TROUBLESHOOTING.md** + **ARCHITECTURE.md**: reword `No second device handy?` → `No working camera on your phone?`; describe the actual UI (two 4-digit boxes with a numpad right below Scan QR) instead of the now-nonexistent `+ → Enter Code` label.
- **TROUBLESHOOTING.md**: rewrite the *already_paired* entry. v0.4.2's Pi-signed force-release means MOONGATE_RESET_OWNER cleans up the cloud row too, so the old "may still exist" caveat is wrong.
- **README**: bump the illustrative APK file listing to v0.4.2.

No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)