### PR TITLE
fix(install): installer correctness — hardware support + [respond] auto-enable

### DIFF
--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -308,11 +308,49 @@ info "Found printer.cfg at $PRINTER_CFG"
 KLIPPER_CFG_DIR="$(dirname "$PRINTER_CFG")"
 MOONGATE_CFG="$KLIPPER_CFG_DIR/moongate.cfg"
 
-cat > "$MOONGATE_CFG" << 'MACROEOF'
+# Detect whether [respond] is already declared anywhere in the user's
+# Klipper config. The MOONGATE_PAIR macro uses M118 to print the pair
+# code, QR URL, and instructions to the Mainsail console; M118 is only
+# available when [respond] is enabled. Many stock setups (vanilla
+# MainsailOS / KIAUH) ship without it.
+#
+# We exclude moongate.cfg itself from the scan: on re-install, our own
+# previously-written [respond] would otherwise trip the detector and
+# we'd strip it back out, breaking M118 again. Excluding our file means
+# the check answers "is [respond] declared *outside* of us?".
+RESPOND_PRESENT=0
+while IFS= read -r f; do
+    [[ "$(basename "$f")" == "moongate.cfg" ]] && continue
+    if grep -qE '^\s*\[respond\]' "$f"; then
+        RESPOND_PRESENT=1
+        break
+    fi
+done < <(find "$KLIPPER_CFG_DIR" -maxdepth 2 -name "*.cfg" 2>/dev/null)
+
+# Build moongate.cfg. Always emits the two macros; conditionally emits
+# [respond] only when no other config file already declares it
+# (declaring [respond] twice is a fatal Klipper config error).
+{
+    cat << 'HEADER'
 # ── Moongate ──────────────────────────────────────────────────────────────────
 # Managed by the Moongate installer — do not edit manually.
 # Updates are handled automatically via Moonraker's update manager.
 
+HEADER
+
+    if [[ $RESPOND_PRESENT -eq 0 ]]; then
+        cat << 'RESPONDSECTION'
+# [respond] enables the M118 command, which MOONGATE_PAIR uses to print
+# the pair code, QR URL, and instructions to the Mainsail/Fluidd console.
+# Without this, MOONGATE_PAIR would log "Unknown command: M118" instead.
+# If you later add [respond] elsewhere in your config, remove this block
+# — Klipper refuses to start with two [respond] sections.
+[respond]
+
+RESPONDSECTION
+    fi
+
+    cat << 'MACROS'
 [gcode_macro MOONGATE_PAIR]
 description: Start a Moongate pairing session and show a QR for the mobile app
 gcode:
@@ -322,8 +360,14 @@ gcode:
 description: Wipe local Moongate owner binding so the printer can be re-paired
 gcode:
     {action_call_remote_method("moongate_reset_owner")}
-MACROEOF
+MACROS
+} > "$MOONGATE_CFG"
 
+if [[ $RESPOND_PRESENT -eq 1 ]]; then
+    info "[respond] already enabled in your config — moongate.cfg uses your existing one"
+else
+    success "[respond] auto-added to moongate.cfg (required for MOONGATE_PAIR's M118 output)"
+fi
 success "Macro written to $MOONGATE_CFG"
 
 if grep -q '\[include moongate\.cfg\]' "$PRINTER_CFG"; then

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -56,14 +56,37 @@ KLIPPER_CFG_DIR="$PRINTER_DATA/config"
 [[ -f "$MOONRAKER_CONF" ]] || die "moonraker.conf not found at $MOONRAKER_CONF."
 
 ARCH=$(uname -m)
-case "$ARCH" in
-    aarch64|arm64) CF_ARCH="arm64" ;;
-    armv7l|armhf)  CF_ARCH="arm"   ;;
-    x86_64)        CF_ARCH="amd64" ;;
-    *) die "Unsupported architecture: $ARCH" ;;
-esac
 
-info "Architecture: $ARCH → cloudflared: $CF_ARCH"
+# Pick the cloudflared deb that matches the dpkg system architecture.
+# uname -m alone is unreliable: the kernel reports armv7l on a system
+# whose userland is armhf, and dpkg refuses to install an "arm" deb on
+# an "armhf" host. dpkg --print-architecture is what dpkg uses when
+# matching a .deb, so it's the authoritative source here.
+DPKG_ARCH=""
+if command -v dpkg &>/dev/null; then
+    DPKG_ARCH="$(dpkg --print-architecture)"
+    case "$DPKG_ARCH" in
+        arm64)  CF_ARCH="arm64" ;;
+        armhf)  CF_ARCH="armhf" ;;
+        armel)  CF_ARCH="arm"   ;;
+        amd64)  CF_ARCH="amd64" ;;
+        i386)   CF_ARCH="386"   ;;
+        *) die "Unsupported dpkg architecture: $DPKG_ARCH (uname: $ARCH)" ;;
+    esac
+else
+    # No dpkg — unusual on a Klipper Pi, but fall back to uname so the
+    # diagnostic still fires before we try to install cloudflared.
+    case "$ARCH" in
+        aarch64|arm64) CF_ARCH="arm64" ;;
+        armv7l)        CF_ARCH="armhf" ;;
+        armv6l)        CF_ARCH="arm"   ;;
+        x86_64)        CF_ARCH="amd64" ;;
+        i686|i386)     CF_ARCH="386"   ;;
+        *) die "Unsupported architecture: $ARCH" ;;
+    esac
+fi
+
+info "Architecture: $ARCH (dpkg: ${DPKG_ARCH:-n/a}) → cloudflared: $CF_ARCH"
 
 # ── 1. Clone or update the Moongate repo ─────────────────────────────────────
 # Cloning to ~/moongate lets Moonraker's update manager track the repo and

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -380,18 +380,46 @@ fi
 success "Plugin HTTP port saved to $PLUGIN_CFG_FILE"
 
 # ── 6. Install cloudflared (skip if already installed) ───────────────────────
