### PR TITLE
CI: build the iOS app on every PR and master push

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,44 @@
+name: Build iOS
+
+# Builds the iOS app on every PR and master push, alongside the Android build.
+# This is the cross-platform guardrail: because Moongate is one Flutter codebase
+# that ships to both stores, a change can compile fine for Android yet break iOS
+# (a plugin without an iOS implementation, a Podfile or Info.plist mistake, a
+# Swift-side issue). Building both platforms here catches that immediately.
+#
+# Cost note: macOS runners use more Actions minutes than Ubuntu. If that becomes
+# a concern, narrow the triggers (e.g. only run on PRs, or only when files under
+# mobile/ change).
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build iOS (no codesign)
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      # Build without code signing so CI needs no Apple certificates or secrets.
+      # This still compiles the Dart + Swift, runs `pod install`, and links every
+      # plugin, which is what catches iOS-only breakage. Signing happens locally
+      # (and later in the release/TestFlight pipeline), not here.
+      - name: Build iOS (no code signing)
+        run: flutter build ios --release --no-codesign


### PR DESCRIPTION
## What will this PR change?

It adds a CI job that **builds the iOS app on every PR and every push to master**, alongside the existing Android build. Nothing about the app itself changes; this only adds a GitHub Actions workflow.

In plain terms: from now on, if a change compiles for Android but breaks the iPhone build, CI will fail and tell you straight away, instead of you finding out later when you try to release on iOS.

## Why

Moongate is a single Flutter codebase that ships to both the Play Store and the App Store. That means most features are shared, but a change can still build fine for Android and break iOS (a plugin with no iOS implementation, a Podfile or Info.plist mistake, a Swift-side issue). Today CI only builds Android, so iOS breakage is invisible until a manual Mac build. This makes the two platforms equal citizens in CI.

## How

- New workflow `.github/workflows/build-ios.yml`, same triggers as the Android build (PRs, master pushes, manual dispatch).
- Runs on a `macos-latest` runner.
- Builds with `flutter build ios --release --no-codesign`, so **no Apple certificates or secrets are needed**. It still compiles the Dart and Swift, runs `pod install`, and links every plugin, which is what catches iOS-only breakage.

Cost note: macOS runners use more Actions minutes than Ubuntu. If that becomes a concern, the triggers can be narrowed later (for example PR-only, or only when files under `mobile/` change). Noted in a comment in the workflow.

## Testing

- The iOS app already builds and runs on a physical iPhone 14 Pro locally, so the same `flutter build ios --no-codesign` is expected to pass on the runner.
- This PR's own CI run exercises the new job end to end.
- Pairs naturally with #138 (the iOS icon + permissions PR); either can merge in any order.
