### PR TITLE
perf(server): access-token TTL 10 -> 30 min to cut /printer-access cost

### DIFF
--- a/supabase/functions/_shared/accessToken.ts
+++ b/supabase/functions/_shared/accessToken.ts
@@ -1,4 +1,4 @@
-// Short-lived (~10 min) access tokens minted by /printer-access and verified
+// Short-lived (~30 min) access tokens minted by /printer-access and verified
 // on the Pi. The app caches a token until ~30 s before this expiry, so a
 // longer TTL directly cuts how often it has to call /printer-access (the
 // dominant Edge Function cost).
@@ -14,7 +14,7 @@
 
 import * as jose from "npm:jose@5";
 
-const ACCESS_TOKEN_TTL_SECONDS = 600; // 10 minutes
+const ACCESS_TOKEN_TTL_SECONDS = 1800; // 30 minutes
 export const KID      = "moongate-access-1";
 export const AUDIENCE = "moongate-printer";
 export const ISSUER   = "moongate";

--- a/supabase/functions/printer-access/index.ts
+++ b/supabase/functions/printer-access/index.ts
@@ -1,7 +1,7 @@
 // POST /functions/v1/printer-access
 //
 // Called by the app immediately before sending a control command to the Pi.
-// Returns the current tunnel URL (decrypted) and a fresh 10-minute access
+// Returns the current tunnel URL (decrypted) and a fresh 30-minute access
 // token signed with the server's Ed25519 key.
 //
 // Caller MUST present a Supabase JWT in the Authorization header.
@@ -14,8 +14,8 @@
 // Response 200:
 //   {
 //     "tunnel_url":   "https://xxx.trycloudflare.com" | null,
-//     "access_token": "<EdDSA JWT, ~10 min TTL>",
-//     "expires_in":   600
+//     "access_token": "<EdDSA JWT, ~30 min TTL>",
+//     "expires_in":   1800
 //   }
 //
 // The access token is valid on the LAN OR the tunnel — the Pi verifies the


### PR DESCRIPTION
## What will this PR change?

Triples how long the app's printer **access tokens** stay valid — 10 minutes → 30 minutes. **Server-only**, with **no visible difference for users**: it just makes the app ask the server for a fresh token 3× less often.

## Why

We went over the Supabase free-tier limit for Edge Function calls (610k vs 500k — grace period runs to **22 July**). Those calls are ~**92% token-minting**. Because the app only refreshes a token when it's about to expire, a longer token life cuts the call rate proportionally:

- At today's ~14k calls/day, this drops us to roughly **~5k/day**.
- That lifts our "users before we hit the limit" ceiling from **~27** to **~80+**.

## How

- `ACCESS_TOKEN_TTL_SECONDS` 600 → 1800 in `supabase/functions/_shared/accessToken.ts` (one constant).
- Doc comments/examples updated to match.
- The app already trusts the server's `expires_in`, so **no app change** is needed — every user benefits the moment the function is deployed.

**Trade-off:** a token stays valid 30 min instead of 10 — fine for this use (owner-scoped access to your own printer over LAN/tunnel; not a sensitive credential). Adjustable to 60 min later (one number) if we want even more headroom.

## Testing

- No app rebuild; pure server constant — the app and `flutter` build are untouched.
- After deploy, watch the **Edge Function Invocations / day** chart in Supabase — it should fall to roughly a third over the next day.

## Deploy (server-only — does not ride the APK build)

1. Merge with **`[skip ci]`** in the merge subject (no release rebuild).
2. `supabase functions deploy printer-access` to activate (re-bundles the shared token module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
