### PR TITLE
docs: privacy policy + App Store privacy answers

### DIFF
--- a/docs/app-store-privacy.md
+++ b/docs/app-store-privacy.md
@@ -1,0 +1,81 @@
+# App Store submission — privacy answers and reviewer notes
+
+Companion to `docs/privacy-policy.md`. This maps what the app actually does to
+Apple's **App Privacy** questionnaire in App Store Connect, plus the **review
+notes** to head off rejections. Grounded in a code audit (see
+`diagnostics_service.dart`, `supabase_service.dart`, the Supabase functions, and
+the dependency list — no analytics/ads/tracking SDKs are present).
+
+## Key facts that shape the answers
+
+- Sign-in is **anonymous** (a random UUID); no name/email/password.
+- The **only** data sent off-device that contains device/network details is the
+  **opt-in bug report** — nothing is transmitted unless the user taps Submit.
+- There are **no analytics, advertising, or tracking SDKs**. Nothing is used to
+  track across apps/sites → **no App Tracking Transparency prompt is required**,
+  and "Used to Track You" is **No** for every data type.
+- "Collect" (Apple's meaning) = transmitted off the device. On-device-only
+  items (settings, app-lock PIN hash, biometrics, the QR camera, custom
+  background image) are **not** "collected".
+
+## App Privacy questionnaire — recommended answers
+
+Mark these as **Collected**, **Linked to the user** (everything ties to the
+anonymous account id), **Not used for tracking**:
+
+| Data type (Apple category) | What it is | Purpose | When |
+|---|---|---|---|
+| Identifiers → User ID | the anonymous account UUID | App Functionality | always |
+| Identifiers → Device ID | the iOS push (APNs) token | App Functionality (notifications) | only if notifications enabled |
+| Contact Info → Email Address | the optional "contact" field in a bug report | App Functionality / Support | only if the user types one |
+| User Content → Customer Support | the bug-report comment text | App Functionality / Support | only if a report is sent |
+| Diagnostics → Other Diagnostic Data | device model/OS, app version, local network addresses, printer connection diagnostics in a bug report | App Functionality / Support | only if a report is sent |
+| Other Data | printer names and their local addresses (setup + bug reports) | App Functionality | setup; and in a report |
+
+Everything else → **Not Collected**: Health, Financial, Precise/Coarse
+Location, Sensitive Info, Contacts, Browsing/Search History, Purchases, Usage
+Data (no analytics), Audio, Photos, etc.
+
+### Note on IP address
+Apple's questionnaire has no explicit "IP address" type. Our providers
+(Supabase/Cloudflare) log IPs **only** for security, abuse-prevention, and
+operations. Data collected solely for those purposes is exempt from the
+"collected" disclosure, so it is **not** declared as a collected data type — but
+it **is** disclosed in the privacy policy (section 1.5) for transparency.
+
+## Account deletion (Guideline 5.1.1(v)) — DECISION NEEDED
+
+Apps that "support account creation" must offer in-app account/data deletion.
+Moongate creates an **anonymous** backend account, which is a grey area, but
+review can be strict. Today, data is removed by deleting printers + uninstalling
+(the anonymous identity is then auto-cleaned after inactivity).
+
+**Recommendation (low risk path):** add a simple in-app **"Delete my data"**
+action that deletes the current anonymous user's records (printers, push tokens)
+and clears the local session. It is a small, self-contained feature and removes
+this as a possible rejection reason. Decide before submission.
+
+## Reviewer notes (paste into App Review Information → Notes)
+
+> Moongate is a self-hosted 3D-printer dashboard. It connects to the user's own
+> Raspberry Pi running Klipper/Moonraker.
+>
+> - **Sign-in is anonymous** — no account, email, or password. An anonymous id
+>   is created automatically so the user's own printers can be associated with
+>   their install.
+> - **Local Network** permission is used to discover (Bonjour/mDNS,
+>   `_moongate._tcp`) and connect directly to the user's printer on their Wi-Fi.
+>   Without it, only the remote (tunnel) path works.
+> - **Camera** is used only to scan the pairing QR code.
+> - **Notifications** are opt-in and report the user's own print status.
+> - No analytics, advertising, or tracking. No data is sold or shared for third-
+>   party purposes.
+> - To test without hardware: [provide a demo path, or a paired test printer the
+>   reviewer can reach — TBD before submission].
+
+## Still to do before submission
+- [ ] Host `privacy-policy.md` at a public URL and put it in App Store Connect (and in the app/README).
+- [ ] Fill the controller name, contact email, and effective date placeholders in the policy.
+- [ ] Decide on the in-app "Delete my data" action (account-deletion guideline).
+- [ ] Confirm the retention periods in the policy against the live cleanup cron.
+- [ ] Provide a reviewer demo path (a reachable test printer, or screenshots/video) since the app needs real hardware.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,182 @@
+# Moongate Privacy Policy
+
+**Effective date:** _[EFFECTIVE DATE — set on publish]_
+**Last updated:** _[EFFECTIVE DATE]_
+
+Moongate ("the app", "we", "us") is a free, open-source app for monitoring and
+controlling your own Klipper/Moonraker 3D printers from your phone. This policy
+explains exactly what data the app handles, why, where it goes, and your
+choices. It is written to be accurate to what the app actually does — nothing
+more is collected than is described here.
+
+**Data controller:** _[CONTROLLER NAME — the developer/individual or entity]_
+**Contact:** _[CONTACT EMAIL]_
+
+---
+
+## The short version
+
+- We do **not** show ads, and we do **not** use any analytics, advertising, or
+  tracking SDKs. The app does not track you across other apps or websites.
+- We do **not** sell, rent, or share your personal data with anyone for their
+  own purposes.
+- You sign in **anonymously**. We never ask for your name, email, or a password
+  to use the app.
+- Most of what the app does happens **directly between your phone and your own
+  printer** (over your local network or an encrypted tunnel). Our servers broker
+  the connection; they are not in the path of your camera feed or print files in
+  a way that stores them.
+- The only time we receive details about your device or network is if **you
+  choose to send a bug report**.
+
+---
+
+## 1. Information the app handles
+
+### 1.1 Anonymous account identifier
+To remember which printers are yours, the app signs you in **anonymously** with
+our backend (Supabase) the first time it launches. This creates a random
+identifier (a UUID). It contains **no** name, email, phone number, or password,
+and it is not linked to your real-world identity. The session is stored securely
+on your device (iOS Keychain / Android Keystore).
+
+### 1.2 Printer setup data
+When you pair a printer, we store, associated with your anonymous identifier:
+- a **printer name** you choose;
+- the printer's (Raspberry Pi's) **public key**, used to verify it;
+- the printer's current remote-access (Cloudflare tunnel) URL, stored
+  **encrypted**;
+- a "last seen" timestamp.
+
+This is the minimum needed to reconnect you to your own printers from anywhere.
+
+### 1.3 Bug reports (only if you choose to send one)
+The app has an optional "Report a problem" feature. **Nothing is sent unless you
+tap to submit a report.** If you do, the report includes:
+- the **comment** you write, and any **contact detail you choose to add** (for
+  example an email, so we can reply — this is optional and entirely up to you);
+- your **device model and operating-system version**, and the **app version**;
+- your phone's **local (private) network addresses** and whether you appear to
+  be on a private network — used to diagnose connection problems;
+- your **printer names and their local addresses**, the results of local
+  printer discovery, and connection status;
+- your **anonymous identifier** (to correlate the report with your printer
+  records).
+
+This information exists to make pairing and connection failures diagnosable. It
+is sent to our backend and stored so we can investigate the issue.
+
+### 1.4 Push notification token (iOS, if you enable notifications)
+If you turn on print notifications on iOS, your device registers with Apple and
+we store the resulting **push token**, associated with your anonymous
+identifier, so our backend can send you alerts when a print starts, finishes, or
+fails. The token is a delivery address for your device; it is not your identity.
+
+### 1.5 Automatically logged technical data
+Like most internet services, our backend providers (Supabase and Cloudflare)
+automatically record standard technical request logs — including your device's
+**IP address** — for security, abuse prevention, and operational reliability.
+These logs are short-lived and are not used to build a profile of you or to
+track you across other services.
+
+### 1.6 Information that never leaves your device
+The following are kept **only on your device** and are never transmitted to us:
+- your **app-lock PIN** (stored only as a salted hash) and biometric unlock
+  (Face ID / Touch ID / fingerprint is handled entirely by your operating
+  system; we never see your biometric data);
+- your **settings** (theme, layout, language, poll interval, and similar) and
+  any **custom dashboard background image** you pick;
+- the **camera**, which is used only to scan a pairing QR code; images are
+  processed on-device and not stored or transmitted.
+
+## 2. How your printer data flows
+
+Moongate is a "middleman" for remote access, not a data warehouse:
+- On your **local network**, the app talks **directly** to your printer.
+- **Remotely**, the app reaches your printer through a **Cloudflare tunnel** the
+  printer itself opens. Our backend's role is to hand your app the current
+  (encrypted) tunnel address and a short-lived access token; the actual printer
+  status, **webcam feed, and print files travel between your phone and your
+  printer**, not into our storage.
+
+## 3. Who processes data on our behalf
+
+We rely on a small number of service providers. We do not sell data to anyone,
+and none of these are advertising or data-broker services:
+
+- **Supabase** — our backend: anonymous sign-in, the database of your printers,
+  bug reports, and push tokens, and the server functions that broker access.
+- **Cloudflare** — provides the secure tunnel that carries traffic between your
+  phone and your printer for remote access.
+- **Apple Push Notification service** — delivers print notifications to your
+  iPhone (only if you enable notifications). The notification content is limited
+  to your printer's name and print status.
+- **GitHub** — on **Android only**, the app fetches a small file to check
+  whether a newer version is available; this reveals your device's IP address to
+  GitHub as part of an ordinary web request. (On iOS, updates come from the App
+  Store and this check is not performed.)
+
+These providers may process and store data on servers located in other
+countries, including outside your own. Where this involves transferring personal
+data internationally, it is done under the providers' own data-protection
+safeguards.
+
+## 4. Permissions we request and why
+
+- **Camera** — to scan the pairing QR code. Nothing else.
+- **Local network** (iOS) — to discover and connect directly to printers on your
+  Wi-Fi.
+- **Notifications** (iOS) — only if you opt in to print notifications.
+- **Face ID / Touch ID / biometrics** — only if you turn on the optional app
+  lock; authentication is performed by your operating system.
+
+## 5. How long we keep data
+
+- **Inactive anonymous identities and their printer records** are deleted
+  automatically after a period of inactivity (currently around six weeks).
+- **Unpaired/removed printers** are permanently deleted shortly after removal
+  (within about a week).
+- **Bug reports** are retained so we can investigate and track issues; tell us
+  (using the contact above) if you want a report you submitted deleted.
+- **Local data** on your device remains until you delete it or uninstall the app.
+
+## 6. Your choices and rights
+
+Because we don't collect your name or email, most data is tied only to an
+anonymous identifier. You can:
+- **Stop all remote data** by removing your printers and/or uninstalling the app;
+  uninstalling removes the local session, and your anonymous identity and its
+  records are then cleaned up automatically (see retention above).
+- **Disable notifications** at any time in the app's menu.
+- **Decline or revoke permissions** (camera, local network, notifications) in
+  your device settings; some features will simply stop working.
+
+Depending on where you live (for example under the EU/UK GDPR or California's
+CCPA), you may have rights to access, correct, or delete personal data and to
+object to processing. Because submitted bug reports are the main place free-text
+or contact details might appear, contact us at the address above to exercise
+these rights and we will act on requests we can verify.
+
+## 7. Children
+
+Moongate is a tool for operating 3D-printing hardware and is not directed to
+children. We do not knowingly collect personal data from children.
+
+## 8. Security
+
+- All client access is scoped by database row-level security so you can only
+  reach your own records.
+- The printer's remote-access URL is stored **encrypted**, and printers
+  authenticate to the backend with a per-device cryptographic key.
+- Your session and app-lock secret are held in your device's secure storage.
+- The app's source is public, so these claims can be independently verified.
+
+## 9. Changes to this policy
+
+If we change what data the app handles, we will update this policy and its
+effective date. Material changes will be noted in the app's release notes.
+
+## 10. Contact
+
+Questions or requests about this policy or your data:
+_[CONTACT EMAIL]_


