### PR TITLE
docs: refresh README Features (drag-to-reorder + remote camera view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Free, open-source Android control for your **Klipper 3D printer** — live webca
 
 ## Features
 
-- 📊 **Fleet dashboard** — live webcam thumbnails (pick the refresh rate to balance smoothness vs. data), print progress matched to Mainsail's estimate, temperatures, chamber sensor, and a per-printer status badge. Tiles auto-sort by activity, so whatever's printing floats to the top.
+- 📊 **Fleet dashboard** — live webcam thumbnails (pick the refresh rate to balance smoothness vs. data), print progress matched to Mainsail's estimate, temperatures, chamber sensor, and a per-printer status badge. Tiles auto-sort by activity so whatever's printing floats to the top — or turn that off and **drag them into your own order**, which sticks and travels in your backups.
 - 📷 **External cameras** — point a tile at a camera that isn't wired into Klipper (an old phone as a webcam, a network IP cam). Cameras already configured in Mainsail are auto-detected; or set one by hand with the tile's gear. Works on Wi-Fi and remotely through the tunnel (home-network cameras), and a menu toggle hides the gears.
 - 🎛️ **Print controls** — pause, resume, and stop from the tile, plus a one-tap firmware restart for idle or errored printers.
 - 📂 **Print files on the printer** — tap the folder button on a ready printer to browse the G-code already saved on it, shown with slicer **thumbnails**, newest first. Pick one and **Start print** with a confirm tap — no slicer, no re-upload.
-- 🖥️ **Full Mainsail / Fluidd UI** — tap a tile to open the complete web UI in-app; whichever you run is auto-detected.
+- 🖥️ **Full Mainsail / Fluidd UI** — tap a tile to open the complete web UI in-app; whichever you run is auto-detected. A built-in full-screen **camera view** (top-bar icon) keeps the feed working when you're away — even for an external camera the embedded page can't load over mobile data.
 - 📡 **Auto local ↔ remote** — tries home WiFi first every poll, falls back to the Cloudflare tunnel within ~2s when you're away, and flips back to "Local" the moment you're home.
 - 🔔 **Print notifications** — opt-in live fleet status in your notification shade — per-printer progress, ETA, temperatures and heat-up — with start / finish / pause / error alerts, and a configurable refresh interval. Off by default.
 - 🔒 **App lock** — optional PIN + biometric (fingerprint/face) on launch, with configurable auto-lock and screenshot protection. Off by default.


### PR DESCRIPTION
Brings the homepage Features list up to date with recently shipped features.

- **Fleet dashboard** bullet — the status auto-sort is now optional; you can turn it off and **drag tiles into your own order** (v0.9.4). Notes that the order persists and rides backups.
- **Full Mainsail / Fluidd UI** bullet — mentions the native full-screen **camera view** (top-bar icon) that keeps working remotely even for an external camera the embedded page can't load over mobile data (v0.9.2).

Docs-only, no version bump — changelog-guard is exempt. Suggest merging with `[skip ci]` to skip the release rebuild:

```
gh pr merge --merge --subject "docs: refresh README Features [skip ci]"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
