### PR TITLE
feat(plugin): detect and fix clock skew (silent killer of remote access)

### DIFF
--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -55,6 +55,86 @@ KLIPPER_CFG_DIR="$PRINTER_DATA/config"
 [[ -d "$MOONRAKER_DIR" ]]  || die "Moonraker not found at $MOONRAKER_DIR. Set MOONRAKER_DIR= if installed elsewhere."
 [[ -f "$MOONRAKER_CONF" ]] || die "moonraker.conf not found at $MOONRAKER_CONF."
 
+# ── Clock sanity check ────────────────────────────────────────────────────────
+# Moongate's remote access is cryptographically time-bound: the Pi signs every
+# heartbeat with its clock and the cloud REJECTS anything more than 60s off its
+# own (replay protection); the short-lived access tokens are time-checked too. A
+# Raspberry Pi has no battery-backed clock, so when NTP (UDP/123) is blocked —
+# common on locked-down networks — the clock silently drifts and ALL remote
+# access fails with cryptic 401s while everything else looks perfectly fine.
+#
+# timedatectl can't be trusted here (it happily reports an active-but-never-synced
+# client), so measure the REAL skew against an HTTPS Date header — the same path
+# the Pi uses to reach Supabase. -k because a badly-wrong clock fails TLS validity
+# (chicken-and-egg) and we're only reading a timestamp, not trusting a secret.
+# When NTP can't sync, keep time honest with htpdate (HTTP-based, survives blocked
+# UDP/123). Runs before apt/cloudflared below so those don't trip over TLS dates.
+MG_TIME_HOST="${MG_TIME_HOST:-https://www.cloudflare.com}"
+MG_CLOCK_MAX_SKEW=30   # seconds; the server's hard cutoff is 60
+
+info "Checking the system clock (remote auth needs it within 60s of real time)..."
+MG_HTTP_DATE=$(curl -fsSI -k --max-time 10 "$MG_TIME_HOST" 2>/dev/null \
+               | grep -i '^date:' | head -n1 | cut -d' ' -f2- || true)
+MG_HTTP_DATE=${MG_HTTP_DATE%$'\r'}
+MG_HTTP_EPOCH=$(date -d "$MG_HTTP_DATE" +%s 2>/dev/null || true)
+
+if [[ -z "$MG_HTTP_DATE" || -z "$MG_HTTP_EPOCH" ]]; then
+    warn "Couldn't verify the clock against network time — skipping (non-fatal)."
+    warn "If remote access later fails with repeated 'Heartbeat 401', check 'timedatectl' first."
+else
+    MG_NOW_EPOCH=$(date +%s)
+    MG_SKEW=$(( MG_NOW_EPOCH > MG_HTTP_EPOCH ? MG_NOW_EPOCH - MG_HTTP_EPOCH : MG_HTTP_EPOCH - MG_NOW_EPOCH ))
+    if (( MG_SKEW <= MG_CLOCK_MAX_SKEW )); then
+        success "Clock is accurate (within ${MG_SKEW}s of network time)."
+    else
+        warn "Pi clock is off by ~${MG_SKEW}s — remote auth needs it within 60s, correcting now."
+        warn "(No battery clock + blocked NTP makes it drift; every signed heartbeat is then"
+        warn " rejected as a replay, so remote access silently fails.)"
+        if sudo date -s "$MG_HTTP_DATE" >/dev/null 2>&1; then
+            success "Clock set from network time: $(date '+%Y-%m-%d %H:%M:%S %Z')."
+        else
+            warn "Couldn't set the clock automatically. Run by hand: sudo date -s \"$MG_HTTP_DATE\""
+        fi
+
+        # Keep it correct across reboots. If NTP genuinely works, leave it alone;
+        # otherwise install htpdate + a small timer so it can't drift back.
+        if timedatectl show -p NTPSynchronized --value 2>/dev/null | grep -qi true; then
+            info "NTP is working — no extra time daemon needed."
+        elif sudo apt-get install -y htpdate >/dev/null 2>&1; then
+            MG_HTPDATE_BIN=$(command -v htpdate || echo /usr/sbin/htpdate)
+            sudo tee /etc/systemd/system/moongate-timesync.service >/dev/null <<UNIT
+[Unit]
+Description=Moongate HTTPS time sync (htpdate) — for networks where NTP is blocked
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$MG_HTPDATE_BIN -s www.cloudflare.com www.google.com www.microsoft.com
+UNIT
+            sudo tee /etc/systemd/system/moongate-timesync.timer >/dev/null <<UNIT
+[Unit]
+Description=Keep the clock synced over HTTPS for Moongate remote auth
+
+[Timer]
+OnBootSec=45
+OnUnitActiveSec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+UNIT
+            sudo systemctl daemon-reload >/dev/null 2>&1 || true
+            sudo systemctl enable --now moongate-timesync.timer >/dev/null 2>&1 || true
+            sudo systemctl start moongate-timesync.service >/dev/null 2>&1 || true
+            success "htpdate installed + timer enabled — clock stays synced over HTTPS (NTP is blocked here)."
+        else
+            warn "Couldn't install htpdate. Open outbound UDP/123 (NTP) on your router, or"
+            warn "re-sync after each reboot with the 'sudo date -s' command above."
+        fi
+    fi
+fi
+
 ARCH=$(uname -m)
 
 # Pick the cloudflared deb that matches the dpkg system architecture.

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -40,6 +40,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -55,7 +56,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running — the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.5"
+MOONGATE_PLUGIN_VERSION = "0.6.6"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -426,6 +427,11 @@ class SupabaseClient:
     def __init__(self, url: str, anon_key: str) -> None:
         self.url      = url.rstrip("/")
         self.anon_key = anon_key
