### PR TITLE
fix: pin device_info_plus at 10.x - 12.x breaks the iOS build

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.0"
+    version: "10.1.2"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -425,10 +425,10 @@ packages:
     dependency: transitive
     description:
       name: functions_client
-      sha256: f3304ca860169f2e8acc5eceb0cd5d788cdac9551497b8326313a8130c14f24e
+      sha256: "5b17b8dcf5ae1cd6a6428e7a4ca8b569477297a7f158955b5407dda23baeaa5b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.6.3"
   glob:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: gotrue
-      sha256: a6120dee1e77d0e31a788d3db761c4ae514be8a9662beec0b7c883e74e391091
+      sha256: "54e8abe49c8596234c503f4b64d07022c7913a6475c7a85c1f1eacc1a93af166"
       url: "https://pub.dev"
     source: hosted
-    version: "2.22.0"
+    version: "2.24.0"
   gtk:
     dependency: transitive
     description:
@@ -709,62 +709,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
-  passkeys:
-    dependency: transitive
-    description:
-      name: passkeys
-      sha256: "09e55fed6ff40499e6bb901da13ab58985e966b05fb91da8323ac081683e97ba"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.20.0"
-  passkeys_android:
-    dependency: transitive
-    description:
-      name: passkeys_android
-      sha256: "4286322398df7cc74b7503e9d638fab7885e56986689a2f683731da473f23f85"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.12.0"
-  passkeys_darwin:
-    dependency: transitive
-    description:
-      name: passkeys_darwin
-      sha256: "3a9008714d392af79d93f5a657fa93b76edea515e2cf71e25da3567aec663ae7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0"
-  passkeys_doctor:
-    dependency: transitive
-    description:
-      name: passkeys_doctor
-      sha256: "83cbed79bff4b63b54a3f3b5d80aa8f68c9009b6a85fb432b5bb7918bb47c681"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.1"
   passkeys_platform_interface:
     dependency: transitive
     description:
       name: passkeys_platform_interface
-      sha256: "10fd4dd6779f6ca928adc2289e05ce0877250e68f2cc584abd2e3fcd6952e454"
+      sha256: "56dd98bbe45d79de87e8683d25741b2f61743542a39a85207b0a5b4bccff600e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
-  passkeys_web:
-    dependency: transitive
-    description:
-      name: passkeys_web
-      sha256: aa32224b289601f6894f243b24d21e56f90d632711bb4db1dedf4ea29f562de4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.9.0"
-  passkeys_windows:
-    dependency: transitive
-    description:
-      name: passkeys_windows
-      sha256: acea5ff790a8c6de0366d1b87dd591c0d6e6770bf17d62efbd9fac7747724cc7
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.1"
+    version: "2.7.0"
   path:
     dependency: transitive
     description:
@@ -921,10 +873,10 @@ packages:
     dependency: transitive
     description:
       name: postgrest
-      sha256: "83bfb9cb4a8a15a01f087bf472e14760f722bf531498a9c428df100c649c028d"
+      sha256: "801f6659cffbb6372d38cb4deb0cd892cb0cb38d75e0686ff24f4a724e9f4999"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.2"
+    version: "2.7.4"
   pub_semver:
     dependency: transitive
     description:
@@ -937,10 +889,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: ac96ac76522de7c7ac30eb99f50899186ff4ac7d426f6bc7997a002e24f0e3a2
+      sha256: "3261ba98af41fccfdbb6c66299b5bd6871907e98bb41bce9d55e0fb91287ed85"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.9.1"
   record_use:
     dependency: transitive
     description:
@@ -1070,10 +1022,10 @@ packages:
     dependency: transitive
     description:
       name: storage_client
-      sha256: "2079d182a3806a9a7be746fee6603bbea207adbc3cc6f11c670f5d1f3eb5263e"
+      sha256: "2cc5432c312c4a08687bcce795aff377d006e2892097c7f88d57512885bb4b10"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.7"
+    version: "2.5.9"
   stream_channel:
     dependency: transitive
     description:
@@ -1094,18 +1046,18 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: "04babf8ece84d9ca528a9d9187b37899ce38ffabb6cd4ef28c6db0e679b0aca9"
+      sha256: d425df9330ce5f215a0ee708b084899d89031e8a8f3e096f46c38ea37df9fd7d
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.3"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: c5f9cc95162fd057be851ce38a0d54a0391cecad3a6ddfce1314e47f89a382f9
+      sha256: "262c7eda45997a308ac0311be82fe8e9134526a18125fe5e0cf0a58e9cd16cb6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.3"
   term_glyph:
     dependency: transitive
     description:
@@ -1138,14 +1090,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  ua_client_hints:
-    dependency: transitive
-    description:
-      name: ua_client_hints
-      sha256: e6e302bb7c21d6a90023db61e0ec413f0810ce341bb7e2ab447ff5d61ec3d87e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.7.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1318,10 +1262,10 @@ packages:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "1.1.5"
   xdg_directories:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -65,7 +65,11 @@ dependencies:
   # Device model + Android version for the in-app bug-report diagnostics.
   # This project's bugs skew heavily Samsung / One UI, so the exact model is
   # worth capturing on every report. Read-only; no runtime permissions.
-  device_info_plus: ^12.4.0
+  # Pinned at 10.x: 12.x's iOS plugin calls NSProcessInfo.isiOSAppOnVision,
+  # a selector our Xcode SDK doesn't have, so 12 fails the iOS build (Android
+  # is unaffected). Revisit when a device_info_plus release guards that call
+  # or the iOS build SDK moves up.
+  device_info_plus: ^10.1.0
 
   # Open URLs in the browser (used for the in-app update download prompt)
   url_launcher: ^6.3.0


### PR DESCRIPTION
## What will this PR change?

Pins `device_info_plus` back to `^10.1.0`. The Dependabot bump to `^12.4.0` (merged in #160) **broke the iOS build** - it compiles fine on Android but fails on iOS, so master's `Build iOS` went red and an iOS App Store build would fail.

device_info_plus 12.4.0's iOS plugin calls `NSProcessInfo.isiOSAppOnVision`, a selector our Xcode SDK doesn't declare:

```
ARC Semantic Issue (Xcode): No visible @interface for 'NSProcessInfo' declares the selector 'isiOSAppOnVision'
device_info_plus-12.4.0/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m:34
```

`supabase_flutter` 2.15.0 (the other half of #160) is kept - it builds fine on both platforms; the break is purely device_info_plus.

## Why it slipped through

`Build iOS (no codesign)` is not a required status check, so #160's auto-merge landed before that job failed. Our usage (`androidInfo.model` / `version`, `iosInfo.systemName` / `utsname.machine` in `diagnostics_service.dart`) is stable across 10.x-12.x, so nothing else changes.

## Testing

- `flutter pub get` resolves device_info_plus back to 10.1.2; `flutter analyze` clean.
- device_info_plus 10.x was green on iOS through #172 and #168, so this restores the known-good state.
- The `Build iOS (no codesign)` check on this PR is the real gate - it should return to green.

Revisit the 12.x bump when device_info_plus guards that selector, or when the iOS build SDK moves up.
