### PR TITLE
Access-token TTL 5 → 10 min (fewer printer-access calls)

### DIFF
--- a/supabase/functions/_shared/accessToken.ts
+++ b/supabase/functions/_shared/accessToken.ts
@@ -1,5 +1,7 @@
-// Short-lived (~5 min) access tokens minted by /printer-access and verified
-// on the Pi.
+// Short-lived (~10 min) access tokens minted by /printer-access and verified
+// on the Pi. The app caches a token until ~30 s before this expiry, so a
+// longer TTL directly cuts how often it has to call /printer-access (the
+// dominant Edge Function cost).
 //
 // Algorithm: EdDSA (Ed25519). Private key is a JWK stored in
 // MOONGATE_JWT_SIGNING_KEY env var. Public key is exposed via the /jwks
@@ -12,7 +14,7 @@
 
 import * as jose from "npm:jose@5";
 
-const ACCESS_TOKEN_TTL_SECONDS = 300; // 5 minutes
+const ACCESS_TOKEN_TTL_SECONDS = 600; // 10 minutes
 export const KID      = "moongate-access-1";
 export const AUDIENCE = "moongate-printer";
 export const ISSUER   = "moongate";

--- a/supabase/functions/printer-access/index.ts
+++ b/supabase/functions/printer-access/index.ts
@@ -1,7 +1,7 @@
 // POST /functions/v1/printer-access
 //
 // Called by the app immediately before sending a control command to the Pi.
-// Returns the current tunnel URL (decrypted) and a fresh 5-minute access
+// Returns the current tunnel URL (decrypted) and a fresh 10-minute access
 // token signed with the server's Ed25519 key.
 //
 // Caller MUST present a Supabase JWT in the Authorization header.
@@ -14,8 +14,8 @@
 // Response 200:
 //   {
 //     "tunnel_url":   "https://xxx.trycloudflare.com" | null,
-//     "access_token": "<EdDSA JWT, ~5 min TTL>",
-//     "expires_in":   300
+//     "access_token": "<EdDSA JWT, ~10 min TTL>",
+//     "expires_in":   600
 //   }
 //
 // The access token is valid on the LAN OR the tunnel — the Pi verifies the


### PR DESCRIPTION
## What will this PR change?

Raises the EdDSA access-token TTL from **5 to 10 minutes** (`accessToken.ts`). The app caches a token until ~30s before expiry, so a longer TTL roughly **halves** how often it calls `/printer-access` — the function that dominates our Supabase Edge invocations.

**Server-only.** No app changes, no version bump. Existing installs honor the server's `expires_in`, so this helps everyone immediately once the functions are redeployed.

## Why

Edge Function invocations were near the free-tier limit; `printer-access` was ~92% of calls in the live logs. This is the cheapest lever — one constant, instant effect, no app update required.

## Deploy

Edge functions don't deploy via CI — after merge, run `supabase functions deploy printer-access` (the change lives in the shared `accessToken.ts`, which `printer-access` imports).

## Safety

The Pi authproxy validates the token's own `exp` (no hardcoded 5-min cap), so a 10-minute token is accepted unchanged. Tradeoff: a leaked token is valid 10 min instead of 5 — still short-lived, printer + owner scoped, HTTPS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