+# Two install paths so this works on the variety of SBCs Klipper runs on:
+#   • Debian-family (dpkg present): grab the matching .deb. Covers
+#     stock MainsailOS / FluiddPI / KIAUH on Raspberry Pi, plus Armbian
+#     on Orange Pi / NanoPi / Odroid etc.
+#   • Anything else (no dpkg): pull the raw binary into /usr/local/bin.
+#     Covers Arch Linux ARM, Alpine, and any future distro where dpkg
+#     isn't around.
+# Cloudflare publishes both shapes for every arch we care about, so a
+# single $CF_ARCH variable drives both paths.
 if command -v cloudflared &>/dev/null; then
-    info "cloudflared already installed — skipping."
+    info "cloudflared already installed at $(command -v cloudflared) — skipping."
 else
-    info "Installing cloudflared..."
-    CF_DEB="cloudflared-linux-${CF_ARCH}.deb"
-    CF_URL="https://github.com/cloudflare/cloudflared/releases/latest/download/$CF_DEB"
-    TMP_DEB="/tmp/$CF_DEB"
-    curl -fsSL "$CF_URL" -o "$TMP_DEB"
-    sudo dpkg -i "$TMP_DEB"
-    rm -f "$TMP_DEB"
-    success "cloudflared installed"
+    CF_BASE="https://github.com/cloudflare/cloudflared/releases/latest/download"
+    if command -v dpkg &>/dev/null; then
+        info "Installing cloudflared via dpkg (cloudflared-linux-${CF_ARCH}.deb)..."
+        TMP_DEB="/tmp/cloudflared-linux-${CF_ARCH}.deb"
+        curl -fsSL "$CF_BASE/cloudflared-linux-${CF_ARCH}.deb" -o "$TMP_DEB" \
+            || die "Failed to download cloudflared deb for $CF_ARCH"
+        sudo dpkg -i "$TMP_DEB" || die "dpkg failed installing $TMP_DEB"
+        rm -f "$TMP_DEB"
+    else
+        # No dpkg — install the binary directly. /usr/local/bin is on
+        # PATH on every Linux we'd realistically run on. systemd will
+        # find it via the resolved $CLOUDFLARED_BIN below.
+        info "Installing cloudflared binary to /usr/local/bin (no dpkg detected)..."
+        sudo curl -fsSL "$CF_BASE/cloudflared-linux-${CF_ARCH}" \
+            -o /usr/local/bin/cloudflared \
+            || die "Failed to download cloudflared binary for $CF_ARCH"
+        sudo chmod +x /usr/local/bin/cloudflared
+    fi
+    success "cloudflared installed at $(command -v cloudflared)"
 fi
+
+# Resolve the cloudflared path once so the systemd unit below uses
+# whichever location it actually ended up in: /usr/bin via dpkg,
+# /usr/local/bin via binary, or somewhere else for a pre-existing
+# install (e.g. the user dropped it in ~/bin). Avoids hard-coding
+# /usr/bin/cloudflared which is wrong on non-Debian systems.
+CLOUDFLARED_BIN="$(command -v cloudflared)"
+[[ -n "$CLOUDFLARED_BIN" ]] || die "cloudflared not on PATH after install"
 
 # ── 6b. Install moongate-authproxy systemd service (v0.4) ────────────────────
 # The auth proxy must be running BEFORE cloudflared starts pointing at it,
@@ -496,7 +524,7 @@ Wants=network-online.target moongate-authproxy.service
 [Service]
 Type=simple
 User=$USER
-ExecStart=/usr/bin/cloudflared tunnel --url http://localhost:$MG_AUTHPROXY_PORT --no-autoupdate
+ExecStart=$CLOUDFLARED_BIN tunnel --url http://localhost:$MG_AUTHPROXY_PORT --no-autoupdate
 Restart=on-failure
 RestartSec=10
 StandardOutput=append:/run/moongate-tunnel.log


### PR DESCRIPTION
## Summary

Three commits' worth of installer fixes, all coming from real-world install failures while adding a 4th printer to an existing Moongate setup. Each addresses a distinct correctness bug:

### 1. Correct cloudflared arch detection

