### PR TITLE
Add external network cameras (custom URL + auto-detect; LAN + tunnel)

### DIFF
--- a/klipper-plugin/moongate_authproxy.py
+++ b/klipper-plugin/moongate_authproxy.py
@@ -37,11 +37,13 @@ Or as a systemd service — see moongate-authproxy.service.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import os
 import sys
 from pathlib import Path
 from typing import Optional, Tuple
+from urllib.parse import urlsplit
 
 from aiohttp import ClientSession, ClientTimeout, WSMsgType, web
 
@@ -81,6 +83,14 @@ MOONRAKER_PATH_PREFIXES: Tuple[str, ...] = (
     "/api",
     "/websocket",
 )
+
+# v0.9.0: external-camera relay. A request to this exact path forwards a
+# snapshot / MJPEG-stream GET to a caller-supplied LAN camera URL (?u=...) —
+# e.g. an old phone running an IP-webcam app that Klipper can't see. Owner-
+# token gated like every other path; the target is SSRF-checked (literal
+# private IPv4 only) by _extcam_target_ok before any connection is opened.
+EXTCAM_PATH = "/mg-extcam"
+EXTCAM_MAX_BYTES = 16 * 1024 * 1024
 
 # RFC 7230 hop-by-hop headers — never forwarded.
 HOP_BY_HOP_HEADERS = frozenset({
@@ -315,6 +325,101 @@ async def _proxy_http(
         return web.Response(status=502, text="bad gateway\n")
 
 
+# ─── External-camera relay ──────────────────────────────────────────────────
+
+
+def _extcam_target_ok(raw: str) -> Optional[str]:
+    """Validate a client-supplied external-camera URL before the proxy will
+    fetch it. Returns the URL to forward to, or None if it fails the SSRF
+    allow-list.
+
+    Only plain http to a LITERAL private IPv4 is allowed — that's a camera on
+    the local network (a phone webcam, an IP cam). Everything that could turn
+    this relay into a weapon is refused:
+      • non-http schemes (file://, gopher://, …)
+      • hostnames (no DNS lookup at all → no DNS-rebinding window)
+      • loopback 127/8        → can't pivot to Moonraker / this proxy
+      • link-local 169.254/16 → can't reach cloud metadata (169.254.169.254)
+      • public / CGNAT / multicast / reserved / unspecified
+    """
+    if not raw:
+        return None
+    try:
+        parts = urlsplit(raw)
+    except ValueError:
+        return None
+    if parts.scheme != "http":
+        return None
+    host = parts.hostname
+    if not host:
+        return None
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return None  # not a bare IP literal → reject
+    if ip.version != 4 or not ip.is_private:
+        return None
+    if (ip.is_loopback or ip.is_link_local or ip.is_multicast
+            or ip.is_reserved or ip.is_unspecified):
+        return None
+    return raw
+
+
+async def _proxy_extcam(request: web.Request) -> web.StreamResponse:
+    """Relay a snapshot / MJPEG frame from a LAN camera the client points us
+    at. Auth was already enforced by _authorize. The app reads one frame then
+    disconnects; the byte cap is a backstop against a target that streams
+    forever, and the content-type gate stops us relaying arbitrary content
+    from whatever happens to answer on that host:port."""
+    target = _extcam_target_ok(request.query.get("u", ""))
+    if target is None:
+        return web.Response(status=400, text="bad target\n",
+                            headers={"Cache-Control": "no-store"})
+
+    client: ClientSession = request.app["client"]
+    headers = {
+        "User-Agent": "moongate-extcam",
+        "Accept": "image/jpeg, image/*, multipart/x-mixed-replace, */*",
+    }
+    try:
+        async with client.request(
+            "GET", target, headers=headers, allow_redirects=False,
+        ) as upstream:
+            if upstream.status != 200:
+                return web.Response(status=502, text="camera error\n")
+            ctype = upstream.headers.get("Content-Type", "")
+            low = ctype.lower()
+            if not (low.startswith("image/")
+                    or "multipart/x-mixed-replace" in low
+                    or low.startswith("application/octet-stream")):
+                return web.Response(status=415, text="unsupported\n")
+
+            response = web.StreamResponse(
+                status=200,
+                headers={
+                    "Content-Type": ctype or "application/octet-stream",
+                    "Cache-Control": "no-store",
+                },
+            )
+            await response.prepare(request)
+            sent = 0
+            async for chunk in upstream.content.iter_chunked(64 * 1024):
+                await response.write(chunk)
+                sent += len(chunk)
+                if sent >= EXTCAM_MAX_BYTES:
+                    break
+            await response.write_eof()
+            return response
+    except asyncio.CancelledError:
+        raise
+    except (ConnectionResetError, ConnectionAbortedError):
+        # App got its frame and closed the connection — normal.
+        return web.Response(status=499, text="")
+    except Exception as exc:
+        logger.warning("extcam %s failed: %s", target, exc)
+        return web.Response(status=502, text="camera unreachable\n")
+
+
 # ─── WebSocket proxy ────────────────────────────────────────────────────────
 
 # Per-direction frame buffer between the reader and writer halves of
@@ -492,6 +597,9 @@ async def handle(request: web.Request) -> web.StreamResponse:
     deny = await _authorize(request)
     if deny is not None:
         return deny
+
+    if request.path == EXTCAM_PATH:
+        return await _proxy_extcam(request)
 
     backend = _backend_for(request.path)
 

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -63,7 +63,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running — the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.7"
+MOONGATE_PLUGIN_VERSION = "0.6.8"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1183,6 +1183,12 @@ class MoongatePlugin:
         result["webcam_flip_vertical"]   = webcam["flip_vertical"]
         result["webcam_rotation"]        = webcam["rotation"]
         result["webcam_target_fps"]      = webcam["target_fps"]
+        # Absolute URL of a camera that lives on another device on the LAN
+        # (e.g. an old phone used as a webcam), read from Mainsail's webcam
+        # config; None for the normal Pi-served camera. The app auto-uses it
+        # — directly on LAN, or through the /mg-extcam proxy when remote.
+        result["webcam_stream_external"]   = webcam["stream_external"]
+        result["webcam_snapshot_external"] = webcam["snapshot_external"]
         return result
 
     async def _handle_control(self, webrequest: Any) -> dict:
@@ -1242,12 +1248,31 @@ class MoongatePlugin:
         _default_path = "/webcam/?action=snapshot"
         _default_fps  = 15
         _defaults = {
-            "snapshot_path":   _default_path,
-            "flip_horizontal": False,
-            "flip_vertical":   False,
-            "rotation":        0,
-            "target_fps":      _default_fps,
+            "snapshot_path":     _default_path,
+            "flip_horizontal":   False,
+            "flip_vertical":     False,
+            "rotation":          0,
+            "target_fps":        _default_fps,
+            "stream_external":   None,
+            "snapshot_external": None,
         }
+
+        def _ext(raw: Any) -> Optional[str]:
+            # An absolute http(s) URL whose host is some OTHER device on the
+            # network (not localhost / 127.x) — i.e. a camera Moonraker can't
+            # snapshot for us, e.g. an old phone running an IP-webcam app and
+            # configured in Mainsail as a stream_url like
+            # http://192.168.0.107:8080/video. Returns the URL, else None. The
+            # app uses it directly on LAN, or via the /mg-extcam proxy remote.
+            s = (raw or "").strip()
+            m = re.match(r"^https?://([^/:]+)", s, re.IGNORECASE)
+            if not m:
+                return None
+            host = m.group(1).lower()
+            if host == "localhost" or host.startswith("127."):
+                return None
+            return s
+
         try:
             req = HTTPRequest(
                 "http://127.0.0.1:7125/server/webcams/list",
@@ -1260,11 +1285,25 @@ class MoongatePlugin:
             webcams = data.get("result", {}).get("webcams", [])
             if not webcams:
                 return _defaults
-            cam  = webcams[0]
-            snap = (cam.get("snapshot_url") or "").strip()
-            if not snap:
-                return _defaults
-            snap = re.sub(r"^https?://(localhost|127\.0\.0\.1)(:\d+)?", "", snap)
+            cam = webcams[0]
+
+            stream_external   = _ext(cam.get("stream_url"))
+            snapshot_external = _ext(cam.get("snapshot_url"))
+
+            # Relative Pi-served snapshot path for the normal (Crowsnest /
+            # uv4l) case. An absolute EXTERNAL snapshot_url must NOT leak into
+            # snapshot_path — the app would build tunnel_base + absolute_url
+            # and get garbage — so fall back to the default and surface the
+            # external URL separately via snapshot_external instead.
+            snap_raw = (cam.get("snapshot_url") or "").strip()
+            if snapshot_external:
+                snap = _default_path
+            elif snap_raw:
+                snap = re.sub(
+                    r"^https?://(localhost|127\.0\.0\.1)(:\d+)?", "", snap_raw)
+            else:
+                snap = _default_path
+
             raw_fps = cam.get("target_fps", _default_fps)
             try:
                 tgt_fps = int(raw_fps)
@@ -1273,11 +1312,13 @@ class MoongatePlugin:
             except (TypeError, ValueError):
                 tgt_fps = _default_fps
             return {
-                "snapshot_path":   snap or _default_path,
-                "flip_horizontal": bool(cam.get("flip_horizontal", False)),
-                "flip_vertical":   bool(cam.get("flip_vertical",   False)),
-                "rotation":        int(cam.get("rotation", 0)),
-                "target_fps":      tgt_fps,
+                "snapshot_path":     snap or _default_path,
+                "flip_horizontal":   bool(cam.get("flip_horizontal", False)),
+                "flip_vertical":     bool(cam.get("flip_vertical",   False)),
+                "rotation":          int(cam.get("rotation", 0)),
+                "target_fps":        tgt_fps,
+                "stream_external":   stream_external,
+                "snapshot_external": snapshot_external,
             }
         except Exception:
             return _defaults

--- a/mobile/lib/features/dashboard/dashboard_screen.dart
+++ b/mobile/lib/features/dashboard/dashboard_screen.dart
@@ -233,6 +233,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     final gridColumns   = ref.watch(gridColumnsProvider);
     final allowRotation = ref.watch(allowRotationProvider);
     final cameraRefresh = ref.watch(dashboardCameraRefreshProvider);
+    final showCameraIcons = ref.watch(showCameraConfigIconsProvider);
     final printNotifications = ref.watch(printNotificationsEnabledProvider);
     final pollInterval = ref.watch(notifPollIntervalProvider);
 
@@ -497,6 +498,17 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                             .read(dashboardCameraRefreshProvider.notifier)
                             .set(s.first),
                       ),
+                    ),
+                    // Show / hide the per-tile camera config gear.
+                    SwitchListTile(
+                      dense: true,
+                      secondary: const Icon(Icons.videocam_outlined),
+                      title: Text(l.dashboardShowCameraIcons),
+                      subtitle: Text(l.dashboardShowCameraIconsSubtitle),
+                      value: showCameraIcons,
+                      onChanged: (v) => ref
+                          .read(showCameraConfigIconsProvider.notifier)
+                          .set(v),
                     ),
 
                     const Divider(),
@@ -775,6 +787,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     await ref.read(gridColumnsProvider.notifier).load();
     await ref.read(allowRotationProvider.notifier).load();
     await ref.read(dashboardCameraRefreshProvider.notifier).load();
+    await ref.read(showCameraConfigIconsProvider.notifier).load();
     await ref.read(printNotificationsEnabledProvider.notifier).load();
     await PrintNotificationService.instance
         .sync(ref.read(printNotificationsEnabledProvider));

--- a/mobile/lib/features/dashboard/printer_tile.dart
+++ b/mobile/lib/features/dashboard/printer_tile.dart
@@ -11,6 +11,7 @@ import '../../l10n/app_localizations.dart';
 import '../../models/printer_config.dart';
 import '../../providers/settings_provider.dart';
 import '../../services/print_control_service.dart';
+import '../../services/printer_registry.dart';
 import '../../services/printer_status_registry.dart';
 import '../../services/printer_status_service.dart';
 import 'gcode_files_overlay.dart';
@@ -200,6 +201,7 @@ class _PrinterTileState extends State<PrinterTile> with WidgetsBindingObserver {
                     webcamFlipV:     _status.webcamFlipV,
                     webcamRotation:  _status.webcamRotation,
                     webcamTargetFps: _status.webcamTargetFps,
+                    webcamIsExternal: _status.webcamIsExternal,
                     uiType: _uiType,
                   ),
                   // Overlay shown while we don't yet have a usable
@@ -220,6 +222,18 @@ class _PrinterTileState extends State<PrinterTile> with WidgetsBindingObserver {
                       left: 8,
                       child: _StatusBadge(status: _status),
                     ),
+                  // Camera config gear (top-right). Lets the user point this
+                  // tile at an external camera (e.g. a phone webcam). The
+                  // button watches the "show camera icons" setting and renders
+                  // nothing when it's off, so it never overlaps the feed.
+                  Positioned(
+                    top: 6,
+                    right: 6,
+                    child: _CameraConfigButton(
+                      printer: widget.printer,
+                      onApplied: _statusService.pollNow,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -568,6 +582,10 @@ class _WebcamSnapshot extends ConsumerStatefulWidget {
   /// rate; the actual rate is bounded below by whatever the server can
   /// sustain (the fetch loop is strictly sequential).
   final int               webcamTargetFps;
+  /// True when the snapshot URL is an external camera (custom or auto-detected)
+  /// — the fetch loop then pulls a single frame from a (possibly MJPEG-stream)
+  /// source instead of doing a plain snapshot GET.
+  final bool              webcamIsExternal;
   /// 'mainsail' | 'fluidd' | null — shown as logo when no snapshot yet.
   final String?           uiType;
 
@@ -577,6 +595,7 @@ class _WebcamSnapshot extends ConsumerStatefulWidget {
     this.webcamFlipV     = false,
     this.webcamRotation  = 0,
     this.webcamTargetFps = 15,
+    this.webcamIsExternal = false,
     this.uiType,
   });
 
@@ -666,6 +685,13 @@ class _WebcamSnapshotState extends ConsumerState<_WebcamSnapshot>
   Future<void> _fetchOnce() async {
     final url = widget.webcamSnapshotUrl;
     if (url == null || url.isEmpty) return;
+    // External cameras (custom or auto-detected) usually expose an MJPEG
+    // stream, not a snapshot — a plain GET on `.../video` would never return.
+    // Pull a single frame from the (possibly multipart) response instead.
+    if (widget.webcamIsExternal) {
+      await _fetchFrameFromStream(url);
+      return;
+    }
     try {
       // 8 s timeout. Generous because uv4l-mjpeg has been observed to
       // take 3 s+ per snapshot on first wake. We'd rather block the
@@ -682,6 +708,68 @@ class _WebcamSnapshotState extends ConsumerState<_WebcamSnapshot>
       // Network blip / 401 / timeout / parse error. No state change —
       // the previous frame stays on screen.
     }
+  }
+
+  /// Pull ONE frame from an external camera URL and display it. Handles both a
+  /// plain snapshot (Content-Type image/*) and an MJPEG stream
+  /// (multipart/x-mixed-replace) — for a stream we read until the first
+  /// complete JPEG, then close the connection so we don't hold it open. Used
+  /// for custom / auto-detected external cameras (LAN-direct, or the Pi's
+  /// /mg-extcam proxy when remote).
+  Future<void> _fetchFrameFromStream(String url) async {
+    final client = http.Client();
+    try {
+      final req = http.Request('GET', Uri.parse(url));
+      final resp = await client.send(req).timeout(const Duration(seconds: 8));
+      if (resp.statusCode != 200) return;
+      final ctype = (resp.headers['content-type'] ?? '').toLowerCase();
+      final isMultipart = ctype.contains('multipart');
+      final buffer = BytesBuilder();
+      const maxBytes = 8 * 1024 * 1024; // safety cap
+      await for (final chunk
+          in resp.stream.timeout(const Duration(seconds: 8))) {
+        buffer.add(chunk);
+        if (isMultipart) {
+          final frame = _extractJpeg(buffer.toBytes());
+          if (frame != null) {
+            if (mounted) setState(() => _currentBytes = frame);
+            return; // got a frame — finally closes the still-open stream
+          }
+        }
+        if (buffer.length > maxBytes) break;
+      }
+      // Non-multipart snapshot (or a multipart that ended without a clean
+      // frame): use whatever bytes we collected if they look usable.
+      if (!isMultipart) {
+        final bytes = buffer.toBytes();
+        if (bytes.isNotEmpty && mounted) {
+          setState(() => _currentBytes = bytes);
+        }
+      }
+    } catch (_) {
+      // Blip / timeout — keep the last frame on screen.
+    } finally {
+      client.close(); // aborts an MJPEG stream still in flight
+    }
+  }
+
+  /// Find the first complete JPEG (SOI ff d8 … EOI ff d9) in [d], or null if
+  /// one isn't present yet. Carves a single frame out of an MJPEG stream.
+  static Uint8List? _extractJpeg(Uint8List d) {
+    int start = -1;
+    for (int i = 0; i + 1 < d.length; i++) {
+      if (d[i] == 0xFF && d[i + 1] == 0xD8) {
+        start = i;
+        break;
+      }
+    }
+    if (start < 0) return null;
+    for (int i = start + 2; i + 1 < d.length; i++) {
+      if (d[i] == 0xFF && d[i + 1] == 0xD9) {
+        return Uint8List.sublistView(d, start, i + 2);
+      }
+    }
+    return null;
   }
 
   @override
@@ -988,4 +1076,144 @@ class _TempChip extends StatelessWidget {
       ],
     );
   }
+}
+
+// ── Camera config button + dialog ─────────────────────────────────────────────
+//
+// A small, semi-transparent gear in the corner of the webcam. Tapping it lets
+// the user point this tile at a camera that isn't connected to Klipper — e.g.
+// an old phone running an IP-webcam app. Watches the "show camera icons"
+// setting and renders nothing when it's off, so it never overlaps the feed.
+
+class _CameraConfigButton extends ConsumerWidget {
+  final PrinterConfig printer;
+  final VoidCallback onApplied;
+
+  const _CameraConfigButton({required this.printer, required this.onApplied});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(showCameraConfigIconsProvider)) {
+      return const SizedBox.shrink();
+    }
+    final l = AppLocalizations.of(context);
+    return Tooltip(
+      message: l.cameraConfigTooltip,
+      child: Material(
+        color: Colors.black.withValues(alpha: 0.35),
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: () async {
+            final changed = await showCameraConfigDialog(context, printer);
+            if (changed == true) onApplied();
+          },
+          child: Padding(
+            padding: const EdgeInsets.all(5),
+            child: Icon(
+              Icons.settings,
+              size: 17,
+              color: Colors.white.withValues(alpha: 0.85),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Edit dialog for a tile's custom camera URL. Returns true if the URL was
+/// changed (set or cleared), false/null if the user cancelled. Persists the
+/// change to [PrinterRegistry]; the caller pokes the status service to refresh.
+Future<bool?> showCameraConfigDialog(
+    BuildContext context, PrinterConfig printer) {
+  final controller = TextEditingController(text: printer.customCameraUrl ?? '');
+  return showDialog<bool>(
+    context: context,
+    builder: (context) {
+      final l = AppLocalizations.of(context);
+      String? error;
+      return StatefulBuilder(
+        builder: (context, setState) {
+          Future<void> apply() async {
+            final raw = controller.text.trim();
+            if (raw.isEmpty) {
+              // Empty = clear the override (fall back to the Klipper camera).
+              await PrinterRegistry.instance
+                  .updateCustomCameraUrl(printer.id, null);
+              if (context.mounted) Navigator.pop(context, true);
+              return;
+            }
+            final uri = Uri.tryParse(raw);
+            final ok = uri != null &&
+                (uri.scheme == 'http' || uri.scheme == 'https') &&
+                uri.host.isNotEmpty;
+            if (!ok) {
+              setState(() => error = l.cameraConfigInvalid);
+              return;
+            }
+            await PrinterRegistry.instance
+                .updateCustomCameraUrl(printer.id, raw);
+            if (context.mounted) Navigator.pop(context, true);
+          }
+
+          return AlertDialog(
+            title: Text(l.cameraConfigTitle),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(l.cameraConfigDescription,
+                    style: Theme.of(context).textTheme.bodySmall),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: controller,
+                  autofocus: true,
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  decoration: InputDecoration(
+                    labelText: l.cameraConfigUrlLabel,
+                    hintText: 'http://192.168.0.107:8080/video',
+                    errorText: error,
+                    border: const OutlineInputBorder(),
+                  ),
+                  onChanged: (_) {
+                    if (error != null) setState(() => error = null);
+                  },
+                  onSubmitted: (_) => apply(),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  l.cameraConfigRemoteNote,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Theme.of(context).hintColor),
+                ),
+              ],
+            ),
+            actions: [
+              if ((printer.customCameraUrl ?? '').isNotEmpty)
+                TextButton(
+                  onPressed: () async {
+                    await PrinterRegistry.instance
+                        .updateCustomCameraUrl(printer.id, null);
+                    if (context.mounted) Navigator.pop(context, true);
+                  },
+                  child: Text(l.cameraConfigUseDefault),
+                ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: Text(l.commonCancel),
+              ),
+              FilledButton(
+                onPressed: apply,
+                child: Text(l.cameraConfigApply),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "de",
 
+  "cameraConfigTooltip": "Kamera-URL festlegen",
+  "cameraConfigTitle": "Eigene Kamera",
+  "cameraConfigDescription": "Zeige eine Kamera, die nicht mit Klipper verbunden ist – etwa ein altes Handy als Webcam. Gib die Adresse ein, die in den Webcam-Einstellungen von Mainsail steht.",
+  "cameraConfigUrlLabel": "Kamera-URL",
+  "cameraConfigRemoteNote": "Funktioniert im WLAN und aus der Ferne über deinen Drucker. Aus der Ferne sind nur Kameras in deinem Heimnetzwerk (private Adressen) erreichbar.",
+  "cameraConfigInvalid": "Gib eine vollständige Adresse ein, z. B. http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "Klipper-Kamera verwenden",
+  "cameraConfigApply": "Übernehmen",
+  "dashboardShowCameraIcons": "Kamera-Konfigsymbole",
+  "dashboardShowCameraIconsSubtitle": "Zahnrad auf jeder Kamera zum Festlegen einer eigenen URL anzeigen",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "Sprache auswählen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1,6 +1,27 @@
 {
   "@@locale": "en",
 
+  "cameraConfigTooltip": "Set camera URL",
+  "@cameraConfigTooltip": {"description": "Tooltip on the small gear shown in the corner of a dashboard tile's webcam."},
+  "cameraConfigTitle": "Custom camera",
+  "@cameraConfigTitle": {"description": "Title of the dialog for setting a tile's external camera URL."},
+  "cameraConfigDescription": "Show a camera that isn't connected to Klipper — like an old phone used as a webcam. Enter the address shown in Mainsail's webcam settings.",
+  "@cameraConfigDescription": {"description": "Explanatory text at the top of the custom-camera dialog."},
+  "cameraConfigUrlLabel": "Camera URL",
+  "@cameraConfigUrlLabel": {"description": "Label for the camera URL text field."},
+  "cameraConfigRemoteNote": "Works on Wi-Fi, and remotely through your printer. Only cameras on your home network (private addresses) can be reached remotely.",
+  "@cameraConfigRemoteNote": {"description": "Note under the URL field explaining LAN vs remote reachability."},
+  "cameraConfigInvalid": "Enter a full address, e.g. http://192.168.0.107:8080/video",
+  "@cameraConfigInvalid": {"description": "Validation error shown when the entered camera URL is not a valid http(s) address."},
+  "cameraConfigUseDefault": "Use Klipper camera",
+  "@cameraConfigUseDefault": {"description": "Button that clears the custom camera and reverts to the Klipper/Pi camera."},
+  "cameraConfigApply": "Apply",
+  "@cameraConfigApply": {"description": "Button that saves the entered custom camera URL."},
+  "dashboardShowCameraIcons": "Camera config icons",
+  "@dashboardShowCameraIcons": {"description": "Drawer toggle title for showing/hiding the per-tile camera gear."},
+  "dashboardShowCameraIconsSubtitle": "Show the gear on each camera for setting a custom URL",
+  "@dashboardShowCameraIconsSubtitle": {"description": "Subtitle under the camera-config-icons toggle."},
+
   "appTitle": "Moongate",
   "@appTitle": {"description": "The application name."},
 

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "es",
 
+  "cameraConfigTooltip": "Definir URL de la cámara",
+  "cameraConfigTitle": "Cámara personalizada",
+  "cameraConfigDescription": "Muestra una cámara que no está conectada a Klipper, como un teléfono antiguo usado como webcam. Introduce la dirección que aparece en los ajustes de webcam de Mainsail.",
+  "cameraConfigUrlLabel": "URL de la cámara",
+  "cameraConfigRemoteNote": "Funciona por Wi-Fi y de forma remota a través de tu impresora. De forma remota solo se pueden ver cámaras de tu red doméstica (direcciones privadas).",
+  "cameraConfigInvalid": "Introduce una dirección completa, p. ej. http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "Usar cámara de Klipper",
+  "cameraConfigApply": "Aplicar",
+  "dashboardShowCameraIcons": "Iconos de config. de cámara",
+  "dashboardShowCameraIconsSubtitle": "Mostrar el engranaje en cada cámara para definir una URL personalizada",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "Elige tu idioma",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "fr",
 
+  "cameraConfigTooltip": "Définir l'URL de la caméra",
+  "cameraConfigTitle": "Caméra personnalisée",
+  "cameraConfigDescription": "Affichez une caméra qui n'est pas connectée à Klipper — par exemple un ancien téléphone utilisé comme webcam. Saisissez l'adresse indiquée dans les paramètres webcam de Mainsail.",
+  "cameraConfigUrlLabel": "URL de la caméra",
+  "cameraConfigRemoteNote": "Fonctionne en Wi-Fi et à distance via votre imprimante. À distance, seules les caméras de votre réseau domestique (adresses privées) sont accessibles.",
+  "cameraConfigInvalid": "Saisissez une adresse complète, p. ex. http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "Utiliser la caméra Klipper",
+  "cameraConfigApply": "Appliquer",
+  "dashboardShowCameraIcons": "Icônes de config caméra",
+  "dashboardShowCameraIconsSubtitle": "Afficher l'engrenage sur chaque caméra pour définir une URL personnalisée",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "Choisissez votre langue",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "it",
 
+  "cameraConfigTooltip": "Imposta URL della telecamera",
+  "cameraConfigTitle": "Telecamera personalizzata",
+  "cameraConfigDescription": "Mostra una telecamera non collegata a Klipper, come un vecchio telefono usato come webcam. Inserisci l'indirizzo indicato nelle impostazioni webcam di Mainsail.",
+  "cameraConfigUrlLabel": "URL della telecamera",
+  "cameraConfigRemoteNote": "Funziona in Wi-Fi e da remoto tramite la stampante. Da remoto sono raggiungibili solo le telecamere della tua rete domestica (indirizzi privati).",
+  "cameraConfigInvalid": "Inserisci un indirizzo completo, es. http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "Usa la telecamera Klipper",
+  "cameraConfigApply": "Applica",
+  "dashboardShowCameraIcons": "Icone config. telecamera",
+  "dashboardShowCameraIconsSubtitle": "Mostra l'ingranaggio su ogni telecamera per impostare un URL personalizzato",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "Scegli la tua lingua",

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -110,6 +110,66 @@ abstract class AppLocalizations {
     Locale('zh')
   ];
 
+  /// Tooltip on the small gear shown in the corner of a dashboard tile's webcam.
+  ///
+  /// In en, this message translates to:
+  /// **'Set camera URL'**
+  String get cameraConfigTooltip;
+
+  /// Title of the dialog for setting a tile's external camera URL.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom camera'**
+  String get cameraConfigTitle;
+
+  /// Explanatory text at the top of the custom-camera dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Show a camera that isn\'t connected to Klipper — like an old phone used as a webcam. Enter the address shown in Mainsail\'s webcam settings.'**
+  String get cameraConfigDescription;
+
+  /// Label for the camera URL text field.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera URL'**
+  String get cameraConfigUrlLabel;
+
+  /// Note under the URL field explaining LAN vs remote reachability.
+  ///
+  /// In en, this message translates to:
+  /// **'Works on Wi-Fi, and remotely through your printer. Only cameras on your home network (private addresses) can be reached remotely.'**
+  String get cameraConfigRemoteNote;
+
+  /// Validation error shown when the entered camera URL is not a valid http(s) address.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a full address, e.g. http://192.168.0.107:8080/video'**
+  String get cameraConfigInvalid;
+
+  /// Button that clears the custom camera and reverts to the Klipper/Pi camera.
+  ///
+  /// In en, this message translates to:
+  /// **'Use Klipper camera'**
+  String get cameraConfigUseDefault;
+
+  /// Button that saves the entered custom camera URL.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get cameraConfigApply;
+
+  /// Drawer toggle title for showing/hiding the per-tile camera gear.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera config icons'**
+  String get dashboardShowCameraIcons;
+
+  /// Subtitle under the camera-config-icons toggle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show the gear on each camera for setting a custom URL'**
+  String get dashboardShowCameraIconsSubtitle;
+
   /// The application name.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/app_localizations_de.dart
+++ b/mobile/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,40 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Kamera-URL festlegen';
+
+  @override
+  String get cameraConfigTitle => 'Eigene Kamera';
+
+  @override
+  String get cameraConfigDescription =>
+      'Zeige eine Kamera, die nicht mit Klipper verbunden ist – etwa ein altes Handy als Webcam. Gib die Adresse ein, die in den Webcam-Einstellungen von Mainsail steht.';
+
+  @override
+  String get cameraConfigUrlLabel => 'Kamera-URL';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Funktioniert im WLAN und aus der Ferne über deinen Drucker. Aus der Ferne sind nur Kameras in deinem Heimnetzwerk (private Adressen) erreichbar.';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Gib eine vollständige Adresse ein, z. B. http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Klipper-Kamera verwenden';
+
+  @override
+  String get cameraConfigApply => 'Übernehmen';
+
+  @override
+  String get dashboardShowCameraIcons => 'Kamera-Konfigsymbole';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Zahnrad auf jeder Kamera zum Festlegen einer eigenen URL anzeigen';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,40 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Set camera URL';
+
+  @override
+  String get cameraConfigTitle => 'Custom camera';
+
+  @override
+  String get cameraConfigDescription =>
+      'Show a camera that isn\'t connected to Klipper — like an old phone used as a webcam. Enter the address shown in Mainsail\'s webcam settings.';
+
+  @override
+  String get cameraConfigUrlLabel => 'Camera URL';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Works on Wi-Fi, and remotely through your printer. Only cameras on your home network (private addresses) can be reached remotely.';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Enter a full address, e.g. http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Use Klipper camera';
+
+  @override
+  String get cameraConfigApply => 'Apply';
+
+  @override
+  String get dashboardShowCameraIcons => 'Camera config icons';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Show the gear on each camera for setting a custom URL';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_es.dart
+++ b/mobile/lib/l10n/app_localizations_es.dart
@@ -9,6 +9,40 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Definir URL de la cámara';
+
+  @override
+  String get cameraConfigTitle => 'Cámara personalizada';
+
+  @override
+  String get cameraConfigDescription =>
+      'Muestra una cámara que no está conectada a Klipper, como un teléfono antiguo usado como webcam. Introduce la dirección que aparece en los ajustes de webcam de Mainsail.';
+
+  @override
+  String get cameraConfigUrlLabel => 'URL de la cámara';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Funciona por Wi-Fi y de forma remota a través de tu impresora. De forma remota solo se pueden ver cámaras de tu red doméstica (direcciones privadas).';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Introduce una dirección completa, p. ej. http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Usar cámara de Klipper';
+
+  @override
+  String get cameraConfigApply => 'Aplicar';
+
+  @override
+  String get dashboardShowCameraIcons => 'Iconos de config. de cámara';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Mostrar el engranaje en cada cámara para definir una URL personalizada';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -9,6 +9,40 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Définir l\'URL de la caméra';
+
+  @override
+  String get cameraConfigTitle => 'Caméra personnalisée';
+
+  @override
+  String get cameraConfigDescription =>
+      'Affichez une caméra qui n\'est pas connectée à Klipper — par exemple un ancien téléphone utilisé comme webcam. Saisissez l\'adresse indiquée dans les paramètres webcam de Mainsail.';
+
+  @override
+  String get cameraConfigUrlLabel => 'URL de la caméra';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Fonctionne en Wi-Fi et à distance via votre imprimante. À distance, seules les caméras de votre réseau domestique (adresses privées) sont accessibles.';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Saisissez une adresse complète, p. ex. http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Utiliser la caméra Klipper';
+
+  @override
+  String get cameraConfigApply => 'Appliquer';
+
+  @override
+  String get dashboardShowCameraIcons => 'Icônes de config caméra';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Afficher l\'engrenage sur chaque caméra pour définir une URL personnalisée';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_it.dart
+++ b/mobile/lib/l10n/app_localizations_it.dart
@@ -9,6 +9,40 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Imposta URL della telecamera';
+
+  @override
+  String get cameraConfigTitle => 'Telecamera personalizzata';
+
+  @override
+  String get cameraConfigDescription =>
+      'Mostra una telecamera non collegata a Klipper, come un vecchio telefono usato come webcam. Inserisci l\'indirizzo indicato nelle impostazioni webcam di Mainsail.';
+
+  @override
+  String get cameraConfigUrlLabel => 'URL della telecamera';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Funziona in Wi-Fi e da remoto tramite la stampante. Da remoto sono raggiungibili solo le telecamere della tua rete domestica (indirizzi privati).';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Inserisci un indirizzo completo, es. http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Usa la telecamera Klipper';
+
+  @override
+  String get cameraConfigApply => 'Applica';
+
+  @override
+  String get dashboardShowCameraIcons => 'Icone config. telecamera';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Mostra l\'ingranaggio su ogni telecamera per impostare un URL personalizzato';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pl.dart
+++ b/mobile/lib/l10n/app_localizations_pl.dart
@@ -9,6 +9,40 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Ustaw adres URL kamery';
+
+  @override
+  String get cameraConfigTitle => 'Własna kamera';
+
+  @override
+  String get cameraConfigDescription =>
+      'Pokaż kamerę, która nie jest połączona z Klipperem — na przykład stary telefon używany jako kamera. Wpisz adres widoczny w ustawieniach kamery w Mainsail.';
+
+  @override
+  String get cameraConfigUrlLabel => 'Adres URL kamery';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Działa w sieci Wi-Fi oraz zdalnie przez drukarkę. Zdalnie dostępne są tylko kamery w sieci domowej (adresy prywatne).';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Wpisz pełny adres, np. http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Użyj kamery Klipper';
+
+  @override
+  String get cameraConfigApply => 'Zastosuj';
+
+  @override
+  String get dashboardShowCameraIcons => 'Ikony konfiguracji kamery';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Pokaż koło zębate na każdej kamerze do ustawienia własnego URL';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_ru.dart
+++ b/mobile/lib/l10n/app_localizations_ru.dart
@@ -9,6 +9,40 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => 'Указать URL камеры';
+
+  @override
+  String get cameraConfigTitle => 'Своя камера';
+
+  @override
+  String get cameraConfigDescription =>
+      'Показать камеру, не подключённую к Klipper, — например, старый телефон в роли веб-камеры. Введите адрес, указанный в настройках веб-камеры Mainsail.';
+
+  @override
+  String get cameraConfigUrlLabel => 'URL камеры';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      'Работает по Wi-Fi и удалённо через ваш принтер. Удалённо доступны только камеры в домашней сети (частные адреса).';
+
+  @override
+  String get cameraConfigInvalid =>
+      'Введите полный адрес, например http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => 'Камера Klipper';
+
+  @override
+  String get cameraConfigApply => 'Применить';
+
+  @override
+  String get dashboardShowCameraIcons => 'Значки настройки камеры';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle =>
+      'Показывать шестерёнку на каждой камере для своего URL';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_localizations_zh.dart
+++ b/mobile/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,39 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get cameraConfigTooltip => '设置摄像头网址';
+
+  @override
+  String get cameraConfigTitle => '自定义摄像头';
+
+  @override
+  String get cameraConfigDescription =>
+      '显示未连接到 Klipper 的摄像头，例如用作网络摄像头的旧手机。请输入 Mainsail 摄像头设置中显示的地址。';
+
+  @override
+  String get cameraConfigUrlLabel => '摄像头网址';
+
+  @override
+  String get cameraConfigRemoteNote =>
+      '可在 Wi-Fi 下使用，也可通过打印机远程访问。远程时只能访问家庭网络中的摄像头（专用地址）。';
+
+  @override
+  String get cameraConfigInvalid =>
+      '请输入完整地址，例如 http://192.168.0.107:8080/video';
+
+  @override
+  String get cameraConfigUseDefault => '使用 Klipper 摄像头';
+
+  @override
+  String get cameraConfigApply => '应用';
+
+  @override
+  String get dashboardShowCameraIcons => '摄像头配置图标';
+
+  @override
+  String get dashboardShowCameraIconsSubtitle => '在每个摄像头上显示齿轮以设置自定义网址';
+
+  @override
   String get appTitle => 'Moongate';
 
   @override

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "pl",
 
+  "cameraConfigTooltip": "Ustaw adres URL kamery",
+  "cameraConfigTitle": "Własna kamera",
+  "cameraConfigDescription": "Pokaż kamerę, która nie jest połączona z Klipperem — na przykład stary telefon używany jako kamera. Wpisz adres widoczny w ustawieniach kamery w Mainsail.",
+  "cameraConfigUrlLabel": "Adres URL kamery",
+  "cameraConfigRemoteNote": "Działa w sieci Wi-Fi oraz zdalnie przez drukarkę. Zdalnie dostępne są tylko kamery w sieci domowej (adresy prywatne).",
+  "cameraConfigInvalid": "Wpisz pełny adres, np. http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "Użyj kamery Klipper",
+  "cameraConfigApply": "Zastosuj",
+  "dashboardShowCameraIcons": "Ikony konfiguracji kamery",
+  "dashboardShowCameraIconsSubtitle": "Pokaż koło zębate na każdej kamerze do ustawienia własnego URL",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "Wybierz język",

--- a/mobile/lib/l10n/app_ru.arb
+++ b/mobile/lib/l10n/app_ru.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "ru",
 
+  "cameraConfigTooltip": "Указать URL камеры",
+  "cameraConfigTitle": "Своя камера",
+  "cameraConfigDescription": "Показать камеру, не подключённую к Klipper, — например, старый телефон в роли веб-камеры. Введите адрес, указанный в настройках веб-камеры Mainsail.",
+  "cameraConfigUrlLabel": "URL камеры",
+  "cameraConfigRemoteNote": "Работает по Wi-Fi и удалённо через ваш принтер. Удалённо доступны только камеры в домашней сети (частные адреса).",
+  "cameraConfigInvalid": "Введите полный адрес, например http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "Камера Klipper",
+  "cameraConfigApply": "Применить",
+  "dashboardShowCameraIcons": "Значки настройки камеры",
+  "dashboardShowCameraIconsSubtitle": "Показывать шестерёнку на каждой камере для своего URL",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "Выберите язык",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1,6 +1,17 @@
 {
   "@@locale": "zh",
 
+  "cameraConfigTooltip": "设置摄像头网址",
+  "cameraConfigTitle": "自定义摄像头",
+  "cameraConfigDescription": "显示未连接到 Klipper 的摄像头，例如用作网络摄像头的旧手机。请输入 Mainsail 摄像头设置中显示的地址。",
+  "cameraConfigUrlLabel": "摄像头网址",
+  "cameraConfigRemoteNote": "可在 Wi-Fi 下使用，也可通过打印机远程访问。远程时只能访问家庭网络中的摄像头（专用地址）。",
+  "cameraConfigInvalid": "请输入完整地址，例如 http://192.168.0.107:8080/video",
+  "cameraConfigUseDefault": "使用 Klipper 摄像头",
+  "cameraConfigApply": "应用",
+  "dashboardShowCameraIcons": "摄像头配置图标",
+  "dashboardShowCameraIconsSubtitle": "在每个摄像头上显示齿轮以设置自定义网址",
+
   "appTitle": "Moongate",
 
   "languagePickerTitle": "选择您的语言",

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -33,6 +33,7 @@ void main() async {
   await container.read(gridColumnsProvider.notifier).load();
   await container.read(allowRotationProvider.notifier).load();
   await container.read(dashboardCameraRefreshProvider.notifier).load();
+  await container.read(showCameraConfigIconsProvider.notifier).load();
   await container.read(appLockEnabledProvider.notifier).load();
   await container.read(biometricUnlockProvider.notifier).load();
   await container.read(autoLockTimeoutProvider.notifier).load();

--- a/mobile/lib/models/printer_config.dart
+++ b/mobile/lib/models/printer_config.dart
@@ -44,6 +44,16 @@ class PrinterConfig {
   /// be a blank spinner).
   final String? uiType;
 
+  /// User-supplied camera override, set from the gear on the dashboard tile.
+  /// An absolute URL to a camera on the LAN that Klipper doesn't serve — e.g.
+  /// an old phone running an IP-webcam app at
+  /// `http://192.168.0.107:8080/video`. When set it takes priority over the
+  /// Pi-reported webcam: fetched directly on LAN, or routed through the Pi's
+  /// `/mg-extcam` proxy (private-IP targets only) when remote. Null = use
+  /// whatever the Pi reports (which may itself be an auto-detected external
+  /// camera from Mainsail's webcam config).
+  final String? customCameraUrl;
+
   const PrinterConfig({
     required this.id,
     required this.name,
@@ -53,6 +63,7 @@ class PrinterConfig {
     this.webcamRotation  = 0,
     this.webcamTargetFps = 15,
     this.uiType,
+    this.customCameraUrl,
   });
 
   PrinterConfig copyWith({
@@ -63,6 +74,7 @@ class PrinterConfig {
     int?    webcamRotation,
     int?    webcamTargetFps,
     String? uiType,
+    Object? customCameraUrl = _sentinel,
   }) =>
       PrinterConfig(
         id:              id,
@@ -73,6 +85,9 @@ class PrinterConfig {
         webcamRotation:  webcamRotation  ?? this.webcamRotation,
         webcamTargetFps: webcamTargetFps ?? this.webcamTargetFps,
         uiType:          uiType          ?? this.uiType,
+        customCameraUrl: identical(customCameraUrl, _sentinel)
+            ? this.customCameraUrl
+            : customCameraUrl as String?,
       );
 
   /// Normalise a user-typed printer address into a base [lanUrl] such as
@@ -141,6 +156,7 @@ class PrinterConfig {
         'webcamRotation':  webcamRotation,
         'webcamTargetFps': webcamTargetFps,
         if (uiType != null) 'uiType': uiType,
+        if (customCameraUrl != null) 'customCameraUrl': customCameraUrl,
       };
 
   factory PrinterConfig.fromJson(Map<String, dynamic> j) {
@@ -157,6 +173,7 @@ class PrinterConfig {
       webcamRotation:  j['webcamRotation']  as int?  ?? 0,
       webcamTargetFps: j['webcamTargetFps'] as int?  ?? 15,
       uiType:          j['uiType']          as String?,
+      customCameraUrl: j['customCameraUrl'] as String?,
     );
   }
 
@@ -243,6 +260,13 @@ class PrinterStatus {
   final int     webcamRotation;
   final int     webcamTargetFps;
 
+  /// True when [webcamSnapshotUrl] points at an external camera (a user
+  /// override, or one auto-detected from Mainsail's webcam config) rather than
+  /// the normal Pi snapshot endpoint. The tile then uses an MJPEG-aware
+  /// fetcher that can pull a single frame from a stream URL, since these
+  /// cameras usually expose only a stream (e.g. .../video), not a snapshot.
+  final bool webcamIsExternal;
+
   const PrinterStatus({
     required this.state,
     required this.progress,
@@ -260,6 +284,7 @@ class PrinterStatus {
     this.webcamFlipV    = false,
     this.webcamRotation = 0,
     this.webcamTargetFps = 15,
+    this.webcamIsExternal = false,
   });
 
   bool get isPrinting => state == 'printing' || state == 'paused';

--- a/mobile/lib/providers/settings_provider.dart
+++ b/mobile/lib/providers/settings_provider.dart
@@ -206,6 +206,36 @@ final dashboardCameraRefreshProvider =
 );
 
 // ---------------------------------------------------------------------------
+// Camera config icons  (show/hide the per-tile camera gear)
+// ---------------------------------------------------------------------------
+
+/// Whether the small camera-config gear is shown in the corner of each
+/// dashboard tile's webcam. On by default; users who don't set custom cameras
+/// can turn it off so it never overlaps the image feed. Travels in backups.
+class ShowCameraConfigIconsNotifier extends Notifier<bool> {
+  static const _key = 'show_camera_config_icons';
+
+  @override
+  bool build() => true;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool(_key) ?? true;
+  }
+
+  Future<void> set(bool show) async {
+    state = show;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, show);
+  }
+}
+
+final showCameraConfigIconsProvider =
+    NotifierProvider<ShowCameraConfigIconsNotifier, bool>(
+  ShowCameraConfigIconsNotifier.new,
+);
+
+// ---------------------------------------------------------------------------
 // Print notifications  (opt-in foreground-service progress + state alerts)
 // ---------------------------------------------------------------------------
 

--- a/mobile/lib/services/printer_registry.dart
+++ b/mobile/lib/services/printer_registry.dart
@@ -228,6 +228,17 @@ class PrinterRegistry {
     await _save();
   }
 
+  /// Persist the user's custom camera URL override (set from the tile gear).
+  /// Pass null to clear it and fall back to the Pi-reported webcam.
+  Future<void> updateCustomCameraUrl(String printerId, String? url) async {
+    final idx = _printers.indexWhere((p) => p.id == printerId);
+    if (idx == -1) return;
+    if (_printers[idx].customCameraUrl == url) return;
+    _printers = List.of(_printers)
+      ..[idx] = _printers[idx].copyWith(customCameraUrl: url);
+    await _save();
+  }
+
   /// Persist the detected web UI type ('mainsail' | 'fluidd') so the tile
   /// can render the right logo on a cold launch — including when the
   /// printer is currently offline (power-off, Pi rebooting, etc.).

--- a/mobile/lib/services/printer_status_service.dart
+++ b/mobile/lib/services/printer_status_service.dart
@@ -91,6 +91,17 @@ class PrinterStatusService {
     PrinterStatusRegistry.instance.recordPoll(config.id, _pollDiag);
   }
 
+  /// The user's current custom camera URL for this printer, read LIVE from the
+  /// registry each poll — so a change made via the tile gear takes effect on
+  /// the next poll without recreating the service. Falls back to the snapshot
+  /// the service was constructed with.
+  String? get _liveCustomCameraUrl {
+    for (final p in PrinterRegistry.instance.printers) {
+      if (p.id == config.id) return p.customCameraUrl;
+    }
+    return config.customCameraUrl;
+  }
+
   bool get _withinStartupGrace =>
       _firstPollAt != null &&
       DateTime.now().difference(_firstPollAt!) < _startupGrace;
@@ -674,6 +685,37 @@ class PrinterStatusService {
       }
     }
 
+    // External / custom camera override.
+    // Precedence: user override (the tile gear) > a camera auto-detected from
+    // Mainsail's webcam config (the plugin reports its absolute URL because
+    // Moonraker can't snapshot it for us) > the normal Pi snapshot built
+    // above. These are absolute LAN URLs — typically an MJPEG stream from a
+    // phone webcam. On LAN we fetch them directly; remote we route through the
+    // Pi's /mg-extcam proxy, which only ever forwards to private LAN IPs (see
+    // klipper-plugin/moongate_authproxy.py).
+    final customUrl    = _liveCustomCameraUrl?.trim();
+    final autoSnapshot = (moongateResult?['webcam_snapshot_external'] as String?)?.trim();
+    final autoStream   = (moongateResult?['webcam_stream_external']   as String?)?.trim();
+    final externalUrl = (customUrl != null && customUrl.isNotEmpty)
+        ? customUrl
+        : (autoSnapshot != null && autoSnapshot.isNotEmpty)
+            ? autoSnapshot
+            : (autoStream != null && autoStream.isNotEmpty)
+                ? autoStream
+                : null;
+
+    bool webcamIsExternal = false;
+    if (externalUrl != null && externalUrl.isNotEmpty) {
+      webcamIsExternal = true;
+      if (isLan) {
+        webcamSnapshotUrl = externalUrl;
+      } else {
+        webcamSnapshotUrl =
+            '$baseUrl/mg-extcam?u=${Uri.encodeComponent(externalUrl)}'
+            '&mg_token=${Uri.encodeComponent(accessToken)}';
+      }
+    }
+
     return PrinterStatus(
       state:              state,
       progress:           progress,
@@ -691,6 +733,7 @@ class PrinterStatusService {
       webcamFlipV:     (moongateResult?['webcam_flip_vertical']   as bool?) ?? false,
       webcamRotation:  (moongateResult?['webcam_rotation']        as num?)?.toInt() ?? 0,
       webcamTargetFps: (moongateResult?['webcam_target_fps']      as num?)?.toInt() ?? 15,
+      webcamIsExternal: webcamIsExternal,
     );
   }
 }

--- a/mobile/lib/services/settings_backup.dart
+++ b/mobile/lib/services/settings_backup.dart
@@ -31,6 +31,7 @@ class SettingsBackup {
     'print_notifications_enabled': _Kind.boolean,
     'notif_poll_interval':         _Kind.string,
     'app_locale':                  _Kind.string,
+    'show_camera_config_icons':    _Kind.boolean,
   };
 
   /// Snapshot the currently-set preferences into a JSON-safe map. Unset keys

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moongate
 description: Remote control interface for Klipper 3D printers via local WiFi or Cloudflare tunnel.
-version: 0.8.5+65
+version: 0.9.0+66
 publish_to: none
 
 environment:


### PR DESCRIPTION
## What

Adds support for **cameras that aren't connected to Klipper** — e.g. an old phone running an IP-webcam app — from a tester request (Galvanic's Galaxy S10e at `http://192.168.0.107:8080/video`).

Each dashboard tile gets a small, semi-transparent **gear** in the top-right of the webcam. Tapping it opens a dialog to set a **custom camera URL**. A new end-drawer toggle ("Camera config icons") hides the gears so they never overlap the feed.

Cameras already configured in Mainsail are **auto-detected** — the plugin reports their external stream URL, so they appear in Moongate with no typing; the gear becomes an override.

## How it renders

External cameras usually expose an **MJPEG stream** (`…/video`), not a snapshot — and in real setups the Mainsail "URL Snapshot" field is often left as the Pi default, so a snapshot-only approach misses them. The tile pulls **one JPEG frame per refresh tick** out of the (multipart) stream, keeping the dashboard light and on the existing cadence. Content-type is sniffed, so a plain snapshot URL works too.

Source precedence per tile: **user override → camera auto-detected from Mainsail → normal Pi snapshot**.

## LAN vs remote

- **Wi-Fi:** the app fetches the camera directly (phone → camera IP). No plugin change needed.
- **Remote:** routed through a new **`/mg-extcam`** relay on the Pi's auth proxy.

## Security (the reviewable bit)

`/mg-extcam` forwards a GET to a client-supplied URL, so it's an SSRF surface. It's gated behind the same EdDSA owner token as every other tunnel path, and the target is hard-validated (`_extcam_target_ok`):

- **http only**, GET, no redirects, content-type must be `image/*` or multipart, 16 MB cap.
- Target host must be a **literal private IPv4** (RFC1918).
- **Refused:** loopback (no pivot to Moonraker:7125 / the proxy), link-local + cloud-metadata (`169.254/16`), public / CGNAT / multicast / reserved / unspecified, and any hostname (no DNS → no rebinding window).

Unit-tested: Galvanic's URL passes; loopback, `169.254.169.254`, public, hostname, and non-http all rejected.

## Versions

- App **0.8.5+65 → 0.9.0+66**
- Plugin **0.6.7 → 0.6.8**

Remote external cameras need the **0.6.8 plugin** on the Pi (for both `/mg-extcam` and auto-detect). **LAN** custom cameras work without any Pi update.

## Verification

- `flutter analyze` — clean
- `flutter build apk --debug` — builds
- `python -m py_compile` on both plugin files — clean
- SSRF validator — 11/11 unit cases

## Testing handoff (on-device — not yet validated on hardware)

Suggested with Galvanic (offered to test):
1. **LAN:** set `http://192.168.0.107:8080/video` via the gear → S10e frames appear on the tile.
2. **Auto-detect:** with the 0.6.8 plugin, clear the override → camera still appears (read from Mainsail's `stream_url`).
3. **Remote:** off Wi-Fi (cellular) → camera still streams via `/mg-extcam`.
4. **Toggle:** drawer → "Camera config icons" off → gears disappear.
5. **Backup/restore:** custom URL + toggle survive a backup/restore.

> 8-language strings are machine-grade (native review advised, per the project's l10n convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
