### PR TITLE
docs(security): drop the "tiny project" framing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -231,7 +231,7 @@ These are real options that came up during v0.4 design and were rejected, in cas
 - **WireGuard on Android.** Requires the user to grant the OS-level `VpnService` permission, which Google Play increasingly disfavours for non-VPN-product apps. No native NAT-traversal mechanism — needs a relay anyway for ~85% of home networks. Closed off at the design stage; see the alternatives appendix in [`docs/v0.4-secure-remote-access-design.md`](docs/v0.4-secure-remote-access-design.md).
 - **Tailscale / Headscale / ZeroTier / NetBird.** Either paid above 3 nodes, requires accounts, or requires self-hosting infrastructure that defeats "no VPN setup". Documented in the same appendix.
 - **Browser-side Mainsail login via `force_logins` in Moonraker.** Was the v0.2.x recommended mitigation; the auth-proxy approach in v0.4 is strictly stronger (no Mainsail HTML ever leaves the Pi for unauthenticated requests) and doesn't require the user to type a Moonraker password into Mainsail every time the cookie expires.
-- **A Moongate-operated print server / relay.** Would centralise G-code, print history, and live status with us. Off the table — both for privacy and for "this is meant to stay a tiny project".
+- **A Moongate-operated print server / relay.** Would centralise G-code, print history, and live status with us. Off the table — both for privacy and by design: the cloud middleman is deliberately kept minimal (a lookup-and-token service), not a print server we operate.
 
 ---
 


### PR DESCRIPTION
## What will this PR change?

A one-line wording fix in **SECURITY.md**. In the "What we explicitly chose not to do" section, the note about a Moongate-operated print server no longer says the project is *"meant to stay a tiny project."* The reason it's off the table is reframed as **privacy + a deliberately-minimal cloud middleman** (a lookup-and-token service, not a print server we run).

## Why

Moongate is now being developed for a larger audience, so the "tiny project" framing is out of date. The real reason for not running a print server — privacy, and keeping the cloud a minimal lookup table — holds regardless of audience size, and `ARCHITECTURE.md` already frames it exactly that way ("a print server is a much larger thing to operate than a lookup table").

## Scope

- `SECURITY.md` only — no code, no version bump, no Pi update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
