### PR TITLE
docs(security): correct Pi service-role claim + extend RLS verification

### DIFF
--- a/docs/v0.4-secure-remote-access-design.md
+++ b/docs/v0.4-secure-remote-access-design.md
@@ -489,7 +489,7 @@ CREATE POLICY "owner can read/write printer signalling"
   );
 ```
 
-The Pi uses its existing Supabase **service-role** path (already in use for heartbeats) — it doesn't authenticate as a user. It subscribes via the Realtime REST API using the service role JWT. RLS doesn't apply to service role.
+> **Correction (post-v0.4 security audit).** The Pi does **not** hold a Supabase service-role key — and never has. Its heartbeats authenticate with the public **anon** key at the gateway plus an **Ed25519 signature** over the payload, which the `printer-heartbeat` Edge Function verifies against the stored `pi_public_key`; the privileged write is done server-side by the Edge Function's service role, never by the Pi. So this signalling design **cannot** rely on the Pi subscribing to Realtime with a service-role JWT. If WebRTC is ever built, the Pi side needs a different path — e.g. a dedicated Edge Function that mints a short-lived, printer-scoped Realtime token for the Pi (mirroring how `/printer-access` mints the EdDSA access token for the app), or routing signalling through an authenticated Edge Function endpoint instead of a direct Realtime subscription. Either keeps the "no privileged key ever sits on the Pi" property intact.
 
 ### 7.4 DTLS fingerprint pinning — the only thing protecting against signalling MITM
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,11 +1,9 @@
-# Moongate v0.3.0 — Supabase Setup
+# Moongate — Supabase Backend Setup & Verification
 
-This directory contains everything needed to set up the Supabase side of v0.3.0.
+This directory contains everything needed to set up and verify Moongate's Supabase backend — the schema, Row-Level Security, cron cleanup, and the Edge Functions that mediate between the app, the Pi, and Postgres. It originated with the v0.3.0 cloud-pairing rewrite and is kept current (e.g. the `feedback` and `restore_grants` tables were added in v0.6.x).
 Design rationale: see [`docs/v0.3-supabase-design.md`](../docs/v0.3-supabase-design.md).
 
-> **All work is local-only until smoke test passes.** Do not push this branch
-> to GitHub. Do not deploy these Edge Functions to a production project that
-> v0.2.x users depend on.
+> **The backend is live and the repo is public — by design.** The rule that keeps that safe: the **server-side secrets never leave Supabase.** `MOONGATE_TUNNEL_URL_KEY`, `MOONGATE_JWT_SIGNING_KEY`, `MOONGATE_DEBUG_KEY`, and the `service_role` key live only in the Edge Functions environment — never in the APK, never in git. Only the **anon** key is public, and it's gated by the Row-Level Security verified in §3.
 
 ---
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -93,10 +93,10 @@ Expect two rows.
 ```sql
 SELECT relname, relrowsecurity, relforcerowsecurity
 FROM pg_class
-WHERE relname IN ('printers', 'enrollment_tokens');
+WHERE relname IN ('printers', 'enrollment_tokens', 'feedback', 'restore_grants');
 ```
 
-Both rows should show `relrowsecurity = t`.
+All four rows should show `relrowsecurity = t`. (`feedback` and `restore_grants` were added in v0.6.x and are locked down the same way — RLS on, all client privileges revoked, writes only via Edge Functions.)
 
 ### 3.3 Cron job scheduled
 


### PR DESCRIPTION
Three doc-accuracy fixes surfaced while auditing what the public repo / released APK expose. **No code change**, and no exposure is being fixed (nothing was exposed) — these correct *documentation* that could mislead a security reviewer.

### 1. Design doc: the Pi has no service-role key
`docs/v0.4-secure-remote-access-design.md` §7.3 (the **deferred** WebRTC signalling design) claimed:
> The Pi uses its existing Supabase service-role path (already in use for heartbeats)…

That's wrong. The shipped plugin authenticates heartbeats with the **public anon key** + an **Ed25519 signature** that the `printer-heartbeat` Edge Function verifies against `pi_public_key`; the privileged DB write is done server-side by the Edge Function's service role, never by the Pi. No Pi ever holds a service-role key. Corrected the line (as a flagged post-audit correction) and noted what a real Pi-side Realtime path would need if WebRTC is ever built.

### 2. README: RLS verification now covers all four tables
`supabase/README.md` §3.2's "RLS is on" query only checked `printers` + `enrollment_tokens`. Extended it to `feedback` + `restore_grants` (added in v0.6.x, locked down identically) so the check matches the live schema.

### 3. README: refreshed the stale v0.3.0 header
The header was titled "v0.3.0 — Supabase Setup" and still warned *"do not push this branch to GitHub"* — both obsolete now that the repo is public and the backend is live through v0.6.x. Retitled to a living setup-and-verification guide; replaced the build-time warning with the enduring rule (server-side secrets never leave Supabase; only the anon key is public, gated by RLS).

**Merge with `[skip ci]`** — docs-only, no rebuild needed.
