### PR TITLE
iOS push notifications (background alerts), behind deploy + Apple account

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -63,7 +63,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running — the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.10"
+MOONGATE_PLUGIN_VERSION = "0.6.11"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -514,6 +514,26 @@ class SupabaseClient:
             "signature":     signature_b64,
         })
 
+    def send_push(
+        self,
+        pi_public_key_b64: str,
+        event: str,
+        detail: str,
+        timestamp: int,
+        signature_b64: str,
+    ) -> tuple[int, dict]:
+        """Tell the cloud a print changed state so it can push a notification
+        to the owner's phone(s). Pi-signed, verified server-side against
+        pi_public_key exactly like the heartbeat. Fires only on real events
+        (start / finish / fail), so it's a trickle, not a poll."""
+        return self._post("/send-push", {
+            "pi_public_key": pi_public_key_b64,
+            "event":         event,
+            "detail":        detail,
+            "timestamp":     timestamp,
+            "signature":     signature_b64,
+        })
+
     def release_pi_signed(
         self,
         pi_public_key_b64: str,
@@ -705,6 +725,111 @@ class HeartbeatLoop:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# PrintEventWatcher — local print-state watch → push notifications
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class PrintEventWatcher:
+    """Polls Moonraker's print_stats locally and, on a meaningful state change
+    (a print starting, finishing, or failing), sends a Pi-signed event to the
+    send-push Edge Function so the printer owner's iPhone gets a background
+    alert.
+
+    Detection is entirely local — we poll our own Moonraker, never the cloud —
+    so the only Supabase call is the one-shot send when an event actually fires
+    (~2 per print, not a continuous stream). Signed with the same Ed25519
+    device key as the heartbeat; the server verifies it identically.
+
+    Unpaired / pre-APNs Pis degrade quietly: the send simply 404s (no printer
+    row server-side), and we log at debug and carry on."""
+
+    # Local poll cadence. A localhost call is cheap, so this is small enough to
+    # catch a finished print promptly without being chatty.
+    _POLL_INTERVAL = 20
+
+    def __init__(self, device: DeviceKey, sb: SupabaseClient, moonraker_port: int = 7125) -> None:
+        self.device = device
+        self.sb     = sb
+        self.port   = moonraker_port
+        self._task: Optional[asyncio.Task] = None
+        # Last print_stats.state we saw. None until the first poll, which only
+        # establishes a baseline — we never fire an event for whatever state
+        # the printer happens to be in when the plugin loads.
+        self._last_state: Optional[str] = None
+
+    def start(self) -> None:
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            logger.warning("No running event loop; print watcher will be deferred")
+            return
+        self._task = loop.create_task(self._run())
+
+    async def _run(self) -> None:
+        loop = asyncio.get_event_loop()
+        while True:
+            try:
+                state, filename = await loop.run_in_executor(None, self._poll_print_state)
+                if state is not None and state != self._last_state:
+                    event = self._event_for(self._last_state, state)
+                    self._last_state = state
+                    if event:
+                        await loop.run_in_executor(None, self._send_event, event, filename)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.warning("Print watcher iteration crashed: %s", exc)
+            try:
+                await asyncio.sleep(self._POLL_INTERVAL)
+            except asyncio.CancelledError:
+                return
+
+    @staticmethod
+    def _event_for(prev: Optional[str], state: str) -> Optional[str]:
+        """Map a print_stats transition to a push event, or None for the ones
+        we don't alert on. prev is None on the first poll (baseline, no event).
+        A user-initiated 'cancelled' is deliberately not alerted in v1, and a
+        'paused' → 'printing' resume is not treated as a fresh start."""
+        if prev is None:
+            return None
+        if state == "printing" and prev != "paused":
+            return "started"
+        if state == "complete":
+            return "completed"
+        if state == "error":
+            return "failed"
+        return None
+
+    def _poll_print_state(self) -> tuple[Optional[str], str]:
+        """Read print_stats.state and .filename from the local Moonraker.
+        Returns (None, "") on any failure so the loop simply skips this tick
+        without disturbing the baseline."""
+        try:
+            url = f"http://127.0.0.1:{self.port}/printer/objects/query?print_stats"
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                data = json.loads(resp.read().decode())
+            ps = data["result"]["status"]["print_stats"]
+            return ps.get("state"), (ps.get("filename") or "")
+        except Exception as exc:
+            logger.debug("print_stats poll failed: %s", exc)
+            return None, ""
+
+    def _send_event(self, event: str, filename: str) -> None:
+        ts        = int(time.time())
+        pk_b64    = self.device.public_key_b64
+        detail    = (filename or "")[:200]
+        canonical = f"moongate-push\n{pk_b64}\n{event}\n{detail}\n{ts}".encode()
+        sig_b64   = self.device.sign_b64(canonical)
+
+        status, body = self.sb.send_push(pk_b64, event, detail, ts, sig_b64)
+        if status in (200, 204):
+            logger.info("Push event '%s' sent", event)
+        elif status == 404:
+            logger.debug("Push event '%s' skipped — printer not paired server-side", event)
+        else:
+            logger.warning("Push event '%s' failed: HTTP %s %s", event, status, body)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # PendingPair — the active enrollment-token session
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -747,6 +872,7 @@ class MoongatePlugin:
             int(self._config["heartbeat_interval_seconds"]),
             on_unpaired_cb=self._on_unpaired,
         )
