### PR TITLE
deps: bump package_info_plus + path_provider (hold the risky 3)

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -261,10 +261,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "825aec673606875c33cd8d3c4083f1a3c3999015a84178b317b7ef396b7384f3"
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.7"
+    version: "8.3.7"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -689,10 +689,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -721,10 +721,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -1182,18 +1182,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "3.0.3"
   webview_flutter:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   shared_preferences: ^2.2.0
 
   # App version info (reads version from the installed package manifest)
-  package_info_plus: ^8.0.0
+  package_info_plus: ^9.0.1
 
   # Device model + Android version for the in-app bug-report diagnostics.
   # This project's bugs skew heavily Samsung / One UI, so the exact model is
@@ -86,7 +86,7 @@ dependencies:
   # Custom dashboard background: copy the user-picked image into the app's
   # documents directory so it persists across launches (file_picker only hands
   # back a cache path the OS may evict). Path lookup only, no permissions.
-  path_provider: ^2.1.0
+  path_provider: ^2.1.6
 
   # App lock: biometric (fingerprint/face) prompt. MainActivity already
   # extends FlutterFragmentActivity, which local_auth requires on Android,


### PR DESCRIPTION
## What will this PR change?

Takes only the **safe** subset of Dependabot #155 (which failed CI). No user-facing change; dependency hygiene. #155 can be closed in favour of this.

| Package | From | To | Status |
|---|---|---|---|
| `package_info_plus` | 8.0.0 | 9.0.1 | bumped |
| `path_provider` | 2.1.0 | 2.1.6 | bumped |
| `device_info_plus` | 10.1.0 | 10.1.2 | auto patch, stays on 10.x |
| `device_info_plus` (12.x) | — | — | **held** |
| `supabase_flutter` (2.15) | — | — | **held** |
| `file_picker` (11.x) | — | — | **held** |

## Why these three are held

- **`file_picker` 8 → 11** removes the `FilePicker.platform` getter, breaking 3 core call sites (backup save `dashboard_screen.dart:984`, backup restore `printer_registry.dart:154`, theme-image import `custom_theme_screen.dart:602`). That migration touches backup/restore + theming and needs on-device testing, so it gets its own change.
- **`device_info_plus` 12** — its iOS plugin calls `NSProcessInfo.isiOSAppOnVision`, which the CI runner's Xcode SDK doesn't declare, so the **iOS build fails** (it builds fine on local Xcode 26.5; the real fix is bumping CI's Xcode image, tracked separately).
- **`supabase_flutter` 2.15** transitively pulls the `passkeys` native stack (`passkeys_doctor`), which we don't use and which **forces `device_info_plus` ≥ 11.2.0**, dragging in the iOS-SDK problem above.

## How / testing

On the full 5-bump set: Android release build + analyze were **green**; only the **iOS build** failed, isolated cleanly to `device_info_plus` 12. This PR keeps the two unaffected bumps. `flutter analyze`: no issues. CI on this PR is the authoritative check for both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)