The installer was downloading `cloudflared-linux-arm.deb` on armhf hosts, which dpkg refuses with `package architecture (arm) does not match system (armhf)`. Root cause: `uname -m` returns `armv7l` on Pi 3/4 32-bit and the script mapped that to `arm`. Cloudflare's `arm` deb is built for armv6 / soft-float EABI; the hard-float build is a separate file, `cloudflared-linux-armhf.deb`.

Switched to `dpkg --print-architecture`, which is what dpkg itself uses when matching `.deb` files. Explicit mappings for `arm64`, `armhf`, `armel`, `amd64`, `i386`. `uname -m` retained as a fallback if dpkg isn't on PATH.

| Host | uname | dpkg | Old picked | New picks |
|---|---|---|---|---|
| Pi 3/4 32-bit (MainsailOS) | `armv7l` | `armhf` | `arm.deb` ✗ | `armhf.deb` ✓ |
| Pi 4/5 64-bit | `aarch64` | `arm64` | `arm64.deb` ✓ | `arm64.deb` ✓ |
| Pi Zero / Pi 1 (Raspbian armel) | `armv6l` | `armel` | — | `arm.deb` ✓ |
| 64-bit kernel + 32-bit userland | `aarch64` | `armhf` | `arm64.deb` ✗ | `armhf.deb` ✓ |
| x86_64 Klipper host | `x86_64` | `amd64` | `amd64.deb` ✓ | `amd64.deb` ✓ |

### 2. Non-Debian distro fallback + dynamic cloudflared path

If `dpkg` isn't on PATH (Arch Linux ARM, Alpine, any other distro on Orange Pi / NanoPi / Odroid / generic SBC), the script previously fell through and `sudo dpkg -i` would just fail. Now it downloads the raw `cloudflared-linux-${CF_ARCH}` binary into `/usr/local/bin/` and `chmod +x`'s it. Cloudflare ships both the .deb and the raw binary for every arch we care about, so a single `$CF_ARCH` drives both paths.

The `moongate-tunnel.service` `ExecStart` was also hardcoded to `/usr/bin/cloudflared` — only correct after a .deb install. Now resolved at install time via `command -v cloudflared`, so the unit points at wherever cloudflared actually landed (`/usr/bin` via deb, `/usr/local/bin` via binary, or a pre-existing user install).

### 3. Auto-enable `[respond]` for `MOONGATE_PAIR`'s `M118` output

`MOONGATE_PAIR` uses `M118` to print the pair code, QR URL, and instructions to the Mainsail console. `M118` is provided by Klipper's `[respond]` module — which many stock setups (vanilla MainsailOS, fresh KIAUH) don't enable by default. On those systems the macro runs but Klipper logs `Unknown command: M118` for every line and the user sees nothing.

Now the installer:
- Greps `.cfg` files in the Klipper config dir for an existing `[respond]` declaration
- If found anywhere already: emits `moongate.cfg` *without* `[respond]` (declaring twice is a fatal Klipper config error)
- If not found: prepends a commented `[respond]` block to `moongate.cfg` before the gcode_macros

The detection scan excludes `moongate.cfg` itself, so re-running the installer doesn't see our own previously-written `[respond]` and strip it back out.

## Reported failures this fixes

1. **dpkg arch mismatch** while installing a 4th printer:
   ```
   dpkg: error processing archive /tmp/cloudflared-linux-arm.deb (--install):
    package architecture (arm) does not match system (armhf)
   ```

2. **M118 spam** after running `MOONGATE_PAIR` on a stock MainsailOS install with no `[respond]`:
   ```
   Unknown command:"M118"
   Unknown command:"M118 =========================================="
   Unknown command:"M118"
   …
   ```

## Test plan

- [ ] Re-run installer on the failing armhf Pi — picks `armhf.deb`, dpkg installs cleanly, authproxy + tunnel units come up
- [ ] On the same Pi, `MOONGATE_PAIR` in the console prints the code + QR URL banner (instead of "Unknown command M118")
- [ ] Sanity-check on 64-bit Pi OS (arm64 / aarch64) — still picks `arm64.deb`, no regression
- [ ] Sanity-check on a Pi where the user *already* has `[respond]` enabled — installer should skip adding it and log "[respond] already enabled in your config"
- [ ] `bash -n install.sh` syntax check — already passes locally
- [ ] (Optional) Try on an Arch Linux ARM SBC — `dpkg` absent, binary should drop into `/usr/local/bin/cloudflared` and systemd unit should find it via `command -v` resolution

## Out of scope

- Pi Zero / Pi 1 armv6 hardware running Raspbian armhf userland (where `dpkg=armhf` but cloudflared armhf needs armv7+ instructions) — Klipper is impractical on these boards; can address if a user actually reports it.
- Switching to Cloudflare's apt repo (`pkg.cloudflare.com`) instead of the GitHub releases. Heavier setup; not justified by these failures.
- Recursive resolution of nested `[include]` chains for `[respond]` detection — the flat scan of `.cfg` files in the config dir covers every realistic layout; over-detection is harmless (M118 just stays broken, no worse than today), and under-detection (the dangerous direction) would require an unusual setup where `[respond]` lives outside the config dir entirely.