+        self.watcher   = PrintEventWatcher(self.device, self.sb)
 
         self._pending: Optional[PendingPair]   = None
         self._chamber_key: Optional[str]       = None
@@ -764,9 +890,10 @@ class MoongatePlugin:
         self.server.register_remote_method("moongate_generate_pair_code", self._klipper_pair)
         self.server.register_remote_method("moongate_reset_owner",        self._klipper_reset_owner)
 
-        # Bootstrap JWKS (best effort) and start the heartbeat loop
+        # Bootstrap JWKS (best effort) and start the heartbeat + print-watch loops
         self.jwks.fetch_now()
         self.heartbeat.start()
+        self.watcher.start()
 
         owner_str = (
             f"{self.owner.owner_user_id[:8]}.../{self.owner.printer_id[:8]}..."

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -1,8 +1,13 @@
 import Flutter
 import UIKit
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  // Channel to the Dart push service. Held so the APNs token callback can push
+  // the token back up to Dart, which registers it with the cloud.
+  private var pushChannel: FlutterMethodChannel?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -12,5 +17,59 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    // Push notifications: mirror the Android secure channel. Dart asks for
+    // permission; on grant we register with Apple and, when the APNs device
+    // token arrives, hand it back to Dart over "onToken". We deliberately do
+    // NOT become the UNUserNotificationCenter delegate, so we never clash with
+    // the local-notifications plugin — the device-token callback below is a
+    // UIApplicationDelegate method and fires regardless.
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "MoongatePushChannel") {
+      let channel = FlutterMethodChannel(
+        name: "com.moongate.app/push",
+        binaryMessenger: registrar.messenger()
+      )
+      channel.setMethodCallHandler { [weak self] call, result in
+        self?.handlePushCall(call, result: result)
+      }
+      pushChannel = channel
+    }
+  }
+
+  private func handlePushCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "requestPermission":
+      UNUserNotificationCenter.current().requestAuthorization(
+        options: [.alert, .sound, .badge]
+      ) { granted, _ in
+        if granted {
+          DispatchQueue.main.async {
+            UIApplication.shared.registerForRemoteNotifications()
+          }
+        }
+        result(granted)
+      }
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // APNs handed us a device token — forward it (hex) to Dart to register.
+  override func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+  ) {
+    let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
+    pushChannel?.invokeMethod("onToken", arguments: hex)
+  }
+
+  // Registration failed. Expected on a free Apple account (no aps-environment
+  // entitlement until the paid membership is active); we just log and carry on
+  // — no token means no push, but nothing breaks.
+  override func application(
+    _ application: UIApplication,
+    didFailToRegisterForRemoteNotificationsWithError error: Error
+  ) {
+    NSLog("Moongate: APNs registration failed: \(error.localizedDescription)")
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -10,6 +10,7 @@ import 'services/ota_installer.dart';
 import 'services/print_notification_service.dart';
 import 'services/printer_liveness_service.dart';
 import 'services/printer_registry.dart';
+import 'services/push_notification_service.dart';
 import 'services/supabase_service.dart';
 
 void main() async {
@@ -72,6 +73,12 @@ void main() async {
   // offline printers and skip minting tokens for them — keeping an offline Pi at
   // zero Edge Function cost. No-ops until the anon session lands, then self-starts.
   PrinterLivenessService.instance.start();
+
+  // iOS background push notifications: ask for permission and register this
+  // device's APNs token so the cloud can alert it when a print finishes. iOS
+  // only (Android keeps its foreground-service notifications); a no-op there
+  // and best-effort everywhere (degrades silently without a paid Apple account).
+  PushNotificationService.instance.start();
 
   // Clean up the APK left behind by a previous in-app update. By now its install
   // has finished (or was declined), so the ~80 MB file is just dead weight in

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -1,0 +1,75 @@
+import 'dart:developer' as dev;
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'supabase_service.dart';
+
+/// iOS background push notifications.
+///
+/// Talks to the native side over a MethodChannel (mirroring the app-lock
+/// secure channel): asks the OS for permission, registers with Apple, receives
+/// the APNs device token, and hands it to the register-push-token Edge Function
+/// so the cloud can deliver "print finished / failed" alerts while the app is
+/// closed.
+///
+/// iOS only for now — Android keeps its existing foreground-service
+/// notifications, so this is a no-op there. Everything degrades quietly: with
+/// no paid Apple account the native registration fails (no aps-environment
+/// entitlement), so we simply never receive a token and nothing is sent.
+class PushNotificationService {
+  PushNotificationService._();
+  static final PushNotificationService instance = PushNotificationService._();
+
+  static const MethodChannel _channel = MethodChannel('com.moongate.app/push');
+  final SupabaseService _supabase = SupabaseService.instance;
+
+  // The APNs token can arrive before anonymous sign-in has completed; stash it
+  // and register once we hold a session (the register-push-token call needs the
+  // user's JWT).
+  String? _pendingToken;
+  bool _started = false;
+
+  void _log(String msg) => dev.log(msg, name: 'MOONGATE/PUSH');
+
+  /// Wire up the token callback and ask the OS for notification permission.
+  /// Call once at startup. No-op on Android and after the first call.
+  Future<void> start() async {
+    if (_started || !Platform.isIOS) return;
+    _started = true;
+
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onToken') {
+        final token = call.arguments as String?;
+        if (token != null && token.isNotEmpty) _onToken(token);
+      }
+      return null;
+    });
+
+    // Retry a stashed token the moment a session lands.
+    _supabase.signedIn.addListener(_flushPending);
+
+    try {
+      final granted =
+          await _channel.invokeMethod<bool>('requestPermission') ?? false;
+      _log('Notification permission granted=$granted');
+      // If granted, the native side registers with Apple and calls back
+      // 'onToken' with the device token (handled above).
+    } on PlatformException catch (e) {
+      _log('requestPermission failed: $e');
+    }
+  }
+
+  void _onToken(String token) {
+    _pendingToken = token;
+    _flushPending();
+  }
+
+  void _flushPending() {
+    final token = _pendingToken;
+    if (token == null) return;
+    if (!_supabase.ready) return; // not signed in yet; the listener will retry
+    _pendingToken = null;
+    _supabase.registerPushToken(token: token, platform: 'ios');
+  }
+}

