### PR TITLE
docs: replace the ASCII How-it-works with an SVG infrastructure diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,24 +123,11 @@ No working camera? Type the **`GATE-XXXX-XXXX`** code shown in the console inste
 
 ## How it works
 
-```
-                        ┌──────────────────────┐
-                        │   Cloud middleman    │   anonymous sign-in;
-                        │   (identity & lookup)│   tells the app where
-                        └──────────┬───────────┘   your printer is right now
-                                   │ short-lived
-                                   │ access token
-                                   ▼
-   ┌─────────────────┐                  ┌──────────────────────────────┐
-   │  Moongate App   │◄──── LAN ───────►│  Raspberry Pi                │
-   │   (Android)     │      (home)      │   • Klipper + Moonraker      │
-   │                 │◄── Cloudflare ──►│   • Moongate plugin          │
-   │                 │   tunnel (away)  │   • Auth proxy — gates every │
-   └─────────────────┘                  │     internet-facing request  │
-                                        └──────────────────────────────┘
-```
+<div align="center">
+<img src="docs/how-it-works.svg" width="820" alt="Moongate infrastructure: the app gets a short-lived signed token from the access broker, then reaches the Raspberry Pi directly over your LAN at home or through Cloudflare's tunnel away; the Pi's auth proxy admits only broker-signed requests, so a leaked tunnel URL returns only 401s.">
+</div>
 
-Your Pi runs Klipper, Moonraker, the Moongate plugin, and an **auth proxy** that gates everything reachable from the internet. A minimal **cloud middleman** handles anonymous sign-in (no email, no password) and tracks the current tunnel URL; the app fetches a fresh signed token before each request and tries home WiFi first, then the tunnel.
+Your Pi runs Klipper, Moonraker, the Moongate plugin, and an **auth proxy** that gates everything reachable from the internet. A minimal **access broker** handles anonymous sign-in (no email, no password) and tracks the current tunnel URL; the app fetches a fresh signed token before each request and tries home WiFi first, then the tunnel.
 
 **The headline:** leaking the tunnel URL alone gives an attacker nothing — every path through it returns `401` without revealing what's underneath. Full threat model in [SECURITY.md](SECURITY.md); code-level detail in [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/docs/how-it-works.svg
