### PR TITLE
iOS: hide the PayPal donation prompt and tip-jar drawer item

### DIFF
--- a/mobile/lib/features/dashboard/dashboard_screen.dart
+++ b/mobile/lib/features/dashboard/dashboard_screen.dart
@@ -825,19 +825,22 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                         context.push('/settings/app-lock');
                       },
                     ),
-                    ListTile(
-                      leading: const Icon(Icons.coffee_outlined,
-                          color: Colors.amber),
-                      title: Text(l.dashboardBuyMeCoffee),
-                      subtitle: Text(l.dashboardBuyMeCoffeeSubtitle),
-                      onTap: () async {
-                        Navigator.pop(context);
-                        await launchUrl(
-                          Uri.parse(kDonationUrl),
-                          mode: LaunchMode.externalApplication,
-                        );
-                      },
-                    ),
+                    // Hidden on iOS: Apple rejects in-app donation links to
+                    // the developer, so the tip jar is Android-only.
+                    if (Platform.isAndroid)
+                      ListTile(
+                        leading: const Icon(Icons.coffee_outlined,
+                            color: Colors.amber),
+                        title: Text(l.dashboardBuyMeCoffee),
+                        subtitle: Text(l.dashboardBuyMeCoffeeSubtitle),
+                        onTap: () async {
+                          Navigator.pop(context);
+                          await launchUrl(
+                            Uri.parse(kDonationUrl),
+                            mode: LaunchMode.externalApplication,
+                          );
+                        },
+                      ),
 
                     const Divider(),
 
@@ -1227,6 +1230,9 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
   /// [_donationPromptedKey] flag is a first-run flag, so it's excluded from
   /// backups and can't carry over to a fresh install.
   Future<void> _maybeShowDonationPrompt() async {
+    // Apple rejects in-app donation links to the developer, so the first-run
+    // tip-jar nudge is Android-only. (The drawer item is guarded the same way.)
+    if (!Platform.isAndroid) return;
     final prefs = await SharedPreferences.getInstance();
     if (prefs.getBool(_donationPromptedKey) ?? false) return;
     if (PrinterRegistry.instance.printers.isEmpty) return;


### PR DESCRIPTION
## What will this PR change?

On iPhone, the app will no longer show either of the two PayPal "tip jar" prompts: the "Buy me a coffee" item in the side drawer, and the one-time first-run donation popup. Both stay exactly as they are on Android. Nothing else changes.

## Why

Apple's App Store rules forbid in-app links that ask users to donate to the developer (only registered nonprofits may). Leaving the donation prompts visible on iOS is a near-certain rejection at review, so they have to be hidden before the first submission. This clears that blocker from the iOS port plan.

## How

Both donation surfaces live in `dashboard_screen.dart` and are now gated to Android:

- the drawer "Buy me a coffee" `ListTile` is wrapped in `if (Platform.isAndroid)`, so it simply is not built on iOS (the divider stays, so the menu spacing is unchanged)
- `_maybeShowDonationPrompt()` early-returns when not on Android, so the first-run nudge never fires on iOS

This matches the `Platform.isAndroid` pattern already used elsewhere in the same file. No strings, localisation, or Android behaviour are touched.

## Testing

- `flutter analyze` on the changed files: no issues.
- Built `--release` and ran on a real iPhone 14 Pro (iOS 26): the side drawer now goes App lock straight to Settings with no tip-jar row, and the first-run donation popup no longer appears (the app falls through to the notifications prompt instead). Android is unaffected.
