### PR TITLE
docs: split README Setup — add Updating + Removing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ moongate/
     ├── moongate-authproxy.service # systemd unit template for the auth proxy
     ├── install.sh                 # One-line installer for the Pi
     ├── update.sh                  # Post-pull hook called by Moonraker update manager
-    ├── uninstall.sh               # Complete uninstaller (Step 4)
+    ├── uninstall.sh               # Complete uninstaller (see "Removing Moongate")
     └── moongate-pair.html         # QR pairing page (deployed to Mainsail)
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ All releases are in the [APK folder](https://github.com/PEEKYPAUL/Moongate/tree/
 
 On first launch the app will ask you to add a printer.
 
-> **Reinstalling, or moving to a new phone?** A fresh install creates a brand-new app identity, so your printers won't reconnect on their own — every tile shows offline until you re-pair. Before pairing again, run **`MOONGATE_RESET_OWNER`** in the Klipper console for each printer (it releases the old association), then `MOONGATE_PAIR` and scan as usual. Exporting your config first (menu → **Export config**) restores your printer *names* and layout, but re-pairing is what restores the actual connection. **Tip:** running `MOONGATE_RESET_OWNER` *before* you uninstall saves a step.
+> **Already running Moongate and just reinstalling, or moving to a new phone?** A fresh install gets a new app identity, so you'll need to re-pair — see **[Reinstalling the app](#reinstalling-the-app-or-moving-to-a-new-phone)** below *before* you uninstall.
 
 ---
 
@@ -120,7 +120,49 @@ On first launch the app will ask you to add a printer.
 
 ---
 
-### Step 4 — Uninstall
+## Updating Moongate
+
+Moongate has two parts — the **app** on your phone and the **plugin** on your Pi. They update independently.
+
+### Updating the app
+
+When a new version is out, the app shows an **update banner** on launch — tap it to download the latest APK, then install over the top. Your printers and settings are preserved (same signing key, so it installs as an upgrade, not a fresh install).
+
+You can also grab it manually any time: **[Download the latest APK](https://github.com/PEEKYPAUL/Moongate/raw/master/APK/Moongate-latest.apk)** and install over your existing copy.
+
+> As long as you **install over** the existing app (rather than uninstalling first), your identity is kept and nothing needs re-pairing.
+
+### Updating the plugin
+
+Pi-side updates appear automatically in **Mainsail → Machine → Software Updates → Moongate** — click **Update** there, no SSH needed.
+
+Prefer the command line? SSH in and re-run the installer — it pulls the latest and restarts the services:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/klipper-plugin/install.sh | bash
+```
+
+> Some releases note **"re-run the Pi installer"** in the changelog — that means a plugin-side change shipped (e.g. v0.5.1's instant-pairing QR). Update the plugin to get it.
+
+### Reinstalling the app (or moving to a new phone)
+
+This is the one case that needs care. A fresh install — uninstalling and reinstalling, clearing app data, or setting up a new phone — creates a **brand-new app identity**. Your printers are still tied to the *old* identity in the cloud, so after a fresh install every tile shows offline until you re-pair.
+
+To reinstall cleanly:
+
+1. **Before uninstalling**, for each printer run **`MOONGATE_RESET_OWNER`** in the Klipper console. This releases the cloud association so the printer can be claimed again.
+   *(Optional: menu → **Export config** to save your printer names + layout. This restores the list, but not the connection — re-pairing is what reconnects.)*
+2. Uninstall the old app / set up the new phone, and install Moongate.
+3. *(If you exported)* menu → **Import config** to bring your printer list back.
+4. For each printer: run `MOONGATE_PAIR` on the Pi and scan the QR (or type the GATE code) — see [Step 3 — Pair](#step-3--pair).
+
+> **Forgot to run `MOONGATE_RESET_OWNER` first?** No problem — run it now (it works any time), then `MOONGATE_PAIR` and pair again. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#all-tiles-offline-after-reinstalling-the-app-or-a-new-phone).
+
+> **Just upgrading the app over the top?** None of this applies — your identity is kept and your printers stay paired.
+
+---
+
+## Removing Moongate
 
 To completely remove Moongate from your Pi, SSH in and run:
 


### PR DESCRIPTION
## README: split Setup — add Updating + Removing sections

"Step 4 — Uninstall" was never really a setup step. This pulls removal and updating out of the numbered Setup flow into their own top-level sections, and adds the reinstall/update guidance you'd otherwise have to figure out the hard way.

### Changes
- **New `## Updating Moongate`** with three parts:
  - **Updating the app** — install over the top (update banner or manual APK); identity kept, no re-pair.
  - **Updating the plugin** — Mainsail → Software Updates, or re-run the installer; notes that "re-run the Pi installer" in a changelog means a plugin-side change shipped.
  - **Reinstalling the app (or moving to a new phone)** — the one case that needs care: run `MOONGATE_RESET_OWNER` *before* uninstalling, then re-pair. Includes the "forgot to reset first" recovery path.
- **`Step 4 — Uninstall` → `## Removing Moongate`** — same content, now its own section instead of a mis-numbered step.
- Setup Step 2 callout links to the new Reinstalling section instead of duplicating it.
- Fixed a stale `(Step 4)` reference in the repo-structure tree.

Docs only — no code, no APK impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
