### PR TITLE
chore(db): restrict internal RPCs to the service role

### DIFF
--- a/supabase/migrations/20260619170000_lock_rpc_execute_to_service_role.sql
+++ b/supabase/migrations/20260619170000_lock_rpc_execute_to_service_role.sql
@@ -1,0 +1,38 @@
+-- Moongate — Restrict the internal RPCs to the service role (least privilege).
+--
+-- These SECURITY DEFINER functions are an implementation detail of the Edge
+-- Functions, which authenticate every caller and then invoke them via the
+-- service-role client (adminClient in _shared/supabaseClients.ts). They are not
+-- part of the public API, so they should be callable only by service_role.
+--
+-- Revoke EXECUTE from PUBLIC/anon/authenticated and grant it explicitly to
+-- service_role for each, so the Edge Functions keep working while direct access
+-- is removed. Idempotent; safe to re-run.
+
+BEGIN;
+
+REVOKE EXECUTE ON FUNCTION
+  public.upsert_enrollment_token(text, text, int),
+  public.claim_printer(text, text, text, uuid),
+  public.get_printer_access(uuid, uuid),
+  public.record_heartbeat(text, text, text),
+  public.release_printer(uuid, uuid),
+  public.release_printer_by_pubkey(text),
+  public.create_restore_grant(text, uuid),
+  public.redeem_restore_grant(text, uuid),
+  public.moongate_cleanup_inactive()
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION
+  public.upsert_enrollment_token(text, text, int),
+  public.claim_printer(text, text, text, uuid),
+  public.get_printer_access(uuid, uuid),
+  public.record_heartbeat(text, text, text),
+  public.release_printer(uuid, uuid),
+  public.release_printer_by_pubkey(text),
+  public.create_restore_grant(text, uuid),
+  public.redeem_restore_grant(text, uuid),
+  public.moongate_cleanup_inactive()
+TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## What will this PR change?

One **server-only** database migration that restricts the internal `SECURITY DEFINER` RPCs to the service role, so they're callable only by the Edge Functions. No app change, no Pi change.

Already applied to production; recorded here as a migration so the repo and the live database stay in sync.

## Why

Least-privilege hardening — these RPCs are an implementation detail of the Edge Functions (which authenticate every caller, then call them via the service role), not part of the public API.

## How

`REVOKE EXECUTE … FROM PUBLIC, anon, authenticated` plus an explicit `GRANT EXECUTE … TO service_role` for each. The grant keeps the Edge Functions working; only direct access is removed. Idempotent.

## Testing

- Every caller is an Edge Function using the service-role client; none are called from the app or the Pi.
- Verified in production that the grants resolve as intended.

**Merge note:** server-only, no version bump — merge with `[skip ci]`.
