### PR TITLE
fix(plugin): re-bind on a new printer_id during an active pairing session

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -55,7 +55,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running — the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.4"
+MOONGATE_PLUGIN_VERSION = "0.6.5"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -973,17 +973,34 @@ class MoongatePlugin:
         if not token:
             raise self.server.error("Authorization token required", 401)
 
-        expected_pid = self.owner.printer_id if self.owner else None
+        # The stored owner's printer_id normally pins this Pi: a validly-signed
+        # token for any OTHER printer_id is refused, so a token minted for a
+        # different printer can never re-bind us. The one legitimate way a NEW
+        # printer_id appears for this same Pi is a deliberate re-pair that
+        # re-enrolled us under a fresh cloud row (the old row was released /
+        # recreated, so the cloud id changed). That only happens while a pairing
+        # session the user just started on the LAN/console is live — during that
+        # window we drop the pin so the new id can first-bind below. Outside
+        # pairing the pin stands and an id mismatch is a hard 401.
+        pairing = (self._pending is not None
+                   and time.time() <= self._pending.expires_at)
+        if pairing:
+            expected_pid = None
+        else:
+            expected_pid = self.owner.printer_id if self.owner else None
         claims = self.verifier.verify(str(token), expected_pid)
         if claims is None:
             raise self.server.error("Invalid or expired token", 401)
 
-        # Bind the owner on first contact, AND re-bind if a validly-signed
-        # token presents a new owner ("sub"). The cloud only mints a valid,
-        # printer-scoped token to the current owner, so a new sub means
-        # ownership was re-assigned in the cloud (e.g. a backup restore on a
-        # fresh install) — the Pi follows the cloud rather than refusing.
-        if self.owner is None or self.owner.owner_user_id != claims.sub:
+        # Bind the owner on first contact, AND re-bind if a validly-signed token
+        # presents a new owner ("sub") — a cloud ownership transfer such as a
+        # backup restore on a fresh install — or a new printer_id from the
+        # re-pair described above. The cloud only ever mints a valid, printer-
+        # scoped token to the current owner, so the Pi follows the cloud rather
+        # than refusing.
+        if (self.owner is None
+                or self.owner.owner_user_id != claims.sub
+                or self.owner.printer_id != claims.printer_id):
             first_bind = self.owner is None
             self.owner = OwnerState(
                 printer_id=claims.printer_id,
@@ -993,10 +1010,14 @@ class MoongatePlugin:
             try:
                 self.owner.save(OWNER_FILE)
                 logger.info("Owner %s: user=%s..., printer=%s...",
-                            "bound" if first_bind else "re-bound (cloud transfer)",
+                            "bound" if first_bind else "re-bound",
                             claims.sub[:8], claims.printer_id[:8])
             except OSError as exc:
                 logger.error("Failed to persist owner.json: %s", exc)
+            # A pairing session (if one was active) has served its purpose now
+            # that a valid token has bound — close it so the printer_id pin is
+            # back in force on the very next poll.
+            self._pending = None
             # The Pi is discoverable on the LAN only once it has a valid owner
             # (unpaired Pis are intentionally invisible on mDNS — see
             # docs/v0.5-lan-discovery-design.md §6.4). Idempotent on re-bind.


### PR DESCRIPTION
## Summary

A re-pair that mints a **new cloud `printer_id`** for the same Pi left the plugin's `owner.json` pinned to the **old** id. Every `/status` poll then carried a token for the new id, which `AccessTokenVerifier.verify()` rejected on the printer_id-mismatch path → **HTTP 401 on every poll, indefinitely** — escapable only by running `MOONGATE_RESET_OWNER`. In the app this surfaces as a permanently **offline** printer with `plugin_version: null` (the version is read from the 401'd `/status` body).

Traced from a real field report: of two printers, one stuck after an uninstall/reinstall + re-pair while the other re-bound fine — the difference was a stale `owner.json` surviving on the broken one.

Root cause: `_authenticate` already **follows a changed owner (`sub`)** — the backup-restore path — but `verify()` rejects a **changed `printer_id`** *before* that re-bind can run, and the pair flow writes `owner.json` lazily on first successful auth, never clearing the old binding.

## Fix

While a **user-initiated pairing session is live** (`self._pending`, set only by `MOONGATE_PAIR` on the console or the LAN pair page), drop the printer_id pin so a validly-signed token bearing a new id can first-bind; and extend the re-bind condition to fire on a `printer_id` change. The session is closed on bind, so the pin is back in force on the next poll.

## Why this is safe

- **Outside pairing the printer_id pin is fully enforced** — a validly-signed token for *someone else's* printer still gets a 401 and can't re-bind this Pi. Only the last row changes:

  | new `printer_id`, … | before | after |
  |---|---|---|
  | …no active pairing (stale / foreign token) | 401 | **401** |
  | …active pairing (deliberate re-pair) | 401 forever | **re-binds** |

- The pin only relaxes while a pairing session is open, which requires **LAN/console access** (the tunnel auth-proxy 401s a remote `/pair`) — the same trust boundary that already governs `MOONGATE_RESET_OWNER`. No new remote attack surface.
- Conservative: the existing binding is untouched until a valid replacement token actually arrives, so an abandoned `MOONGATE_PAIR` never unpairs anyone.

Bumps `MOONGATE_PLUGIN_VERSION` 0.6.4 → 0.6.5 so fixed Pis are identifiable.

## Test plan

- **Automated:** `ruff check klipper-plugin/` clean; `python -m py_compile` clean. Plugin-only change; no app code touched.
- **Manual (recommended, not run in this PR):** on a Pi paired under an old `printer_id`, run `MOONGATE_PAIR` + re-pair → tile re-binds with no `MOONGATE_RESET_OWNER`. Confirm that outside a pairing window a token for a different `printer_id` still 401s.

## Merge note

Pi-side only — the plugin reaches Pis via the installer (git), not the APK. Per the non-release convention (#48; precedent #41/#42/#43), **quiet-merge with `[skip ci]`** in the merge-commit subject so this doesn't rebuild and clobber the published v0.6.5 APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
