### PR TITLE
ci: changelog guard (require a changelog on every version bump)

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -1,0 +1,55 @@
+name: Changelog guard
+
+# A version bump cuts a release and fires the in-app update banner, so every PR
+# that bumps mobile/pubspec.yaml's `version:` MUST carry its changelog in the
+# SAME PR — both the in-app source (mobile/assets/changelog.json, which feeds the
+# "What's new" dialog and the update overlay) and the public CHANGELOG.md. This
+# check fails the PR otherwise. PRs that don't bump the version (docs, plugin-
+# only, CI, etc.) are exempt and pass straight through.
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  changelog-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require a changelog entry when the app version is bumped
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Only the changes THIS PR introduces (three-dot = since the merge base),
+          # so a PR that's merely behind master isn't blamed for master's bumps.
+          version_diff=$(git diff "${BASE_SHA}...${HEAD_SHA}" -- mobile/pubspec.yaml || true)
+          if ! echo "$version_diff" | grep -qE '^\+version:'; then
+            echo "No app version bump in this PR — changelog not required. ✓"
+            exit 0
+          fi
+
+          echo "This PR bumps the app version:"
+          echo "$version_diff" | grep -E '^[+-]version:' || true
+          echo ""
+
+          changed=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
+          missing=""
+          echo "$changed" | grep -qx "mobile/assets/changelog.json" || missing="${missing} mobile/assets/changelog.json"
+          echo "$changed" | grep -qx "CHANGELOG.md"                 || missing="${missing} CHANGELOG.md"
+
+          if [ -n "$missing" ]; then
+            echo "::error title=Changelog missing::This PR bumps the app version but does not update:${missing}"
+            echo "A version bump cuts a release and fires the in-app update banner, so the"
+            echo "changelog must ship in the same PR. Add the new version's entry to:"
+            echo "  - mobile/assets/changelog.json  (the in-app \"What's new\" + update overlay)"
+            echo "  - CHANGELOG.md                  (the public changelog table)"
+            exit 1
+          fi
+
+          echo "Version bump carries changelog.json + CHANGELOG.md. ✓"


### PR DESCRIPTION
## What
A CI guard enforcing the new process: **a PR that bumps the app version must carry its changelog in the same PR.**

If a PR changes `mobile/pubspec.yaml`'s `version:`, it must also update **both**:
- `mobile/assets/changelog.json` — the in-app "What's new" + update overlay, and
- `CHANGELOG.md` — the public changelog table.

…otherwise the check fails with a clear message. PRs that don't bump the version (docs, plugin-only, CI) pass straight through.

## Why
v0.9.0 (#69) and v0.9.1 (#71) both shipped **without** their changelog, forcing follow-up docs PRs (#70, #72) — and the overlap even caused a merge conflict mid-stream. This makes each release atomic and the changelog impossible to forget.

(The check runs on its own PR here — no version bump → passes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