--- a/mobile/lib/services/supabase_service.dart
+++ b/mobile/lib/services/supabase_service.dart
@@ -278,6 +278,31 @@ class SupabaseService {
     _log('Feedback submitted');
   }
 
+  // ── Push notifications ──────────────────────────────────────────────────────
+
+  /// Register (or refresh) this device's push token via the register-push-token
+  /// Edge Function — clients can't write the device_push_tokens table directly
+  /// (same lockdown as every other table here). [platform] is 'ios' or
+  /// 'android'.
+  ///
+  /// Best effort: failures are logged, not thrown. A missing notification is
+  /// never worth disrupting startup, and the app re-registers on the next
+  /// launch anyway.
+  Future<void> registerPushToken({
+    required String token,
+    required String platform,
+  }) async {
+    try {
+      await client.functions.invoke(
+        'register-push-token',
+        body: {'token': token, 'platform': platform},
+      );
+      _log('Push token registered ($platform)');
+    } catch (e) {
+      _log('register-push-token failed (will retry next launch): $e');
+    }
+  }
+
   // ── Backup restore grants ──────────────────────────────────────────────────
 
   /// Mint a single-use restore code for the current identity (called when

--- a/supabase/functions/register-push-token/index.ts
+++ b/supabase/functions/register-push-token/index.ts
@@ -1,0 +1,82 @@
+// POST /functions/v1/register-push-token
+//
+// Stores (or refreshes) the calling device's push-notification token so the
+// send-push function can later deliver "print finished / failed" alerts to it.
+// Verifies the caller's Supabase JWT (anonymous is fine), validates the
+// payload, and upserts one row into public.device_push_tokens via the service
+// role — clients have no direct access to that table (see migration
+// 20260626120000_device_push_tokens).
+//
+// Upsert key is the token itself: re-registering the same device updates its
+// row in place (and re-points it at the current anon user, e.g. after a
+// restore) instead of leaving duplicates. Dead tokens are pruned later by
+// send-push when Apple/Google report them unregistered.
+//
+// Caller MUST present a Supabase JWT (anonymous or otherwise) in the
+// Authorization header.
+//
+// Request body:
+//   {
+//     "token":    "<required, the APNs (iOS) or FCM (Android) token>",
+//     "platform": "ios" | "android"   // required
+//   }
+//
+// Response 200: { "ok": true }
+//
+// Errors:
+//   400 — malformed body / missing token / bad platform
+//   401 — no/invalid JWT
+//   500 — internal
+
+import { handleCorsPreflight } from "../_shared/cors.ts";
+import {
+  jsonResponse, badRequest, unauthorized, methodNotAllowed, internalError,
+} from "../_shared/responses.ts";
+import { adminClient, getUserFromRequest } from "../_shared/supabaseClients.ts";
+
+const MAX_TOKEN = 4096;
+const PLATFORMS = new Set(["ios", "android"]);
+
+Deno.serve(async (req) => {
+  const preflight = handleCorsPreflight(req);
+  if (preflight) return preflight;
+  if (req.method !== "POST") return methodNotAllowed();
+
+  const user = await getUserFromRequest(req);
+  if (!user) return unauthorized();
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return badRequest("invalid_json");
+  }
+
+  const token = typeof body.token === "string" ? body.token.trim() : "";
+  if (token.length === 0 || token.length > MAX_TOKEN) {
+    return badRequest("token required");
+  }
+
+  const platform = typeof body.platform === "string" ? body.platform : "";
+  if (!PLATFORMS.has(platform)) {
+    return badRequest("platform must be ios or android");
+  }
+
+  // Upsert on the token: a device re-registering (or a token that moved to a
+  // new anon identity after a restore) updates in place. created_at keeps its
+  // insert default; updated_at is bumped every time.
+  const db = adminClient();
+  const { error } = await db
+    .from("device_push_tokens")
+    .upsert(
+      { user_id: user.id, token, platform, updated_at: new Date().toISOString() },
+      { onConflict: "token" },
+    );
+
+  if (error) {
+    console.error("device_push_tokens upsert error", error);
+    return internalError();
+  }
+
+  return jsonResponse({ ok: true });
+});

