### PR TITLE
fix(notif): calmer idle text when 'show only online' hides every printer (#126)

### DIFF
--- a/mobile/lib/services/print_notification_service.dart
+++ b/mobile/lib/services/print_notification_service.dart
@@ -413,7 +413,11 @@ class _PrintTaskHandler extends TaskHandler {
     final String text;
     if (entries.isEmpty) {
       title = 'Moongate';
-      text = noneOnline ? _l.printNotifNoneOnline : _l.printNotifNoPrinters;
+      // "Show only online devices" on with every printer offline: show the calm
+      // idle watcher line (as at service start) instead of the alarming "No
+      // printers online", which a user flagged as naggy (#126). The real fix,
+      // letting the watcher sleep via push, is tracked separately.
+      text = noneOnline ? _l.printNotifWatching : _l.printNotifNoPrinters;
     } else if (entries.length == 1) {
       // Single printer: emoji + full status on the title line.
       title = _statusLine(entries.first.$1, entries.first.$2, withEmoji: true);


### PR DESCRIPTION
## What will this PR change?
When "Show only online devices" is on and every printer is offline, the persistent print-status notification now reads **"Watching your printers"** instead of **"No printers online"**. Purely cosmetic, no behaviour change.

A user ([#126](https://github.com/PEEKYPAUL/Moongate/issues/126)) found "No printers online" read like a nagging alert. This softens it to the same calm wording the watcher already shows at startup.

## Why
The print-notification watcher runs as an Android foreground service, which must show one ongoing notification while it runs, so it cannot be hidden while Print notifications are on. The empty-list fallback text was the only thing we could improve short of the real fix.

## How
One line in `mobile/lib/services/print_notification_service.dart`: the empty-roster, filter-on branch now uses `printNotifWatching` instead of `printNotifNoneOnline`. Reuses an existing localized string, so no new translation work. The now-unused `printNotifNoneOnline` string is left in place.

## Testing
`flutter analyze` on the changed file: no issues.

## Not in this PR
The proper fix is a push-based system so the watcher can sleep when nothing is online, with no notification at all until a printer checks in. Tracked separately as a larger piece of work.
