### PR TITLE
fix: correct broken changelog + doc links

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -91,7 +91,7 @@ jobs:
             echo "Creating Release $TAG"
             gh release create "$TAG" "$ASSET" \
               --title "Moongate v${VERSION}" \
-              --notes "See the [changelog](https://github.com/${GITHUB_REPOSITORY}/blob/master/README.md#changelog) for what's in this release.
+              --notes "See the [changelog](https://github.com/${GITHUB_REPOSITORY}/blob/master/CHANGELOG.md) for what's in this release.
 
           **APK is signed with the project release key — installs cleanly over any previous CI build.**" \
               --latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -315,4 +315,4 @@ In-app, users running an older version will see the update banner appear within 
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — how the pieces fit together, data flow diagrams, key design decisions
 - [SECURITY.md](SECURITY.md) — auth, transport, threat model, audit references
-- [docs/setup-guide.md](docs/setup-guide.md) — end-user setup walkthrough (the friendlier version of [README.md](README.md#setup))
+- [docs/setup-guide.md](docs/setup-guide.md) — end-user setup walkthrough (the friendlier version of [README.md](README.md#quick-start))


### PR DESCRIPTION
## Fix broken changelog / doc links

A repo-wide internal-link + anchor audit turned up two broken links:

1. **Release notes → `README.md#changelog`** (`.github/workflows/build-android.yml`): every GitHub Release's auto-generated notes linked to a `#changelog` anchor that doesn't exist — the changelog lives in `CHANGELOG.md`. This is the broken "changelog" link on the release pages. Now points to `CHANGELOG.md`; takes effect for all future releases.
2. **`DEVELOPMENT.md` → `README.md#setup`**: that anchor doesn't exist; the README section is `#quick-start`.

Everything else (README TOC, the Documentation table, `ARCHITECTURE.md → README#how-it-works`, all doc cross-links) resolves correctly.

**Docs / CI-config only — please merge with `[skip ci]`** in the merge-commit subject so it doesn't trigger a redundant APK rebuild. The already-published v0.8.0–v0.8.2 release notes are being corrected separately via `gh release edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
