### PR TITLE
chore: add dependabot.yml (alerts re-enabled; 0 current vulns)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot keeps dependencies patched and surfaces vulnerable packages.
+#
+# Repo-level Dependabot *alerts* + *automated security fixes* were enabled on
+# 2026-06-07 (they had been switched off, which is why a stale vuln count
+# lingered for weeks with no way to verify it). Security-update PRs are driven
+# by those alerts and need no config here. This file adds scheduled *version*
+# update coverage so dependencies don't silently drift out of date.
+version: 2
+updates:
+  # ── Flutter / Dart packages (the app) ──────────────────────────────────────
+  - package-ecosystem: "pub"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    # Bundle in-range minor/patch bumps into one PR to keep the noise down;
+    # majors (mostly constraint-blocked here) still come through individually.
+    groups:
+      dart-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # ── Android / Gradle (native side) ─────────────────────────────────────────
+  # Not currently in the dependency graph, so adding it here also extends
+  # scanning to the Android build. Flutter's generated Gradle can be awkward for
+  # Dependabot to parse; if it can't, it just logs on the Dependabot tab.
+  - package-ecosystem: "gradle"
+    directory: "/mobile/android"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(android)"
+
+  # ── GitHub Actions used by CI ──────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Context
The repo's long-standing **"6 Dependabot vulns (2 high / 4 moderate)"** follow-up was never re-verifiable across sessions — because Dependabot **alerts had been disabled** at the repo level. The stale count just kept getting copied forward.

## What this session did
- **Enabled** repo vulnerability alerts (`PUT /vulnerability-alerts` → `204`) and **automated security fixes** (`{"enabled":true,"paused":false}`) via the API.
- Confirmed the dependency graph is populated — **144 packages** across `pub` + `github-actions`.
- Result: **0 Dependabot alerts in any state** (open / fixed / dismissed). The historical "6" was stale — those vulnerable deps were updated over the v0.4 → v0.6 work.

## This PR
Adds `.github/dependabot.yml` with weekly **version-update** coverage for:
- `pub` — the Flutter app (`/mobile`); minor/patch grouped into one PR to limit noise
- `gradle` — Android native (`/mobile/android`); also extends scanning to the Android build (not in the graph today)
- `github-actions` — CI action versions (`/`)

Security-update PRs are driven by the now-enabled alerts and need no config here — this just keeps versions from silently drifting and ensures any *new* advisory surfaces as a PR.

## Heads-up
On first run after merge, Dependabot may open a few version-update PRs (capped at 5/ecosystem; Dart minor/patch grouped). Most Dart majors are constraint-blocked so won't appear. Review/merge or close at leisure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