+++ b/docs/how-it-works.svg
@@ -1,0 +1,63 @@
+<svg viewBox="0 0 1120 600" role="img" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif">
+  <title>Moongate infrastructure diagram</title>
+  <desc>The access broker signs you in anonymously and issues a short-lived token plus your Pi's address. The app carries that token to the Raspberry Pi — directly over your LAN at home, or via Cloudflare's tunnel away — and the Pi's auth proxy opens only for a token the broker signed, so a leaked tunnel URL returns only 401s.</desc>
+  <defs>
+    <mask id="b3"><rect width="100" height="100" fill="#000"/><circle cx="50" cy="50" r="15" fill="#fff"/><circle cx="56.5" cy="47" r="12.6" fill="#000"/></mask>
+    <g id="m3"><circle cx="50" cy="50" r="32" fill="none" stroke="#FF3B30" stroke-width="6.5"/><circle cx="50" cy="50" r="15" fill="#FF3B30" mask="url(#b3)"/></g>
+    <marker id="p3" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse"><path d="M0,0 L6,3 L0,6 Z" fill="#6C63FF"/></marker>
+    <marker id="g3" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse"><path d="M0,0 L6,3 L0,6 Z" fill="#34C759"/></marker>
+    <marker id="o3" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse"><path d="M0,0 L6,3 L0,6 Z" fill="#FF9F0A"/></marker>
+  </defs>
+  <rect width="1120" height="600" rx="26" fill="#F5F5F7"/>
+  <use href="#m3" transform="translate(40,28) scale(0.46)"/>
+  <text x="98" y="50" font-size="25" font-weight="700" fill="#1d1d1f">Moongate</text>
+  <text x="98" y="69" font-size="13" fill="#6e6e73">Infrastructure — how it connects</text>
+
+  <rect x="56" y="90" width="266" height="86" rx="18" fill="#ffffff" stroke="#dcd9fb" stroke-width="1.5"/>
+  <g transform="translate(78,120)" fill="#6C63FF"><ellipse cx="14" cy="20" rx="17" ry="11"/><ellipse cx="29" cy="15" rx="13" ry="12"/><ellipse cx="6" cy="15" rx="9" ry="8"/><rect x="0" y="20" width="38" height="9" rx="4.5"/></g>
+  <text x="140" y="116" font-size="15" font-weight="700" fill="#1d1d1f">Access broker</text>
+  <text x="140" y="134" font-size="11" fill="#6e6e73">anonymous sign-in</text>
+  <text x="140" y="150" font-size="11" fill="#6e6e73">signs your token + Pi address</text>
+  <text x="140" y="166" font-size="10.5" font-style="italic" fill="#8a86c9">the Pi trusts only its signature</text>
+
+  <rect x="452" y="96" width="196" height="78" rx="18" fill="#fff8f0" stroke="#f3d8af" stroke-width="1.4"/>
+  <g transform="translate(474,124)" fill="#FF9F0A"><ellipse cx="16" cy="20" rx="19" ry="12"/><ellipse cx="33" cy="14" rx="14" ry="13"/><ellipse cx="7" cy="15" rx="10" ry="9"/><rect x="1" y="20" width="42" height="10" rx="5"/></g>
+  <text x="536" y="126" font-size="15" font-weight="700" fill="#1d1d1f">Cloudflare</text>
+  <text x="536" y="145" font-size="11.5" fill="#cc7a00">secure tunnel · away</text>
+
+  <rect x="70" y="250" width="140" height="270" rx="26" fill="#0E0E10"/>
+  <rect x="81" y="266" width="118" height="238" rx="15" fill="#16161b"/>
+  <use href="#m3" transform="translate(123,330) scale(0.32)"/>
+  <text x="140" y="386" font-size="11.5" font-weight="600" fill="#f2f2f2" text-anchor="middle">Moongate</text>
+  <circle cx="125" cy="408" r="4.5" fill="#34C759"/><circle cx="155" cy="408" r="4.5" fill="#FF9F0A"/>
+  <text x="140" y="429" font-size="9.5" fill="#cfcfd6" text-anchor="middle">2 printers · online</text>
+  <text x="140" y="540" font-size="13.5" font-weight="600" fill="#1d1d1f" text-anchor="middle">Your phone</text>
+
+  <rect x="810" y="262" width="280" height="234" rx="20" fill="#ffffff" stroke="#e6e6ec" stroke-width="1.2"/>
+  <g transform="translate(828,282)"><rect x="0" y="0" width="56" height="38" rx="4" fill="#1f7a4d"/><rect x="6" y="6" width="15" height="15" rx="2" fill="#0e0e10"/><rect x="27" y="8" width="11" height="11" rx="1.5" fill="#0e0e10"/><rect x="2" y="-3" width="38" height="3" rx="1" fill="#e7b94e"/><rect x="42" y="22" width="11" height="9" rx="1.5" fill="#3a3a3a"/></g>
+  <text x="898" y="296" font-size="16" font-weight="700" fill="#1d1d1f">Raspberry Pi</text>
+  <text x="898" y="314" font-size="11" fill="#6e6e73">on your bench</text>
+  <line x1="828" y1="334" x2="1072" y2="334" stroke="#eeeef2" stroke-width="1.2"/>
+  <g font-size="12.5" fill="#33333a"><circle cx="836" cy="356" r="3" fill="#86868b"/><text x="850" y="360">Klipper + Moonraker</text><circle cx="836" cy="384" r="3" fill="#86868b"/><text x="850" y="388">Moongate plugin</text></g>
+  <rect x="824" y="402" width="244" height="44" rx="10" fill="#efeefb"/>
+  <g transform="translate(834,414)"><rect x="0" y="6" width="15" height="11" rx="2" fill="#6C63FF"/><path d="M3,6 V3.6 a4.5,4.5 0 0 1 9,0 V6" fill="none" stroke="#6C63FF" stroke-width="2"/></g>
+  <text x="858" y="421" font-size="12.5" font-weight="700" fill="#4b45c6">Auth proxy</text>
+  <text x="858" y="437" font-size="10.5" fill="#6e6e73">opens only for the broker's token</text>
+
+  <path d="M140,250 C140,210 158,184 188,172" fill="none" stroke="#6C63FF" stroke-width="2.4" stroke-dasharray="2 6" stroke-linecap="round" marker-start="url(#p3)" marker-end="url(#p3)"/>
+  <g transform="translate(150,196)" stroke="#6C63FF" stroke-width="2" fill="none" stroke-linecap="round"><circle cx="4" cy="4" r="3.4"/><path d="M6.6,6.6 L14,14"/><path d="M11.2,11.2 L13.6,8.8 M13.6,13.6 L16,11.2"/></g>
+  <text x="200" y="206" font-size="12" font-weight="600" fill="#6C63FF">① signed token</text>
+
+  <path d="M210,332 C320,300 400,232 486,176" fill="none" stroke="#FF9F0A" stroke-width="3" stroke-linecap="round" marker-start="url(#o3)"/>
+  <path d="M614,176 C700,232 760,300 810,332" fill="none" stroke="#FF9F0A" stroke-width="3" stroke-linecap="round" marker-end="url(#o3)"/>
+  <rect x="442" y="214" width="216" height="22" rx="11" fill="#fff3e0"/>
+  <text x="550" y="230" font-size="12.5" font-weight="600" fill="#cc7a00" text-anchor="middle">② away · via Cloudflare tunnel</text>
+
+  <path d="M210,452 L810,452" fill="none" stroke="#34C759" stroke-width="3" marker-start="url(#g3)" marker-end="url(#g3)"/>
+  <rect x="406" y="441" width="208" height="22" rx="11" fill="#eaf8ee"/>
+  <text x="510" y="457" font-size="12.5" font-weight="600" fill="#1e9e4a" text-anchor="middle">② home · direct over your LAN</text>
+
+  <rect x="350" y="552" width="420" height="40" rx="20" fill="#ffffff" stroke="#f0dede" stroke-width="1.2"/>
+  <g transform="translate(372,564)"><rect x="0" y="6" width="17" height="13" rx="2.5" fill="#FF3B30"/><path d="M3,6 V3.2 a5.5,5.5 0 0 1 11,0 V6" fill="none" stroke="#FF3B30" stroke-width="2.3"/></g>
+  <text x="400" y="578" font-size="13" font-weight="600" fill="#1d1d1f">Tunnel-safe — leak the URL, an attacker gets only 401s</text>
+</svg>


### PR DESCRIPTION
Replaces the ASCII "How it works" block with a proper **SVG infrastructure diagram** (`docs/how-it-works.svg`) — matching the hero's `#F5F5F7` backdrop, the moon-gate mark, and the app's own **green = home / orange = away** colour language.

It also **corrects the architecture** the ASCII blurred:
- The cloud (renamed **"access broker"**) is **control-only** — it signs you in, issues a short-lived **token**, and tells the app **where your Pi is**. No printer traffic flows through it.
- The data path is **phone → Pi direct over the LAN** (home), or **phone → Cloudflare → Pi** (away).
- The Pi's **auth proxy** admits only broker-signed requests, so a leaked tunnel URL returns only `401`s.

Changes: new `docs/how-it-works.svg`; README ASCII → centered `<img>`; prose "cloud middleman" → "access broker" for consistency within the section.

Docs-only, no version bump — merge with `[skip ci]`. (ARCHITECTURE.md / DEVELOPMENT.md still say "cloud middleman" — a repo-wide rename can follow if you want it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