--- a/supabase/functions/send-push/apns.ts
+++ b/supabase/functions/send-push/apns.ts
@@ -1,0 +1,142 @@
+// Apple Push Notification service (APNs) sender, provider-token (JWT) auth.
+//
+// This is the "final hop" to an iPhone: every background alert to a closed app
+// must go through Apple. We talk to APNs directly over HTTP/2 with a JWT signed
+// by the team's APNs auth key (.p8). No Firebase, no third party.
+//
+// All credentials come from Supabase function secrets (set with
+// `supabase secrets set ...`), never committed and never on the Pi:
+//   MOONGATE_APNS_KEY_P8    the .p8 key contents (PEM, "-----BEGIN PRIVATE KEY----- ...")
+//   MOONGATE_APNS_KEY_ID    the 10-char Key ID for that .p8
+//   MOONGATE_APNS_TEAM_ID   the 10-char Apple Team ID
+//   MOONGATE_APNS_BUNDLE_ID the app bundle id, used as apns-topic (com.moongate.app.moongate)
+//   MOONGATE_APNS_HOST      optional; defaults to api.push.apple.com
+//                           (use api.sandbox.push.apple.com for dev builds)
+//
+// NOTE: untestable end to end until the $99 Apple Developer account exists
+// (the .p8 key is issued there). The structure follows Apple's documented
+// provider API; we verify against a real device once the account is active.
+
+import { base64ToBytes } from "../_shared/cryptoUtils.ts";
+
+const DEFAULT_HOST = "api.push.apple.com";
+
+// APNs JWTs are valid up to 60 min and Apple rejects regenerating them too
+// often, so we sign once and reuse for ~50 min.
+const TOKEN_TTL_MS = 50 * 60 * 1000;
+
+interface CachedToken {
+  jwt: string;
+  mintedAt: number;
+}
+let cached: CachedToken | null = null;
+
+function env(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`missing secret ${name}`);
+  return v;
+}
+
+function base64UrlFromBytes(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlFromString(s: string): string {
+  return base64UrlFromBytes(new TextEncoder().encode(s));
+}
+
+// Pull the base64 DER out of a PEM ".p8" and import it as an ECDSA P-256
+// private key for signing.
+async function importP8(pem: string): Promise<CryptoKey> {
+  const der = pem
+    .replace(/-----BEGIN [^-]+-----/, "")
+    .replace(/-----END [^-]+-----/, "")
+    .replace(/\s+/g, "");
+  return await crypto.subtle.importKey(
+    "pkcs8",
+    base64ToBytes(der),
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+}
+
+// Mint (or reuse) the APNs provider JWT: header {alg:ES256, kid}, payload
+// {iss:teamId, iat}. Signature is raw r||s, which is exactly ES256.
+async function providerToken(): Promise<string> {
+  const now = Date.now();
+  if (cached && now - cached.mintedAt < TOKEN_TTL_MS) return cached.jwt;
+
+  const keyId = env("MOONGATE_APNS_KEY_ID");
+  const teamId = env("MOONGATE_APNS_TEAM_ID");
+  const key = await importP8(env("MOONGATE_APNS_KEY_P8"));
+
+  const header = base64UrlFromString(JSON.stringify({ alg: "ES256", kid: keyId }));
+  const payload = base64UrlFromString(
+    JSON.stringify({ iss: teamId, iat: Math.floor(now / 1000) }),
+  );
+  const signingInput = `${header}.${payload}`;
+
+  const sig = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      key,
+      new TextEncoder().encode(signingInput),
+    ),
+  );
+
+  const jwt = `${signingInput}.${base64UrlFromBytes(sig)}`;
+  cached = { jwt, mintedAt: now };
+  return jwt;
+}
+
+export interface ApnsResult {
+  ok: boolean;
+  // true when APNs says this token is permanently dead (410 Unregistered, or
+  // 400 BadDeviceToken) so the caller can prune it.
+  unregistered: boolean;
+  status: number;
+  reason?: string;
+}
+
+export interface ApnsAlert {
+  title: string;
+  body: string;
+}
+
+// Deliver one alert to one device token.
+export async function sendApns(deviceToken: string, alert: ApnsAlert): Promise<ApnsResult> {
+  const host = Deno.env.get("MOONGATE_APNS_HOST") || DEFAULT_HOST;
+  const topic = env("MOONGATE_APNS_BUNDLE_ID");
+  const jwt = await providerToken();
+
+  const res = await fetch(`https://${host}/3/device/${deviceToken}`, {
+    method: "POST",
+    headers: {
+      "authorization": `bearer ${jwt}`,
+      "apns-topic": topic,
+      "apns-push-type": "alert",
+      "apns-priority": "10",
+    },
+    body: JSON.stringify({
+      aps: { alert: { title: alert.title, body: alert.body }, sound: "default" },
+    }),
+  });
+
+  if (res.status === 200) {
+    await res.body?.cancel();
+    return { ok: true, unregistered: false, status: 200 };
+  }
+
+  let reason = "";
+  try {
+    reason = ((await res.json()) as { reason?: string }).reason ?? "";
+  } catch {
+    // no/!json body
+  }
+  const unregistered = res.status === 410 || reason === "BadDeviceToken" ||
+    reason === "Unregistered";
+  return { ok: false, unregistered, status: res.status, reason };
+}

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -1,0 +1,153 @@
+// POST /functions/v1/send-push
+//
+// Called by the Pi (Moongate plugin) when a print changes state. Delivers a
+// background notification to the printer owner's iPhone(s) via Apple's APNs.
+// Android is intentionally not handled here yet (it keeps its existing
+// foreground-service notifications); the device_push_tokens platform column
+// lets Android join later without touching this contract.
+//
+// Auth model: identical to printer-heartbeat. The Pi has no Supabase user; it
+// signs a canonical payload with its Ed25519 device key, and we look the
+// printer up by pi_public_key and verify. Replay is bounded by a 60s window.
+//
+// Request body:
+//   {
+//     "pi_public_key": "<base64 Ed25519 pubkey>",
+//     "event":         "started" | "completed" | "failed",
+//     "detail":        "<optional, e.g. the gcode filename>",
+//     "timestamp":     <unix seconds>,
+//     "signature":     "<base64 Ed25519 signature over canonical payload>"
+//   }
+//
+// Canonical payload (UTF-8 bytes signed by Pi):
+//   "moongate-push\n" + pi_public_key + "\n" + event + "\n" + detail + "\n" + timestamp
+//
+// Response 204 on success (including "owner has no iOS devices" — nothing to do
+// is still success). Errors mirror printer-heartbeat: 400 / 401 / 404 / 500.
+
+import { handleCorsPreflight } from "../_shared/cors.ts";
+import {
+  emptyResponse, badRequest, unauthorized, notFound,
+  methodNotAllowed, internalError,
+} from "../_shared/responses.ts";
+import { adminClient } from "../_shared/supabaseClients.ts";
+import { verifyEd25519, base64ToBytes } from "../_shared/cryptoUtils.ts";
+import { sendApns, ApnsAlert } from "./apns.ts";
+
+const REPLAY_WINDOW_SECONDS = 60;
+const MAX_DETAIL = 200;
+const EVENTS = new Set(["started", "completed", "failed"]);
+
+// Server-side message text. English for v1; APNs loc-keys can localise this
+// later against the app's iOS strings without changing the signed contract.
+function buildAlert(event: string, printerName: string, detail: string): ApnsAlert {
+  const base = event === "started"
+    ? "Print started"
+    : event === "completed"
+    ? "Print finished"
+    : "Print failed";
+  return { title: printerName, body: detail ? `${base}: ${detail}` : base };
+}
+
+Deno.serve(async (req) => {
+  const preflight = handleCorsPreflight(req);
+  if (preflight) return preflight;
+  if (req.method !== "POST") return methodNotAllowed();
+
+  let body: {
+    pi_public_key?: unknown;
+    event?:         unknown;
+    detail?:        unknown;
+    timestamp?:     unknown;
+    signature?:     unknown;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return badRequest("invalid_json");
+  }
+
+  const piPubKey  = body.pi_public_key;
+  const event     = body.event;
+  const timestamp = body.timestamp;
+  const signature = body.signature;
+  // detail is optional; normalise to a capped string (also part of the signed
+  // payload, so "" must be signed when absent).
+  const detail = typeof body.detail === "string" ? body.detail.slice(0, MAX_DETAIL) : "";
+
+  if (typeof piPubKey !== "string") return badRequest("pi_public_key required");
+  if (typeof event !== "string" || !EVENTS.has(event)) {
+    return badRequest("event must be started, completed, or failed");
+  }
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    return badRequest("timestamp required (unix seconds)");
+  }
+  if (typeof signature !== "string") return badRequest("signature required");
+
+  try {
+    if (base64ToBytes(piPubKey).length !== 32) {
+      return badRequest("pi_public_key must decode to 32 bytes");
+    }
+  } catch {
+    return badRequest("invalid pi_public_key base64");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > REPLAY_WINDOW_SECONDS) return unauthorized();
+
+  const canonical = `moongate-push\n${piPubKey}\n${event}\n${detail}\n${timestamp}`;
+  const message   = new TextEncoder().encode(canonical);
+  if (!(await verifyEd25519(piPubKey, signature, message))) return unauthorized();
+
+  const db = adminClient();
+
+  // Look the printer (and its owner) up by the verified key.
+  const { data: printer, error: pErr } = await db
+    .from("printers")
+    .select("owner_user_id, name")
+    .eq("pi_public_key", piPubKey)
+    .is("revoked_at", null)
+    .maybeSingle();
+  if (pErr) {
+    console.error("printer lookup error", pErr);
+    return internalError();
+  }
+  if (!printer) return notFound(); // unpaired / revoked — Pi should re-pair
+
+  // Fetch the owner's iOS device tokens.
+  const { data: rows, error: tErr } = await db
+    .from("device_push_tokens")
+    .select("token")
+    .eq("user_id", printer.owner_user_id)
+    .eq("platform", "ios");
+  if (tErr) {
+    console.error("token lookup error", tErr);
+    return internalError();
+  }
+  if (!rows || rows.length === 0) return emptyResponse(204); // nobody to notify
+
+  const alert = buildAlert(event, printer.name, detail);
+
+  // Deliver to each token; collect any APNs says are permanently dead.
+  const dead: string[] = [];
+  await Promise.all(rows.map(async ({ token }) => {
+    try {
+      const r = await sendApns(token as string, alert);
+      if (r.unregistered) dead.push(token as string);
+      else if (!r.ok) console.error("apns send failed", r.status, r.reason);
+    } catch (e) {
+      console.error("apns send threw", e);
+    }
+  }));
+
+  // Prune dead tokens so we stop wasting sends on them.
+  if (dead.length > 0) {
+    const { error: dErr } = await db
+      .from("device_push_tokens")
+      .delete()
+      .in("token", dead);
+    if (dErr) console.error("token prune error", dErr);
+  }
+
+  return emptyResponse(204);
+});

