### PR TITLE
Generic placeholder name in the notification preview

### DIFF
--- a/mobile/lib/features/settings/notification_content_screen.dart
+++ b/mobile/lib/features/settings/notification_content_screen.dart
@@ -91,8 +91,11 @@ class _PreviewCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final shown =
         cfg.order.where(cfg.enabled.contains).map(notifFieldExample).toList();
+    // Generic placeholder for the preview; the live notification uses the
+    // printer's real name.
+    final name = '(${l.printerNameLabel})';
     final line =
-        shown.isEmpty ? '🖨️ MadMax' : '🖨️ MadMax — ${shown.join(' · ')}';
+        shown.isEmpty ? '🖨️ $name' : '🖨️ $name — ${shown.join(' · ')}';
     return Card(
       margin: EdgeInsets.zero,
       child: Padding(


### PR DESCRIPTION
The **Notification content** preview card used a hard-coded sample name. This swaps it for the existing localized `printerNameLabel`, so the preview reads as a neutral **"(Printer name)"** placeholder in every language.

- **Preview-only** — the live notification is unaffected and still uses each printer's real name.
- **No new strings** (reuses `printerNameLabel`), **no version bump** (cosmetic), so no changelog/release is needed — it rides the next feature release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
