### PR TITLE
iOS: don't surface the Android APK self-updater

### DIFF
--- a/mobile/lib/services/update_service.dart
+++ b/mobile/lib/services/update_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -27,6 +28,13 @@ class UpdateService {
       'https://raw.githubusercontent.com/PEEKYPAUL/moongate/master/APK/latest_version.json';
 
   Future<UpdateInfo?> checkForUpdate() async {
+    // Android only: this self-update path tracks the GitHub APK build. On iOS
+    // the App Store handles updates, and the manifest's build number / apk_url
+    // refer to the Android build — surfacing them on an iPhone is meaningless
+    // (you can't install an APK) and pointing users at an off-store download is
+    // an App Store review risk. Returning null suppresses the update banner and
+    // the in-app updater on iOS; the "What's new" changelog still shows.
+    if (!Platform.isAndroid) return null;
     try {
       final info          = await PackageInfo.fromPlatform();
       final installedBuild = int.tryParse(info.buildNumber) ?? 0;


### PR DESCRIPTION
## What will this PR change?

On iPhone, the app will no longer show the "update available" banner or the in-app updater. Those track the GitHub **APK** build and offer to download/install an Android `.apk`, which an iPhone can't use. The "What's new" changelog still shows on iOS. Android is unchanged.

## Why

Two problems on iOS today:
1. **Broken UX** — `checkForUpdate()` compares the iOS build against `APK/latest_version.json` (the Android build) and, if "newer", shows a banner whose Update button opens an `.apk` URL in a browser. You can't install an APK on iOS.
2. **App Store review risk** — Apple expects updates to come from the App Store; an in-app "update available, download here" pointing off-store is a rejection risk.

## How

`UpdateService.checkForUpdate()` returns null on non-Android. That suppresses the banner and the in-app updater in one place (downstream UI is already guarded by `if (update != null)`), while the platform-neutral "What's new" changelog still renders. Found during an iOS-readiness audit ahead of the App Store submission.

## Testing

- `flutter analyze`: clean.
- Logic: on iOS the provider resolves to null, so `_UpdateBanner`, the update action buttons in the notes dialog, and `_startInAppUpdate` are never reached; the changelog dialog still shows. Android path untouched.