### PR DESCRIPTION
## What will this PR change?

Adds two documents, no code. `docs/privacy-policy.md` is the public privacy policy (a public URL for it is mandatory to submit to the App Store). `docs/app-store-privacy.md` is the companion that maps the app to Apple's App Privacy questionnaire and gives reviewer notes.

## Why

The App Store requires an accurate privacy policy URL, and Apple cross-checks the policy against actual app behaviour. Both were written from a code audit, not assumptions.

## What the audit found (and the policy reflects)

- Sign-in is anonymous (random UUID), no name/email/password.
- The only device/network details sent off-device come from the **opt-in bug report** (nothing unless the user submits one).
- **No analytics, ads, or tracking SDKs anywhere** → "Used to track you: No" for every data type, and no App Tracking Transparency prompt needed.
- Processors: Supabase, Cloudflare (tunnel), Apple (push), GitHub (Android update check). No data sold or shared for third-party purposes.
- Providers log IP for security/ops (disclosed in the policy; exempt from the "collected" nutrition-label declaration).

## Decisions still needed (placeholders in the docs)

- Controller name, contact email, effective date.
- Where to host the policy (e.g. GitHub Pages).
- Whether to add an in-app "Delete my data" action for Apple's account-deletion guideline (5.1.1(v)) — recommended.
- Confirm the retention periods against the live cleanup cron.
