### PR TITLE
docs: reinstall reset-owner guidance (follow-up to v0.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ All releases are in the [APK folder](https://github.com/PEEKYPAUL/Moongate/tree/
 
 On first launch the app will ask you to add a printer.
 
+> **Reinstalling, or moving to a new phone?** A fresh install creates a brand-new app identity, so your printers won't reconnect on their own — every tile shows offline until you re-pair. Before pairing again, run **`MOONGATE_RESET_OWNER`** in the Klipper console for each printer (it releases the old association), then `MOONGATE_PAIR` and scan as usual. Exporting your config first (menu → **Export config**) restores your printer *names* and layout, but re-pairing is what restores the actual connection. **Tip:** running `MOONGATE_RESET_OWNER` *before* you uninstall saves a step.
+
 ---
 
 ### Step 3 — Pair

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -108,6 +108,16 @@ In **v0.4.2+** the recovery is one macro: `MOONGATE_RESET_OWNER` on the Pi (Klip
 
 Before v0.4.2 the cloud row could be orphaned by a fresh app install (new anonymous identity), which would cause `already_paired` on re-pair. That's gone now — the Pi can clean up its own cloud row without the original app being reachable.
 
+## All tiles offline after reinstalling the app (or a new phone)
+
+**Symptom:** You reinstalled Moongate, or switched to a new phone, and every printer shows offline — even sitting on your home WiFi.
+
+**Cause:** A fresh install creates a new anonymous app identity. Your printers are still associated with the *previous* identity in the cloud, so the new install owns nothing and every tile reads offline. Importing a config backup brings back the printer names and layout, but not the cloud association.
+
+**Fix:** Re-pair each printer. On the Pi, run `MOONGATE_RESET_OWNER` in the Klipper console, then `MOONGATE_PAIR`, and scan the QR (or type the GATE code) in the app.
+
+> **Save yourself a step:** run `MOONGATE_RESET_OWNER` *before* you uninstall the old app. Then a fresh install just needs `MOONGATE_PAIR` and a scan.
+
 ## Tunnel URL leakage — what's actually exposed in v0.4?
 
 **Nothing.** This was a real concern in v0.2.x where the tunnel terminated at nginx serving Mainsail without auth. In v0.4 the tunnel terminates at the auth proxy, which returns flat 401s for every request without a valid short-lived token. The URL alone is useless. Share it with anyone — they get 401s.


### PR DESCRIPTION
## Docs follow-up to v0.5.1 — reinstall reset-owner guidance

Two markdown edits that were meant to ship in the v0.5.1 release but failed to apply in the release commit (a linter touched the files mid-edit). Re-applied here. **No APK impact** — the in-app "What's new" bullet about this already shipped in v0.5.1; this is README + TROUBLESHOOTING only.

- **README → Step 2 — Install the app:** a callout for reinstalling / moving to a new phone — explains the all-tiles-offline symptom (fresh install = new app identity) and the fix: run `MOONGATE_RESET_OWNER` on the Pi, then re-pair.
- **TROUBLESHOOTING:** new entry "All tiles offline after reinstalling the app (or a new phone)" with symptom / cause / fix.

Safe to merge any time — purely documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