+        # Clock delta (local − server) in seconds, taken from the most recent
+        # response's Date header. Lets a 401 be explained as clock drift — the
+        # usual cause of "everything's running but remote never connects" — rather
+        # than a bald "signature or replay window failure". None until first seen.
+        self._server_skew: Optional[float] = None
 
     def _post(self, path: str, body: dict, timeout: float = 10.0) -> tuple[int, dict]:
         full_url = f"{self.url}/functions/v1{path}"
@@ -436,9 +442,11 @@ class SupabaseClient:
         )
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
+                self._note_server_date(resp.headers)
                 raw = resp.read().decode() if resp.length != 0 else ""
                 return resp.status, (json.loads(raw) if raw else {})
         except urllib.error.HTTPError as exc:
+            self._note_server_date(exc.headers)
             try:
                 body_dict = json.loads(exc.read().decode())
             except Exception:
@@ -447,6 +455,24 @@ class SupabaseClient:
         except Exception as exc:
             logger.warning("Supabase request %s failed: %s", path, exc)
             return 0, {"error": str(exc)}
+
+    def _note_server_date(self, headers: Any) -> None:
+        """Record clock skew (local − server, seconds) from a response's Date
+        header. Cheap and side-channel — every Edge Function response carries one,
+        so a later 401 can be attributed to a wrong Pi clock with no extra call."""
+        try:
+            date_hdr = headers.get("Date") if headers is not None else None
+            if not date_hdr:
+                return
+            server_epoch = parsedate_to_datetime(date_hdr).timestamp()
+        except (TypeError, ValueError, AttributeError):
+            return
+        self._server_skew = time.time() - server_epoch
+
+    def clock_skew_seconds(self) -> Optional[float]:
+        """Most recent (local − server) clock delta in seconds, or None if no
+        response has carried a parseable Date header yet."""
+        return self._server_skew
 
     def enroll_prepare(self, pi_public_key_b64: str, token_hash_b64: str) -> tuple[int, dict]:
         return self._post("/enroll-prepare", {
@@ -594,7 +620,17 @@ class HeartbeatLoop:
                     logger.warning("on_unpaired callback failed: %s", exc)
             return
         if status == 401:
-            logger.warning("Heartbeat 401 — signature or replay window failure")
+            skew = self.sb.clock_skew_seconds()
+            if skew is not None and abs(skew) > 60:
+                logger.warning(
+                    "Heartbeat 401: Pi clock is ~%+ds vs server time (limit ±60s) — "
+                    "remote access will keep failing until the clock is synced. A Pi "
+                    "has no battery clock; if NTP is blocked, sync over HTTPS (htpdate). "
+                    "Check with: timedatectl",
+                    int(skew),
+                )
+            else:
+                logger.warning("Heartbeat 401 — signature or replay window failure")
             return
         logger.warning("Heartbeat HTTP %s: %s", status, body)
 

--- a/klipper-plugin/uninstall.sh
+++ b/klipper-plugin/uninstall.sh
@@ -35,6 +35,7 @@ echo "This will remove:"
 echo "  • moongate-tunnel systemd service (cloudflared tunnel)"
 echo "  • cloudflared itself — binary + cache (unless another service uses it)"
 echo "  • moongate-authproxy systemd service (v0.4 auth proxy)"
+echo "  • moongate-timesync service/timer (HTTPS clock sync, if installed)"
 echo "  • Moongate Moonraker plugin"
 echo "  • ~/moongate repository clone"
 echo "  • ~/.config/moongate (tokens + secret key + v0.4 backup dir)"
@@ -119,6 +120,22 @@ if [[ -f /etc/systemd/system/moongate-authproxy.service ]]; then
 fi
 
 sudo rm -f /run/moongate-authproxy.log
+
+# ── 1b-time. Remove the HTTPS time-sync timer/service (if this install added it) ─
+# Only present on Pis where NTP was blocked and install.sh fell back to htpdate.
+# The htpdate package is left installed (harmless); note how to drop it.
+info "Removing moongate-timesync (HTTPS clock sync)..."
+if systemctl is-active --quiet moongate-timesync.timer 2>/dev/null; then
+    sudo systemctl stop moongate-timesync.timer
+fi
+if systemctl is-enabled --quiet moongate-timesync.timer 2>/dev/null; then
+    sudo systemctl disable moongate-timesync.timer
+fi
+if [[ -f /etc/systemd/system/moongate-timesync.timer || -f /etc/systemd/system/moongate-timesync.service ]]; then
+    sudo rm -f /etc/systemd/system/moongate-timesync.timer /etc/systemd/system/moongate-timesync.service
+    sudo systemctl daemon-reload
+    success "moongate-timesync removed (htpdate left installed; drop it with: sudo apt-get remove htpdate)"
+fi
 
 # ── 1c. Restore v0.4 backups BEFORE wiping ~/.config/moongate ────────────────
 # Order matters: the backup dir lives inside ~/.config/moongate which step 4


### PR DESCRIPTION
## Summary

A Raspberry Pi has **no RTC**, so when **NTP (UDP/123) is blocked** — common on locked-down networks — its clock silently drifts. The cloud then rejects every Pi-signed heartbeat as outside its **60-second replay window** (`printer-heartbeat` → 401), the printer never reports a tunnel, and **all remote access silently fails while everything else looks fine**. The only signal is a cryptic `Heartbeat 401 — signature or replay window failure` buried in `moonraker.log` — a real field case took an entire debugging session to trace back to "the Pi's clock is wrong."

This makes Moongate resilient to that, at both install time and runtime.

## Changes

**`install.sh` — catch it up front (the common case)**
- Measures **real** clock skew against an **HTTPS `Date` header** (the same path the Pi already uses to reach Supabase), not `timedatectl` — which cheerfully reports an *active-but-never-synced* client as fine.
- If off by >30s (the server's hard cutoff is 60), corrects the clock immediately; and **when NTP can't sync, installs `htpdate` + a 30-min systemd timer** so it can't drift back after a reboot.
- Runs **before** the apt/cloudflared steps, so a badly-wrong clock can't break *their* TLS validation either (uses `curl -k` for the probe — we're reading a timestamp, not trusting a secret).
- Fully non-fatal: any failure warns and continues.
- `uninstall.sh` tears the timer/service back down.

**`moongate_standalone.py` — explain it if it drifts later (runtime)**
- Captures the server's `Date` header from **every** Edge Function response (side-channel in `_post`, no extra request) into a `clock_skew_seconds()` value.
- On a heartbeat 401, logs the **actual skew with remediation** —
  `Heartbeat 401: Pi clock is ~+182s vs server time (limit ±60s) — remote access will keep failing until the clock is synced … sync over HTTPS (htpdate). Check with: timedatectl`
  — instead of the opaque `signature or replay window failure`.
- Bumps `MOONGATE_PLUGIN_VERSION` 0.6.5 → 0.6.6.

## Why this layering
The installer fixes the clock at setup (when it's usually first wrong); the plugin message catches **drift that happens later** (the installer only runs once, and a no-RTC Pi goes wrong again on the next reboot if NTP stays blocked). Together they turn a silent, hours-to-diagnose failure into either an automatic fix or a one-line "your clock is off."

## Test plan
- **Automated:** `bash -n` clean on `install.sh` + `uninstall.sh`; `python -m py_compile` + `ruff check` clean on the plugin.
- **Live-tested the detection core** against `https://www.cloudflare.com`: the `Date`-header parse → epoch → skew math returns 0s on a correctly-set clock.
- **Manual on a Pi (recommended, not run here):** with the clock deliberately set wrong + NTP blocked, run `install.sh` → it corrects the clock, installs the htpdate timer, and the printer comes online; with NTP working it prints "Clock is accurate" and adds nothing.

## Merge note
Pi-side only (no APK impact) — per the non-release convention, **quiet-merge with `[skip ci]`** so it doesn't rebuild/clobber the published v0.6.5 APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
