### PR TITLE
docs(v0.5): LAN discovery design — Pi-advertised mDNS + app browse

### DIFF
--- a/docs/v0.5-lan-discovery-design.md
+++ b/docs/v0.5-lan-discovery-design.md
@@ -1,6 +1,6 @@
 # Moongate v0.5.0 — LAN Discovery Design
 
-> **Status:** Proposed — awaiting review. Branch `docs/v0.5-lan-discovery-spec`. Implementation begins only after this spec is merged.
+> **Status:** Accepted scope. §11 decisions resolved 2026-05-29. Implementation proceeds per §10.
 
 ---
 
@@ -12,7 +12,7 @@ This document specifies how the app discovers a Pi's current LAN address without
 - §6 — Pi-side Avahi service file advertising `_moongate._tcp.local` with `printer_id` and `http_port` TXT records, installed by `install.sh` and removed by `uninstall.sh`.
 - §7 — App-side mDNS browse on foreground and on every successful poll-cycle resync, populating an in-memory `printerId → discovered LAN URL` map.
 - §8 — Integration with `PrinterStatusService` and `PrintControlService`: discovered URL is preferred over the persisted `lanUrl` when both exist for a given printer.
-- §10.1 — **Phase 0 precursor fix:** `PrintControlService` reads `lanUrl` live from the registry instead of capturing it at construction. Ships as its own PR ahead of the v0.5.0 implementation work — see §10.
+- §10.2 — **`PrintControlService` reads `lanUrl` live from the registry** instead of capturing it at construction. Rolled into the v0.5.0 mobile PR per the §11.Q5 decision rather than shipping ahead.
 
 **Out of scope for v0.5.0 (deferred):**
 - iOS port (the `bonsoir` package supports iOS, but no iOS build target exists yet)
@@ -409,34 +409,9 @@ The new column is row 2 — the case this whole spec exists to fix.
 
 ## 10. Rollout plan
 
-### 10.1 Phase 0 — `PrintControlService` reads `lanUrl` live (precursor)
+Two phases. Per the §11.Q5 decision, the `PrintControlService` live-`lanUrl` bug fix from §8.2 rolls into Phase 2 rather than shipping ahead as its own PR.
 
-**Not blocking on this spec being merged.** Shipped as its own small PR. The bug exists in v0.4.3 today: `PrintControlService` captures `config.lanUrl` at construction and never re-reads, so after an IP change the *status* service flips back to LAN within one poll but pause/resume/cancel still try the old IP until the tile is rebuilt.
-
-Fix shape:
-
-```dart
-class PrintControlService {
-  final PrinterConfig config;
-  PrintControlService(this.config);
-
-  Future<bool> sendAction(String action) async {
-    // ... unchanged token-fetching code ...
-
-    // v0.5 §10.1: read lanUrl live from the registry so an IP change
-    // surfaced by PrinterStatusService is picked up by the next action
-    // we send, without waiting for the tile to be rebuilt.
-    final live = PrinterRegistry.instance.printers
-        .firstWhereOrNull((p) => p.id == config.id);
-    final lanUrl = live?.lanUrl ?? config.lanUrl;
-    // ... rest unchanged ...
-  }
-}
-```
-
-This phase has no dependency on §6 or §7. Ships before either.
-
-### 10.2 Phase 1 — Pi-side Avahi advertisement
+### 10.1 Phase 1 — Pi-side Avahi advertisement
 
 Ships as v0.4.4 (Pi-side only, no app change). Plugin + installer changes from §6. v0.5.0-app browsing for this will pick up Pi-side Phase 1 changes when both are deployed.
 
@@ -445,9 +420,34 @@ Pi-side Phase 1 is **safe to ship before any app-side change** because:
 - The plugin and installer changes are small and localised
 - Rollback is straightforward (delete the service file and the sudoers entry)
 
-### 10.3 Phase 2 — App-side discovery integration
+### 10.2 Phase 2 — App-side discovery integration + control-service live-`lanUrl` fix
 