--- a/supabase/migrations/20260626120000_device_push_tokens.sql
+++ b/supabase/migrations/20260626120000_device_push_tokens.sql
@@ -1,0 +1,65 @@
+-- Moongate — device push-notification tokens.
+--
+-- Backs background push notifications (iPhone first; the column is platform-
+-- tagged so Android can join later without a schema change). Each phone that
+-- opts in registers its delivery token here, and the send-push Edge Function
+-- looks up a printer owner's tokens to deliver "print finished / failed"
+-- alerts straight to Apple's APNs (and later Google's FCM).
+--
+-- Consistent with the rest of the schema (see 20260526120000_v03_initial and
+-- 20260609120000_feedback):
+--   • Clients NEVER write directly. The register-push-token Edge Function
+--     (service role) upserts rows; ALL privileges are revoked from
+--     anon/authenticated and no client RLS policy is defined.
+--   • user_id is the anonymous owner. ON DELETE CASCADE — a token is useless
+--     once its anon identity is cleaned up by the orphan sweep, so it goes
+--     with it (unlike feedback, whose text we deliberately keep).
+--   • token is UNIQUE: a given device token maps to exactly one row, so a
+--     re-registration (or a token moving to a new anon user after a restore)
+--     upserts in place instead of leaving duplicates. Dead tokens are pruned
+--     by send-push when Apple/Google report them unregistered.
+--
+-- Idempotent (IF NOT EXISTS). Safe to re-run.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.device_push_tokens (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token       text NOT NULL UNIQUE,
+  platform    text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT device_push_tokens_platform_chk CHECK (platform IN ('ios', 'android')),
+  CONSTRAINT device_push_tokens_token_len     CHECK (char_length(token) BETWEEN 1 AND 4096)
+);
+
+COMMENT ON TABLE public.device_push_tokens IS
+  'Per-device push tokens for background notifications. Written ONLY by the register-push-token Edge Function (service role); read by send-push to target a printer owner''s devices. platform is ios/android (iOS shipped first). user_id is the anon owner (CASCADE: tokens die with the throwaway identity).';
+COMMENT ON COLUMN public.device_push_tokens.token IS
+  'APNs token (iOS) or FCM token (Android). Opaque delivery address from the OS; unique per device+install.';
+
+-- ============================================================================
+-- 2. INDEX
+-- ============================================================================
+
+-- send-push looks tokens up by owner.
+CREATE INDEX IF NOT EXISTS device_push_tokens_user_idx
+  ON public.device_push_tokens (user_id);
+
+-- ============================================================================
+-- 3. ROW-LEVEL SECURITY  (locked down exactly like printers/feedback)
+-- ============================================================================
+
+ALTER TABLE public.device_push_tokens ENABLE ROW LEVEL SECURITY;
+
+-- No policy on purpose: with RLS enabled and no policy, anon/authenticated can
+-- do nothing here. The service role used by the Edge Functions bypasses RLS.
+-- Belt-and-braces REVOKE in case a future default-privilege grant leaks in.
+REVOKE ALL ON public.device_push_tokens FROM anon, authenticated;
+
+COMMIT;


