### PR TITLE
docs(ci): quiet-merge non-release PRs to avoid release clobber

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -271,6 +271,8 @@ The CI pipeline ([`.github/workflows/build-android.yml`](.github/workflows/build
 
 So **the only thing you commit by hand is code + screenshots + docs**. The release APK lands as a Release asset 2–3 minutes after each push; the in-app updater downloads from there.
 
+> **Merging a non-release PR? Quiet-merge it with `[skip ci]`.** The build above runs on *every* push to `master` and rebuilds the APK for whatever `version:` is in `mobile/pubspec.yaml`. Merging a PR that **doesn't** bump the version therefore rebuilds the *current* release and **clobbers its existing Release asset** (`gh release upload --clobber`) — silently replacing the published APK with a fresh build (the `latest_version.json` manifest is left untouched when the build number hasn't changed). For deps / config / Pi-side-only PRs, put `[skip ci]` in the **merge-commit subject** so nothing rebuilds; the changes ride into the next versioned release.
+
 `ci.yml` runs `flutter analyze` and `flutter test` on PRs.
 
 ---


### PR DESCRIPTION
## Summary

Documents a non-obvious CI behaviour and the convention that goes with it.

`build-android.yml` runs on **every** push to `master` and rebuilds the APK for whatever `version:` is in `mobile/pubspec.yaml`. If a GitHub Release for that version already exists, it **clobbers that release's APK asset** (`gh release upload --clobber`) — so merging a PR that doesn't bump the version silently replaces the *published* APK with a fresh build (the `latest_version.json` manifest is left untouched when the build number hasn't changed).

The new `## CI / CD` callout records the fix: merge **deps / config / Pi-side-only** PRs with `[skip ci]` in the merge-commit subject so nothing rebuilds, and the changes ride into the next versioned release. Precedent: #41, #42, #43.

## Test plan

- Docs-only change to `DEVELOPMENT.md`; no code paths touched.
- PR checks (analyze / plugin lint / build) run as normal and should stay green.

## Merge note

This PR is itself a non-release docs change — **quiet-merge it with `[skip ci]`** in the merge-commit subject, per the rule it documents.