### PR TITLE
iOS: hide the print-notification settings and first-run offer

### DIFF
--- a/mobile/lib/features/dashboard/dashboard_screen.dart
+++ b/mobile/lib/features/dashboard/dashboard_screen.dart
@@ -695,21 +695,26 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                           .set(v),
                     ),
 
-                    const Divider(),
+                    // Print notifications run on an Android foreground service;
+                    // iOS has no equivalent yet, so the whole section (and its
+                    // leading divider) is Android-only — don't offer a feature
+                    // that does nothing on iOS. See docs/ios-port-plan.md.
+                    if (Platform.isAndroid) const Divider(),
 
                     // ── Print notifications ──────────────────────────────────
                     // Opt-in foreground service: live progress + state alerts.
-                    SwitchListTile(
-                      dense: true,
-                      secondary:
-                          const Icon(Icons.notifications_active_outlined),
-                      title: Text(l.printNotifTitle),
-                      subtitle: Text(l.printNotifSubtitle),
-                      value: printNotifications,
-                      onChanged: _togglePrintNotifications,
-                    ),
+                    if (Platform.isAndroid)
+                      SwitchListTile(
+                        dense: true,
+                        secondary:
+                            const Icon(Icons.notifications_active_outlined),
+                        title: Text(l.printNotifTitle),
+                        subtitle: Text(l.printNotifSubtitle),
+                        value: printNotifications,
+                        onChanged: _togglePrintNotifications,
+                      ),
                     // Poll cadence — only relevant while notifications are on.
-                    if (printNotifications) ...[
+                    if (Platform.isAndroid && printNotifications) ...[
                       Padding(
                         padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
                         child: Text(l.notifPollIntervalTitle,
@@ -1243,6 +1248,10 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
   /// install pairs first). Tapping "Turn on" requests the OS permission and
   /// enables the service.
   Future<void> _maybeOfferNotifications() async {
+    // Background print notifications need an Android foreground service; iOS
+    // has no equivalent yet, so never offer them there. (The settings toggle
+    // is hidden on iOS the same way.)
+    if (!Platform.isAndroid) return;
     final prefs = await SharedPreferences.getInstance();
     if (prefs.getBool(_notifPromptedKey) ?? false) return;
     if (PrinterRegistry.instance.printers.isEmpty) return;


### PR DESCRIPTION
## What will this PR change?

On iPhone, the app will no longer show anything about print notifications: the "Print notifications" toggle (and its poll-interval, online-only, and notification-content options) disappears from the side drawer, and the one-time "Get print notifications?" prompt no longer appears. Android is completely unchanged.

## Why

Background print notifications are driven by an Android foreground service. iOS has no equivalent yet (a push backend is the planned future fix), so on iOS the feature simply does nothing. The service already no-ops safely, but the UI still advertised a feature that has no effect on iOS, which is misleading. This hides it until iOS notifications are actually built.

## How

Both surfaces live in `dashboard_screen.dart` and are now gated to Android:

- the whole "Print notifications" settings block, including its leading divider, is wrapped in `if (Platform.isAndroid)`, so on iOS the drawer goes from the camera settings straight to the About section with no gap or orphaned divider
- `_maybeOfferNotifications()` early-returns when not on Android, so the first-run prompt never fires on iOS

This matches the `Platform.isAndroid` pattern already used in this file (and mirrors the donation-prompt guard in #140). No strings, localisation, or Android behaviour are touched, and the notification service logic is left as-is since it already no-ops on iOS.

## Testing

- `flutter analyze` on the changed file: no issues.
- Built `--release` and ran on a real iPhone 14 Pro (iOS 26): the drawer no longer shows the Print notifications toggle or its sub-settings, the camera section flows directly into About with no stray divider, and relaunching no longer triggers the first-run notifications prompt. Android is unaffected.
