### PR TITLE
docs(diagram): move header top-right, center the tunnel-safe note, enlarge logo

### DIFF
--- a/docs/how-it-works.svg
+++ b/docs/how-it-works.svg
@@ -9,9 +9,9 @@
     <marker id="o3" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto-start-reverse"><path d="M0,0 L6,3 L0,6 Z" fill="#FF9F0A"/></marker>
   </defs>
   <rect width="1120" height="600" rx="26" fill="#F5F5F7"/>
-  <use href="#m3" transform="translate(40,28) scale(0.46)"/>
-  <text x="98" y="50" font-size="25" font-weight="700" fill="#1d1d1f">Moongate</text>
-  <text x="98" y="69" font-size="13" fill="#6e6e73">Infrastructure — how it connects</text>
+  <use href="#m3" transform="translate(791,22) scale(0.55)"/>
+  <text x="856" y="51" font-size="28" font-weight="700" fill="#1d1d1f">Moongate</text>
+  <text x="856" y="71" font-size="14" fill="#6e6e73">Infrastructure — how it connects</text>
 
   <rect x="56" y="90" width="266" height="86" rx="18" fill="#ffffff" stroke="#dcd9fb" stroke-width="1.5"/>
   <g transform="translate(78,120)" fill="#6C63FF"><ellipse cx="14" cy="20" rx="17" ry="11"/><ellipse cx="29" cy="15" rx="13" ry="12"/><ellipse cx="6" cy="15" rx="9" ry="8"/><rect x="0" y="20" width="38" height="9" rx="4.5"/></g>
@@ -57,7 +57,7 @@
   <rect x="406" y="441" width="208" height="22" rx="11" fill="#eaf8ee"/>
   <text x="510" y="457" font-size="12.5" font-weight="600" fill="#1e9e4a" text-anchor="middle">① home · direct over your LAN</text>
 
-  <rect x="350" y="552" width="420" height="40" rx="20" fill="#ffffff" stroke="#f0dede" stroke-width="1.2"/>
-  <g transform="translate(372,564)"><rect x="0" y="6" width="17" height="13" rx="2.5" fill="#FF3B30"/><path d="M3,6 V3.2 a5.5,5.5 0 0 1 11,0 V6" fill="none" stroke="#FF3B30" stroke-width="2.3"/></g>
-  <text x="400" y="578" font-size="13" font-weight="600" fill="#1d1d1f">Tunnel-safe — leak the URL, an attacker gets only 401s</text>
+  <rect x="350" y="336" width="420" height="40" rx="20" fill="#ffffff" stroke="#f0dede" stroke-width="1.2"/>
+  <g transform="translate(372,348)"><rect x="0" y="6" width="17" height="13" rx="2.5" fill="#FF3B30"/><path d="M3,6 V3.2 a5.5,5.5 0 0 1 11,0 V6" fill="none" stroke="#FF3B30" stroke-width="2.3"/></g>
+  <text x="400" y="362" font-size="13" font-weight="600" fill="#1d1d1f">Tunnel-safe — leak the URL, an attacker gets only 401s</text>
 </svg>


### PR DESCRIPTION
Refresh of the README "how it works" graphic, addressing user feedback on the previous version.

Changes:
- Moongate logo + title moved from the top-left to the top-right (right-aligned to the Raspberry Pi card).
- Logo icon and title nudged slightly larger.
- The "tunnel-safe / only 401s" note moved from the bottom of the graphic up into the middle.

Docs-only change to a single SVG asset (`docs/how-it-works.svg`) — no version bump, so changelog-guard does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