### PR DESCRIPTION
## What will this PR change?

Adds the full pipeline for **background push notifications on iPhone** (print started / finished / failed), built on one backend (Supabase) sending straight to Apple's APNs. Nothing on Android changes. The code is complete but **dormant until two activation steps happen** (deploy + the paid Apple account), so merging it is safe and changes no current behaviour.

See `docs/push-notifications-plan.md` for the design.

## Why

Notifications were the number one request on Android, so iPhone users will expect them, and shipping iOS without them risks early negative reviews.

## How (the four pieces)

1. **`device_push_tokens` table** (migration) — one row per opted-in device, ios/android tagged, locked down like every other table (service-role writes only).
2. **`register-push-token` function** — the only writer; the app posts its token here (JWT-verified, upsert on token).
3. **`send-push` function** — receives a **Pi-signed** print event (verified exactly like the heartbeat), looks up the owner's iOS tokens, and delivers straight to APNs over HTTP/2 with a provider JWT from the `.p8` key (all APNs secrets live in Supabase function secrets). Prunes tokens Apple reports dead.
4. **Plugin watcher** (`moongate_standalone.py`) — polls `print_stats` locally and fires a signed event on start/finish/fail. Detection is entirely local, so the only cloud call is the one-shot send (~2 per print). Plugin 0.6.10 → 0.6.11.
5. **App registration** — a native push MethodChannel (mirrors the Android secure channel) gets the APNs token; the Dart `PushNotificationService` registers it. iOS only; Android is a no-op.

## What is deliberately NOT here

No push entitlement is wired into the Xcode build. That needs the paid Apple account and would break the current free-account builds. Without it, registration fails gracefully (logged, no token, no push). This keeps everything mergeable and the existing iOS build working.

## Testing

- `flutter analyze` on all changed Dart: clean.
- Plugin: `python3 -m py_compile` clean; transition logic reasoned through (boot-while-printing sets a baseline with no false "started"; pause/resume and user-cancel don't alert; complete/error map to finish/fail).
- iOS `flutter build ios --release`: still builds and signs on the **free** account with the native changes in place.
- **Not yet tested:** actual APNs delivery to a device — that needs the paid account's `.p8` key.

## To activate (later, not in this PR)

1. Apply the migration and deploy `register-push-token` + `send-push` to Supabase.
2. Enrol the $99 Apple Developer account; create an APNs `.p8` key; set the `MOONGATE_APNS_*` Supabase secrets.
3. Enable the Push Notifications capability in Xcode and test on the real iPhone.
4. Roll the 0.6.11 plugin to a test printer.
