### PR TITLE
ci: move GitHub Actions to Node 24 (off deprecated Node 20)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -14,12 +14,12 @@ jobs:
       contents: write   # needed to push the manifest + publish the Release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -166,7 +166,7 @@ jobs:
           fi
 
       - name: Upload APK as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Moongate-release
           path: Moongate-v${{ steps.meta.outputs.version }}.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: mobile
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
GitHub **force-migrates Node-20 actions to Node 24 on 2026-06-16** (Node 20 removed 2026-09-16). This bumps the three flagged actions to their node24 majors:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 (node20) | **v6** (node24) |
| `actions/setup-java` | v4 (node20) | **v5** (node24) |
| `actions/upload-artifact` | v4 (node20) | **v7** (node24) |

Versions were verified by reading each action's `action.yml` `using:` runtime — note `upload-artifact@v5` and `@v6` are **still node20**, so v7 is the correct target. `subosito/flutter-action@v2` and `actions/setup-python@v5` weren't in the deprecation warnings and are left alone.

CI on this PR runs the workflows with the bumped versions, so a green check confirms compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)