-Ships as v0.5.0. `LanDiscoveryService` + integration with `PrinterStatusService` and `PrintControlService` per §7 and §8.
+Ships as v0.5.0. Combined PR (or coordinated PR pair, at implementor's discretion) covering:
+
+1. **`LanDiscoveryService` + integration** with `PrinterStatusService` and `PrintControlService` per §7 and §8.
+2. **`PrintControlService` reads `lanUrl` live from `PrinterRegistry`** instead of capturing `config.lanUrl` at construction. The bug exists in v0.4.3: the *status* service flips back to LAN within one poll of an IP change, but pause/resume/cancel still try the old IP until the tile is rebuilt. Fix shape:
+
+   ```dart
+   class PrintControlService {
+     final PrinterConfig config;
+     PrintControlService(this.config);
+
+     Future<bool> sendAction(String action) async {
+       // ... unchanged token-fetching code ...
+
+       // v0.5: discovered URL (mDNS) > registry-live lanUrl > construction-time
+       // lanUrl. Last-resort fallback handles the case where the registry
+       // entry vanished between construction and this call.
+       final discovered = LanDiscoveryService.instance.lookup(config.id);
+       final live = PrinterRegistry.instance.printers
+           .firstWhereOrNull((p) => p.id == config.id);
+       final lanUrl = discovered ?? live?.lanUrl ?? config.lanUrl;
+       // ... rest unchanged ...
+     }
+   }
+   ```
+
+   Bundling this with the mDNS integration is correct because the two changes touch the same code path and ship in the same v0.5.0 release — splitting them would create two near-identical PRs reviewing the same lines.
 
 v0.5.0 works correctly against:
 - Pis that have been updated to Phase 1 (full benefit)
@@ -455,7 +455,7 @@ v0.5.0 works correctly against:
 
 This means **v0.5.0 ships without a hard dependency on every Pi having been updated**. The user pulls down v0.5.0 to their phone, and any Pi they later update to Phase 1 starts being discovered automatically.
 
-### 10.4 Phase 3 — Future (v0.5.1+)
+### 10.3 Phase 3 — Future (v0.5.1+)
 
 Out of scope for v0.5.0 but worth flagging:
 
@@ -466,17 +466,15 @@ Out of scope for v0.5.0 but worth flagging:
 
 ---
 
-## 11. Open questions
+## 11. Decisions (resolved 2026-05-29)
 
-These need a decision before implementation begins.
-
-| # | Question | Default if no answer |
-|---|---|---|
-| Q1 | Should the Avahi service file land at the start of `install.sh` (and be rewritten on pair) or only after a successful pair? §6.4 recommends the latter. | After-pair only (Option B in §6.4) |
-| Q2 | Sudoers-entry vs `chown pi /etc/avahi/services` for the plugin to install the service file? §6.6 recommends sudoers. | Sudoers entry |
-| Q3 | mDNS browse cadence — every N polls or every M minutes? §7.4 recommends N=15 (≈1 min at 4 s polling). | Every 15 polls |
-| Q4 | Bonsoir vs nsd Flutter package? §7.1 recommends bonsoir for iOS-readiness. | Bonsoir |
-| Q5 | Phase 0 (PrintControlService live `lanUrl`) — ship now as its own PR or roll into v0.5.0? | Ship now as its own PR |
+| # | Question | Decision | Implementation reference |
+|---|---|---|---|
+| Q1 | When does the Pi write the Avahi service file? | **After successful pair only.** Cleaner state model — one source of truth (`owner.json`), unpaired Pi is invisible on the LAN. | §6.4 Option B |
+| Q2 | How does the plugin write to `/etc/avahi/services/`? | **Sudoers entry** (`/etc/sudoers.d/moongate-avahi`) limited to the specific `cp` and `rm` needed. Least privilege. | §6.6 |
+| Q3 | mDNS browse cadence? | **Every 15th status poll** (~1 minute at 4 s polling) plus on app foreground and on pull-to-refresh. | §7.4 |
+| Q4 | Flutter mDNS package? | **`bonsoir`.** Maintained, covers Android + iOS, sets up the future iOS port without re-integration. | §7.1 |
+| Q5 | Phase 0 (`PrintControlService` live `lanUrl`) ship timing? | **Hold and roll into v0.5.0 Phase 2.** Single coordinated change covering both the mDNS integration and the live-`lanUrl` fix in the same code path. | §10.2 |
 
 ---
 

--- a/docs/v0.5-lan-discovery-design.md
+++ b/docs/v0.5-lan-discovery-design.md
@@ -1,0 +1,501 @@
+# Moongate v0.5.0 — LAN Discovery Design
+
+> **Status:** Proposed — awaiting review. Branch `docs/v0.5-lan-discovery-spec`. Implementation begins only after this spec is merged.
+
+---
+
+## 0. v0.5.0 scope — what we are actually building
+
+This document specifies how the app discovers a Pi's current LAN address without depending on Supabase + Cloudflare being reachable. **v0.5.0 ships a Pi-advertised mDNS service plus app-side discovery that prefers it over the persisted LAN URL when present.**
+
+**In scope for v0.5.0:**
+- §6 — Pi-side Avahi service file advertising `_moongate._tcp.local` with `printer_id` and `http_port` TXT records, installed by `install.sh` and removed by `uninstall.sh`.
+- §7 — App-side mDNS browse on foreground and on every successful poll-cycle resync, populating an in-memory `printerId → discovered LAN URL` map.
+- §8 — Integration with `PrinterStatusService` and `PrintControlService`: discovered URL is preferred over the persisted `lanUrl` when both exist for a given printer.
+- §10.1 — **Phase 0 precursor fix:** `PrintControlService` reads `lanUrl` live from the registry instead of capturing it at construction. Ships as its own PR ahead of the v0.5.0 implementation work — see §10.
+
+**Out of scope for v0.5.0 (deferred):**
+- iOS port (the `bonsoir` package supports iOS, but no iOS build target exists yet)
+- Cross-subnet discovery via mDNS reflector / mDNS proxy (single-subnet only; Pi and phone on different VLANs fall through to the existing tunnel path)
+- Pairing-flow integration (mDNS could in principle replace the QR code for "find the Pi I'm about to pair with"; deliberately out of scope here to keep the pairing model unchanged)
+- Pi-side service advertised over IPv6-only links. Avahi handles dual-stack by default; we don't require IPv6 specifically.
+
+**Promise of v0.5.0:** when the phone is on the same WiFi as the Pi, the dashboard tile flips to "Local" and stays on LAN even when (a) the Pi's IP has just changed, (b) the internet is unreachable, or (c) Supabase / Cloudflare are degraded. When the phone and Pi are on different networks, behaviour is unchanged from v0.4.3 — tunnel via Supabase, exactly as today.
+
+What v0.5.0 does **not** promise: discovery across NATs, across guest-network isolation, or when the user's router blocks multicast (some enterprise / hotel setups do). All three fall back to the existing tunnel path; v0.5.0 never *reduces* reachability vs v0.4.
+
+---
+
+## 1. Why this exists
+
+v0.4.x established LAN-first routing: the status service tries the cached LAN URL before falling through to the tunnel on every poll. That works as long as the cached LAN URL is correct. Today the cache is seeded one way: by the Pi reporting `local_ip` in every `/server/moongate/status` response, which the app writes back into `PrinterRegistry`. So the cache stays current — *as long as a tunnel poll succeeds*.
+
+This creates a single chokepoint when the Pi's LAN address moves but the internet leg is degraded:
+
+1. DHCP shuffles the Pi from `192.168.178.50` → `192.168.178.99`
+2. Next status poll tries cached `.50` → 2 s timeout (Pi isn't there any more)
+3. Falls through to tunnel → would surface the new IP — **but the tunnel needs Supabase + Cloudflare to be reachable**
+4. If they aren't: cache stays stale. Tile shows "offline" forever even though the Pi is online on the same WiFi as the phone.
+
+This is the gap the user surfaced as the "what about MAC addresses?" question. The framing is right, the mechanism is wrong:
+
+- **MAC addresses are unreachable from Android user-space.** Since Android 6 (Marshmallow), apps can't read ARP, can't open raw sockets, can't enumerate neighbours. Even on rooted devices, mainline Flutter packages don't expose this and the Play Store policies discourage it. A "match the printer by MAC" design would require either a privileged system app or the user installing a separate root-only helper — both violate the [v0.4 hard constraint §2.2 "no second app"](v0.4-secure-remote-access-design.md#2-hard-constraints).
+- **DHCP reservation** is a router-side fix the user does once and lives with. It works but isn't enforceable by the app — we can't make the user configure their router, and a fresh router or ISP-swapped gateway resets it.
+- **mDNS / DNS-SD (Bonjour)** is the platform-blessed way to find a service on the local network without knowing its IP in advance. Android's `NsdManager` (API 16+) is purpose-built for it; Flutter has a maintained wrapper. The Pi is already running Avahi as part of stock MainsailOS / FluiddPI / KIAUH — advertising a new service is a single file in `/etc/avahi/services/`.
+
+The mDNS path also delivers a side benefit: zero-cost **first-pair LAN-first**. Today's first poll on a freshly paired printer is always via tunnel because no LAN URL has been seeded yet. With mDNS, the discovery service can populate the LAN URL before the first poll fires.
+
+This document specifies that work.
+
+---
+
+## 2. Hard constraints
+
+Carrying forward from v0.4 plus new ones specific to LAN discovery:
+
+1. **Zero ongoing infrastructure cost.** No new cloud component, no paid mDNS reflector. Avahi (already installed) and on-device mDNS only.
+2. **No second app.** mDNS browsing must be inside Moongate. No separate "Moongate Discovery" agent.
+3. **Must coexist with v0.4 auth.** mDNS only changes *which LAN URL the app fetches from* — the auth model (EdDSA tokens via Supabase) is unchanged. A discovered URL still hits the same plugin endpoints with the same `mg_token=` query parameter.
+4. **No regression off-LAN.** When the user is away from home, mDNS finds nothing → behaviour is byte-for-byte identical to v0.4.3 (tunnel via Supabase).
+5. **No new Android permissions that scare users.** `NsdManager` doesn't require `ACCESS_FINE_LOCATION` (unlike WiFi scanning), doesn't require background-location, doesn't require any runtime grant. The `INTERNET` permission already in the manifest covers the local socket open.
+6. **Pi installer stays idempotent.** Re-running `install.sh` must not produce a second `_moongate._tcp` advertisement, must not break the existing service file, and `uninstall.sh` must remove it cleanly.
+7. **No Google Play policy risk.** mDNS is the explicitly-recommended pattern in Google's network-discovery docs; nothing on the Play Store policy radar.
+8. **Bounded discovery latency.** Steady-state mDNS browsing must not delay the first poll cycle. If discovery hasn't completed by the time the status service wants to send its first poll, fall back to the persisted LAN URL (or the tunnel) and pick up the discovered URL on the next cycle.
+
+---
+
+## 3. Threat model
+
+### 3.1 New surface introduced
+
+| Threat | Severity | Mitigation |
+|---|---|---|
+| **mDNS advertisement leaks `printer_id` to anyone on the WiFi** | Low | The `printer_id` is a UUIDv4 — knowing it is not sufficient to talk to the Pi (still need a Supabase-issued EdDSA token bound to the owner). The UUID is not personally-identifying. Same exposure as e.g. an AirPlay device advertising its name. |
+| **Hostile device on the same WiFi spoofs the advertisement to redirect the app to a malicious URL** | Medium | The app still authenticates the response: the plugin endpoint is hit with the user's EdDSA token, and the response signature is verified the same way as today. A spoofed host that doesn't hold the Pi's signing key cannot return a valid `/server/moongate/status` response. Worst case: the app routes one poll to a dead host, then falls through to the tunnel — same recovery as a stale persisted LAN URL. |
+| **Multicast snooping on a hostile WiFi (e.g. café, airport)** reveals you own a Klipper printer | Low | The phone only *browses* on the home network in the steady state — there is no spec requirement to advertise the printer's existence from the phone. Browsing is passive listening to multicast; it doesn't leak the user's interest in `_moongate._tcp` to other devices on the network (browses are unicast queries to a multicast address, but observers can see them). If the user is on a hostile WiFi and worried about this, the existing v0.4 tunnel path remains unchanged — and the recommended posture on hostile networks is "don't browse for your home printer". v0.5.1 may add a "LAN discovery: off" toggle in settings; not required for v0.5.0. |
+| **mDNS-flood DoS from a malicious LAN device** | Low | `NsdManager` and `bonsoir` both cap concurrent service records and reject malformed advertisements at the OS layer. The worst a flooder can do is increase the app's discovery latency from <200 ms to ~5 s for the duration of the flood. No persistent state corruption. |
+
+### 3.2 Out of scope (unchanged from v0.4)
+
+- Targeted attacker who already knows the user
+- Malware on the user's phone
+- Physical attacker with the Pi
+- Compromise of the network infrastructure (router, switch firmware)
+
+### 3.3 What the threat model says about *defaults*
+
+The v0.4.x default is "LAN-first on every poll, fall back to tunnel". v0.5.0 keeps that default. mDNS discovery is purely a way to *find the LAN URL faster and more reliably*; it doesn't change what the app does once the URL is in hand. Every request still carries the EdDSA token and is verified by the plugin.
+
+---
+
+## 4. Decision matrix
+
+Five approaches were evaluated. Summary, then detail in §5 onward.
+
+| Property | DHCP reservation (status quo) | Supabase-heartbeat-only (status quo) | Subnet scan | **mDNS (RECOMMENDED)** | WebRTC mDNS candidates |
+|---|---|---|---|---|---|
+| Works without internet | ✗ | ✗ | ✓ | ✓ | ✓ (with caveats) |
+| Works without router config | ✗ | ✓ | ✓ | ✓ | ✓ |
+| First-pair LAN-first | ✗ | ✗ | ✓ (slow) | ✓ (fast) | ✓ |
+| Latency to first LAN URL | n/a | seconds (tunnel round-trip) | 0.5–5 s (parallel /24) | 100–500 ms | 500–2000 ms (ICE) |
+| Pi-side change required | None | None | None | One Avahi service file (~10 lines) | Major (signalling + STUN) |
+| App-side change required | None | None | New scanner | New discovery service (~150 lines) | WebRTC stack (~1000+ lines) |
+| New Android permissions | None | None | None | None | `BIND_TELECOM_CONNECTION_SERVICE` not needed but adds complexity |
+| Battery cost | None | None (worse than mDNS — one extra round-trip per poll cycle when LAN stale) | Moderate (254 connect attempts) | Negligible (passive multicast listen, ~1 packet/min) | Higher (ICE keep-alives) |
+| Plays nice with existing v0.4 auth | n/a | n/a (status quo) | ✓ | ✓ — pure URL discovery, auth unchanged | Requires major auth rework |
+
+**Recommendation: ship mDNS as v0.5.0.** It's the only option that delivers all of (internet-independent, no router config, first-pair LAN-first, low battery, no new permissions, no Pi-side disruption) — and it's the platform-blessed pattern that aligns with how Android, iOS, macOS, Linux desktop, and the printer industry already do LAN discovery.
+
+Subnet scan is rejected as primary: 254 parallel connect attempts on every poll is noisy and slow. It may have a place as a **fallback** when mDNS finds nothing within a deadline (e.g. routers that block multicast), but that's a v0.5.1 enhancement — not required for v0.5.0.
+
+WebRTC mDNS candidates are rejected: massive complexity, requires reworking the auth path, and the relevant case (NAT traversal for IP discovery) doesn't apply when phone and Pi are on the same LAN.
+
+---
+
+## 5. Existing behaviour baseline (v0.4.3)
+
+For reference when reading §6–§8.
+
+### 5.1 Status poll path
+
+[`printer_status_service.dart`](../mobile/lib/services/printer_status_service.dart) — one `PrinterStatusService` instance per tile. Every 4 s:
+
+```
+_doPoll()
+├─ Supabase ready? no → emit Offline, return
+├─ Get fresh {tunnel_url, access_token} from PrinterAccessCache
+│  └─ If Pi has no heartbeat → emit StartingUp, return
+│  └─ If row missing       → emit Offline, return
+├─ if _currentLanUrl != null:
+│    └─ _tryMoongateEndpoint(lan, 2s timeout) → return on success
+├─ _tryMoongateEndpoint(tunnel, 8s timeout) → return on success
+├─ invalidate access, retry tunnel once
+└─ HEAD probe both candidates → Waiting vs Offline
+```
+
+`_currentLanUrl` is mutable. When `_parseStatus` sees `local_ip` in the moongate result, it overwrites `_currentLanUrl` and persists via `PrinterRegistry.updateLanUrl`.
+
+### 5.2 Where the LAN URL comes from
+
+| Source | When |
+|---|---|
+| Persisted in `PrinterRegistry` (SharedPreferences key `moongate_printers`) | At cold launch — first poll picks it up |
+| Reported by Pi in every `/status` response (`local_ip` + `http_port`) | On every successful poll — keeps the cache fresh |
+
+There is no other source. Specifically: nothing scans the network, nothing reads from mDNS, nothing inspects ARP.
+
+### 5.3 Control path
+
+[`print_control_service.dart`](../mobile/lib/services/print_control_service.dart) — created once per tile, uses `config.lanUrl` captured at construction time. **This has the staleness bug fixed in §10.1.**
+
+---
+
+## 6. Pi-side specification — Avahi service file
+
+### 6.1 Service file location and content
+
+The installer writes:
+
+```
+/etc/avahi/services/moongate.service
+```
+
+Content (Avahi standard XML, no templating needed beyond `MOONGATE_PORT`):
+
+```xml
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">Moongate on %h</name>
+  <service>
+    <type>_moongate._tcp</type>
+    <port>__MOONGATE_PORT__</port>
+    <txt-record>printer_id=__PRINTER_ID__</txt-record>
+    <txt-record>http_port=__MOONGATE_PORT__</txt-record>
+    <txt-record>version=v0.5</txt-record>
+  </service>
+</service-group>
+```
+
+The two placeholders are substituted at install time:
+
+- `__MOONGATE_PORT__` ← the same `MOONGATE_PORT` already used by the plugin and the cloudflared tunnel (default 80, overridable via `--port` / `MOONGATE_PORT` env var).
+- `__PRINTER_ID__` ← the `printer_id` UUID written into `~/.config/moongate/owner.json` at pairing time. **At first install, before a pair, this field is unknown.** See §6.4 for how that's handled.
+
+### 6.2 Why these TXT records
+
+- `printer_id` — the only field the app strictly needs. Lets the app match an advertisement to a specific entry in its registry. Without this, multi-printer households can't disambiguate.
+- `http_port` — strictly redundant with the `<port>` element. We include it because some `nsd` / `bonsoir` versions surface only TXT and not the port element cleanly; this guarantees the port is visible regardless of which package version we ship.
+- `version=v0.5` — forward-compat marker. If a future v0.6 changes the TXT schema, the app can branch on this. Costs nothing today.
+
+### 6.3 Service name
+
+`_moongate._tcp` — registered under the unofficial-services convention. We are not in IANA's registry; the v0.5 promise is that this service name is stable and won't change.
+
+### 6.4 First-install ordering — the chicken-and-egg
+
+The installer runs *before* the user pairs the printer, so `~/.config/moongate/owner.json` doesn't exist yet. Three options:
+
+| Option | Behaviour |
+|---|---|
+| A. Write service file at install time with `printer_id=unknown`, rewrite at pair time | App-side has to ignore advertisements with `printer_id=unknown` until they update. Two source-of-truth files. |
+| B. Don't write service file until first pair | Cleaner. Plugin's `moongate_generate_pair_code` handler writes the service file as the last step of a successful pair. Avahi picks up new files in `/etc/avahi/services/` without restart. |
+| C. Write service file at install time with no `printer_id` TXT, rewrite at pair | Same problem as A but with one fewer field. |
+
+**Recommended: Option B.** Cleaner state model — exactly one source of truth (`owner.json`), service file exists iff the Pi is paired. `uninstall.sh` removes the service file as part of `MOONGATE_RESET_OWNER` and the full uninstall path.
+
+This also has a nice operational property: an unpaired Pi is invisible on the LAN, which matches the v0.4 security stance.
+
+### 6.5 Installer changes
+
+`install.sh`:
+
+- New helper function `_write_avahi_service` called from the plugin's pair-success handler (Python side — see §6.6).
+- `install.sh` ensures `avahi-daemon` is enabled and running. On stock MainsailOS / FluiddPI it already is; the check is a 2-line `systemctl is-enabled avahi-daemon || sudo systemctl enable --now avahi-daemon` (idempotent, no error if already running).
+
+`uninstall.sh`:
+
+- Remove `/etc/avahi/services/moongate.service` if present.
+- Do not touch `avahi-daemon` itself — it's a system service used by other things (Mainsail's `mainsail.local` hostname, etc.).
+
+### 6.6 Plugin changes
+
+`moongate_standalone.py` gets a small helper:
+
+```python
+async def _write_avahi_service(self, printer_id: str, port: int) -> None:
+    """Write /etc/avahi/services/moongate.service. Idempotent.
+    Called from _handle_pair_complete and _handle_reset_owner.
+    """
+    ...
+```
+
+Called on:
+- Successful first pair (after `owner.json` is written)
+- `MOONGATE_RESET_OWNER` (removes the service file)
+- Plugin startup (re-writes if the file is missing but `owner.json` exists — defensive against a manual deletion)
+
+The helper writes to a temp file in `/etc/avahi/services/.moongate.service.tmp` and `mv`s into place to keep Avahi from seeing a partial file.
+
+Sudo: the plugin runs as `pi`, so writing to `/etc/avahi/services/` needs either (a) a one-time `sudo chown pi /etc/avahi/services` in `install.sh` (heavy-handed), or (b) a sudoers entry letting `pi` install this specific file (cleaner). **Recommended: option (b) — `install.sh` adds `/etc/sudoers.d/moongate-avahi` letting the plugin's user run `cp /etc/avahi/services/.moongate.service.tmp /etc/avahi/services/moongate.service` and `rm /etc/avahi/services/moongate.service` without a password.**
+
+### 6.7 IP address: not in the advertisement
+
+Deliberately. Avahi advertises the host's current IP as part of the standard `A`-record resolution; the app's mDNS client resolves the discovered service to an IP at lookup time. Putting the IP in a TXT record would be redundant and would create a second drift opportunity.
+
+---
+
+## 7. App-side specification — discovery service
+
+### 7.1 Package choice
+
+`bonsoir` (https://pub.dev/packages/bonsoir) is the recommended Flutter mDNS package:
+
+- Maintained
+- Supports Android `NsdManager` + iOS `NetServiceBrowser` (positions us for the future iOS port)
+- Wraps both browse-for-services and read-TXT-records cleanly
+- Used by several other Flutter projects with active maintenance
+
+`nsd` (https://pub.dev/packages/nsd) is the alternative — slimmer API, Android-only at present. Either works; `bonsoir` is chosen because it covers iOS without a second integration.
+
+### 7.2 Service layout
+
+New file `mobile/lib/services/lan_discovery_service.dart`:
+
+```dart
+class LanDiscoveryService {
+  LanDiscoveryService._();
+  static final LanDiscoveryService instance = LanDiscoveryService._();
+
+  /// printer_id → "http://<ip>[:<port>]" — the current discovered LAN URL,
+  /// or absent if no advertisement for that printer has been seen recently.
+  final Map<String, String> _discovered = {};
+
+  /// Discovered URL for the given printer, or null if mDNS hasn't seen it
+  /// in this session. Read by PrinterStatusService at the top of each poll.
+  String? lookup(String printerId);
+
+  /// Start a 5 s browse cycle. Called on app foreground and at the start
+  /// of every Nth status poll cycle (N=15, i.e. once per minute at 4 s
+  /// polling). Browse runs in the background; lookup() returns the most
+  /// recently seen URL at any time.
+  Future<void> refresh();
+
+  /// Forget all discoveries — used on sign-out / user change.
+  void clear();
+}
+```
+
+The service is a singleton paralleling `PrinterAccessCache`. It holds in-memory state only; on cold launch `_discovered` is empty and `lookup` returns null until the first browse completes, which is fine — the persisted `lanUrl` covers that gap.
+
+### 7.3 Browse cycle
+
+```
+refresh()
+├─ Start Bonsoir browse for _moongate._tcp
+├─ For each discovered service event:
+│   ├─ Resolve to {host, port, txt-records}
+│   ├─ Extract printer_id from TXT (or skip if missing)
+│   ├─ Construct URL: 'http://<host>:<port>'  (omit :port if port==80)
+│   └─ _discovered[printer_id] = url
+├─ After 5 s OR app backgrounds, stop browse
+└─ return
+```
+
+5 s is conservative — most home networks resolve mDNS in <500 ms. The longer window covers stale Avahi caches, congested networks, and the Bonsoir-on-Android cold-start delay (~300 ms).
+
+### 7.4 Browse trigger points
+
+- App foreground (`WidgetsBindingObserver.didChangeAppLifecycleState` → resumed)
+- Every Nth poll-cycle resync — start with N=15 (≈ once per minute at 4 s polling).
+- On user pull-to-refresh of the dashboard
+
+NOT triggered every poll cycle — that would be wasteful. The cached `_discovered` entry is reused between refreshes.
+
+### 7.5 Stale-entry handling
+
+If a previously-discovered printer doesn't appear in the next browse, **the entry stays in `_discovered`**. The status service will try it; if it fails, the standard fallback to tunnel kicks in. The discovered URL is removed only when:
+
+- A subsequent browse explicitly emits a "service removed" event (Avahi sends these on graceful shutdown)
+- The status service reports the discovered URL has failed N consecutive polls (N=3) — at which point we proactively drop it so the next browse can find the new IP without first failing
+
+### 7.6 Concurrency
+
+Browse starts are debounced — if `refresh()` is called while one is already running, the second call is a no-op. The `_discovered` map is mutated only from the main isolate (Flutter convention); `lookup()` is a synchronous read.
+
+---
+
+## 8. Integration with existing services
+
+### 8.1 PrinterStatusService
+
+Top of `_doPoll`, before the existing LAN-URL check:
+
+```dart
+// v0.5: prefer a freshly-discovered LAN URL from mDNS over the
+// last one we persisted. The discovered URL is what's *actually*
+// being advertised right now; the persisted one might be stale.
+final discovered = LanDiscoveryService.instance.lookup(config.id);
+final lanUrl = discovered ?? _currentLanUrl;
+if (lanUrl != null) {
+  // ... existing LAN-first code, unchanged
+}
+```
+
+If discovery returns a URL, we use it. If not, fall through to the existing persisted URL. Always — never both.
+
+When a discovered URL succeeds, we still call `PrinterRegistry.updateLanUrl` from `_parseStatus` so the persisted copy is also refreshed — this keeps cold-launch behaviour identical to today.
+
+### 8.2 PrintControlService
+
+Same shape:
+
+```dart
+final discovered = LanDiscoveryService.instance.lookup(config.id);
+final lanUrl = discovered ?? _liveLanUrlFromRegistry();  // §10.1
+```
+
+(The `_liveLanUrlFromRegistry` helper is part of the §10.1 Phase 0 fix.)
+
+### 8.3 No other services need changes
+
+The webcam snapshot URL is constructed by `PrinterStatusService._parseStatus` using whichever base URL won the poll. Once LAN routes via the discovered URL, the snapshot URL inherits it automatically. No `_WebcamSnapshot` change needed.
+
+`PrinterAccessCache`, `SupabaseService`, `MoonrakerService` — all unchanged. mDNS is a pure-LAN feature; the tunnel-and-auth machinery is untouched.
+
+---
+
+## 9. Test plan
+
+### 9.1 Pi-side
+
+| Test | Pass criterion |
+|---|---|
+| Fresh `install.sh` on stock MainsailOS | `avahi-daemon` enabled, no service file yet (unpaired) |
+| `MOONGATE_PAIR` → successful claim | `/etc/avahi/services/moongate.service` exists with correct `printer_id` and `http_port` TXT |
+| From a Mac on the same WiFi: `dns-sd -B _moongate._tcp local` | Sees the Pi advertising as "Moongate on \<hostname\>" |
+| `dns-sd -L "Moongate on <hostname>" _moongate._tcp local` | Resolves to the Pi's current IP and the correct port, with all three TXT records |
+| Change the Pi's IP via DHCP lease renewal | New IP shows up in `dns-sd -L` within ~5 s of Avahi reacting to the netlink event |
+| `MOONGATE_RESET_OWNER` | Service file is removed; `dns-sd -B` no longer shows the Pi |
+| Re-run `install.sh` | Idempotent — no duplicate service files, no sudoers entry duplication |
+| `uninstall.sh` | Service file removed, sudoers entry removed, `avahi-daemon` left enabled (other services use it) |
+
+### 9.2 App-side
+
+| Test | Pass criterion |
+|---|---|
+| Cold launch on home WiFi with one paired printer | `_WebcamSnapshot` shows the LAN snapshot; tile badge says "Local"; first poll uses the discovered URL (not the persisted one — verify via dev-log inspector) |
+| Cold launch off-LAN | `LanDiscoveryService.lookup` returns null for all printers; behaviour identical to v0.4.3 (tunnel-first within ~2 s) |
+| Pi's IP changes while the app is open on the dashboard | Within one full poll cycle after the next mDNS browse (≤ ~60 s), tile flips back to "Local" on the new IP without going through tunnel |
+| Internet disconnected at the router, Pi LAN intact | Tile stays on "Local"; status updates continue; pause/resume/cancel work via LAN |
+| Two printers on the same WiFi | Both discovered, both matched to the correct registry entries by `printer_id` (no cross-talk) |
+| Hostile LAN device advertises a fake `_moongate._tcp` with a `printer_id` matching ours | App attempts the fake URL once → fails auth (no valid plugin response) → falls through to tunnel as usual. No persistent corruption. |
+| Background → foreground after >5 minutes | `LanDiscoveryService.refresh()` fires; discovered map is re-populated |
+| Subnet without multicast (router config disables IGMP snooping or blocks 224.0.0.251) | No discovery; tile uses persisted LAN URL + tunnel; user-visible behaviour identical to v0.4.3 |
+
+### 9.3 Verification matrix at a glance
+
+| User location | Internet up? | mDNS works? | v0.4.3 behaviour | v0.5.0 behaviour |
+|---|---|---|---|---|
+| Home, same WiFi | Yes | Yes | "Local" via cached IP | "Local" via discovered IP — survives IP changes |
+| Home, same WiFi | **No** | Yes | "Offline" until internet returns | **"Local" — survives the outage** |
+| Home, same WiFi | Yes | No (e.g. multicast blocked) | "Local" via cached IP | "Local" via cached IP (unchanged) |
+| Away (cellular / different WiFi) | Yes | n/a | "Tunnel" | "Tunnel" (unchanged) |
+| Away | No | n/a | "Offline" | "Offline" (unchanged) |
+
+The new column is row 2 — the case this whole spec exists to fix.
+
+---
+
+## 10. Rollout plan
+
+### 10.1 Phase 0 — `PrintControlService` reads `lanUrl` live (precursor)
+
+**Not blocking on this spec being merged.** Shipped as its own small PR. The bug exists in v0.4.3 today: `PrintControlService` captures `config.lanUrl` at construction and never re-reads, so after an IP change the *status* service flips back to LAN within one poll but pause/resume/cancel still try the old IP until the tile is rebuilt.
+
+Fix shape:
+
+```dart
+class PrintControlService {
+  final PrinterConfig config;
+  PrintControlService(this.config);
+
+  Future<bool> sendAction(String action) async {
+    // ... unchanged token-fetching code ...
+
+    // v0.5 §10.1: read lanUrl live from the registry so an IP change
+    // surfaced by PrinterStatusService is picked up by the next action
+    // we send, without waiting for the tile to be rebuilt.
+    final live = PrinterRegistry.instance.printers
+        .firstWhereOrNull((p) => p.id == config.id);
+    final lanUrl = live?.lanUrl ?? config.lanUrl;
+    // ... rest unchanged ...
+  }
+}
+```
+
+This phase has no dependency on §6 or §7. Ships before either.
+
+### 10.2 Phase 1 — Pi-side Avahi advertisement
+
+Ships as v0.4.4 (Pi-side only, no app change). Plugin + installer changes from §6. v0.5.0-app browsing for this will pick up Pi-side Phase 1 changes when both are deployed.
+
+Pi-side Phase 1 is **safe to ship before any app-side change** because:
+- An advertised but unobserved service is invisible — no user-visible effect on existing v0.4.3 users
+- The plugin and installer changes are small and localised
+- Rollback is straightforward (delete the service file and the sudoers entry)
+
+### 10.3 Phase 2 — App-side discovery integration
+
+Ships as v0.5.0. `LanDiscoveryService` + integration with `PrinterStatusService` and `PrintControlService` per §7 and §8.
+
+v0.5.0 works correctly against:
+- Pis that have been updated to Phase 1 (full benefit)
+- Pis that have *not* been updated to Phase 1 (no benefit, no regression — `LanDiscoveryService.lookup` returns null, falls through to the existing path)
+
+This means **v0.5.0 ships without a hard dependency on every Pi having been updated**. The user pulls down v0.5.0 to their phone, and any Pi they later update to Phase 1 starts being discovered automatically.
+
+### 10.4 Phase 3 — Future (v0.5.1+)
+
+Out of scope for v0.5.0 but worth flagging:
+
+- **Settings toggle for "LAN discovery: on/off"** — for users on hostile WiFi who want to opt out
+- **Subnet-scan fallback** when mDNS finds nothing within 2 s, for routers blocking multicast
+- **iOS port** — `bonsoir` covers iOS; no spec change needed when the iOS build target lands
+- **mDNS-based pairing** — replace QR-with-LAN-URL with "found a Pi advertising itself as ready-to-pair". Deliberately deferred — pairing's QR-with-LAN-URL flow has had careful security review in v0.3 and v0.4, and changing the pairing transport is a separate spec.
+
+---
+
+## 11. Open questions
+
+These need a decision before implementation begins.
+
+| # | Question | Default if no answer |
+|---|---|---|
+| Q1 | Should the Avahi service file land at the start of `install.sh` (and be rewritten on pair) or only after a successful pair? §6.4 recommends the latter. | After-pair only (Option B in §6.4) |
+| Q2 | Sudoers-entry vs `chown pi /etc/avahi/services` for the plugin to install the service file? §6.6 recommends sudoers. | Sudoers entry |
+| Q3 | mDNS browse cadence — every N polls or every M minutes? §7.4 recommends N=15 (≈1 min at 4 s polling). | Every 15 polls |
+| Q4 | Bonsoir vs nsd Flutter package? §7.1 recommends bonsoir for iOS-readiness. | Bonsoir |
+| Q5 | Phase 0 (PrintControlService live `lanUrl`) — ship now as its own PR or roll into v0.5.0? | Ship now as its own PR |
+
+---
+
+## 12. Open issues / risks (after the open questions are resolved)
+
+| Risk | Mitigation |
+|---|---|
+| Bonsoir maintenance lapse | If Bonsoir is unmaintained at implementation time, switch to `nsd` — Android-only, but acceptable for v0.5.0 (no iOS target yet) |
+| Avahi config syntax drift between distros | The Avahi XML format has been stable since 2010; we don't anticipate this changing. Smoke-test on at least MainsailOS, FluiddPI, and stock Raspberry Pi OS before ship. |
+| User's router blocks multicast (some enterprise / hotel APs) | Documented fallback to persisted-LAN-URL + tunnel, exactly as today. No regression. |
+| Multiple Pis with the same `printer_id` (cloned SD card) | This is a pre-existing v0.3 issue — Supabase claim model expects unique IDs. Out of scope for this spec; flagged for the v0.5.1 cloning-detection work. |
+
+---
+
+## 13. References
+
+- [v0.3 Supabase design](v0.3-supabase-design.md) — cloud-mediated pairing and access-token mint
+- [v0.4 secure remote access design](v0.4-secure-remote-access-design.md) — Pi auth proxy, EdDSA gate, hardened tunnel
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — current data flows, state map, service-layer responsibilities
+- Apple's [DNS-SD service-type registry](https://developer.apple.com/bonjour/) for the unofficial-services convention
+- Android `NsdManager` reference: https://developer.android.com/develop/connectivity/wifi/use-nsd
+- Bonsoir package: https://pub.dev/packages/bonsoir


### PR DESCRIPTION
## Summary

**Spec only — no implementation in this PR.** Adds `docs/v0.5-lan-discovery-design.md` (501 lines) following the same shape as `docs/v0.4-secure-remote-access-design.md`. Implementation begins only after this is merged.

## Why this exists

Closes the gap surfaced by the *"what about MAC addresses?"* question: when the Pi's LAN IP changes **and** the internet leg is degraded, today's recovery path (tunnel → Supabase → app updates cached LAN URL) doesn't fire and the tile sits on "offline" forever even though the phone is on the same WiFi as the Pi.

MAC addresses aren't reachable from Android user-space (since API 23). The platform-blessed equivalent is mDNS / DNS-SD — Avahi (already installed on stock MainsailOS) advertises a service from the Pi; `NsdManager` (via the `bonsoir` Flutter package) browses on the app side.

## What the spec covers

| § | Content |
|---|---|
| §0 | Scope: what v0.5.0 ships, what's deferred |
| §1 | Why this exists — the IP-change-while-offline gap |
| §2 | Hard constraints (zero infra cost, no second app, no new permissions, no off-LAN regression) |
| §3 | Threat model — five new surfaces analysed, all low/medium severity with mitigations |
| §4 | Decision matrix — DHCP reservation vs Supabase-heartbeat-only vs subnet scan vs **mDNS (recommended)** vs WebRTC mDNS candidates |
| §5 | Existing-behaviour baseline (v0.4.3) for reference |
| §6 | **Pi-side spec** — Avahi service file format, TXT records, install/uninstall integration, sudoers vs chown decision, plugin helper |
| §7 | **App-side spec** — `LanDiscoveryService` singleton, browse cadence, stale-entry handling, concurrency |
| §8 | Integration with `PrinterStatusService` + `PrintControlService` |
| §9 | Test plan (Pi-side, app-side, behaviour matrix) |
| §10 | Three-phase rollout |
| §11 | Five open questions for review |
| §12 | Risks |
| §13 | References |

## Rollout (from §10)

| Phase | Ships as | Depends on |
|---|---|---|
| 0 | `PrintControlService` reads `lanUrl` live (small bug fix, separate PR) | Nothing — independent |
| 1 | Pi-side Avahi advertisement | This spec being merged |
| 2 | App-side `LanDiscoveryService` (v0.5.0) | Phase 1 deployed on user's Pi (graceful — no Phase 1 = no benefit, no regression) |

## What this PR does *not* do

- No code changes
- No version bump (the only file added is in `docs/`)
- No CI APK rebuild trigger (no mobile source changed)

## Open questions for review (from §11)

1. Avahi service file at install time vs after-pair? Default: after-pair (cleaner state model)
2. Sudoers entry vs `chown pi /etc/avahi/services`? Default: sudoers (least privilege)
3. Browse cadence — every Nth poll? Default: N=15 (~1 min at 4 s polling)
4. Bonsoir vs nsd package? Default: bonsoir (iOS-ready)
5. Ship Phase 0 bugfix now or roll into v0.5.0? Default: now, as its own PR

## Suggested review path

1. Skim §0 and §4 to agree the approach
2. Read §6 and §7 for the wire-level details
3. Confirm the five §11 defaults or push back on any of them
4. Merge — then I can open the Phase 0 PR and start work on Phase 1