### PR TITLE
fix(plugin): re-pair connects in seconds, not minutes (plugin 0.6.7)

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -63,7 +63,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running — the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.6"
+MOONGATE_PLUGIN_VERSION = "0.6.7"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -620,6 +620,13 @@ class HeartbeatLoop:
             return
         if status == 404:
             logger.warning("Heartbeat 404 — printer record gone server-side")
+            # The cloud row we knew is gone — typically a re-pair / reset-owner
+            # has created a NEW row. Drop back to the fast bootstrap cadence so
+            # we report our tunnel URL into that new row within ~5 s, instead of
+            # waiting up to a full heartbeat interval (5 min) for the next tick.
+            # Without this, re-pairing on a network that blocks mDNS left the
+            # tile "Starting up…" for minutes while the app waited on the tunnel.
+            self._last_url_reported = None
             if self.on_unpaired:
                 try:
                     self.on_unpaired()


### PR DESCRIPTION
**Re-pairing was slow.** On a network where the app can't reach the Pi over mDNS, re-pairing a printer (reinstall, new phone, `MOONGATE_RESET_OWNER`) could leave the dashboard tile on *Starting up…* for **minutes**.

**Cause:** the Pi's heartbeat loop uses a fast 5 s "bootstrap" cadence only until its *first* successful tunnel-URL report, then locks to the 300 s (5 min) interval — and never resets. A re-pair creates a **new** cloud row; the old row 404s, but the loop stayed at 5 min, so the new row could wait up to a full interval before its tunnel URL was reported. With no LAN/mDNS path to reach the Pi sooner, the app sat waiting.

**Fix:** reset `_last_url_reported = None` on a 404, so the loop drops back to the 5 s bootstrap cadence and reports into the new row within ~5 s — making a re-pair as fast as a first pair. (First pairs were already fast: a never-paired Pi is in bootstrap from boot. This just extends that to re-pairs — consistent behaviour, no new risk.)

Plugin-only change, **0.6.6 → 0.6.7**. Pis pick it up via **Mainsail → Software Updates → Moongate** (or re-running `install.sh`). No app change; the `pubspec` version is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)