### PR TITLE
iOS: add location purpose string to Info.plist (fixes ITMS-90683)

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -43,6 +43,8 @@
 	<string>Moongate uses Face ID to unlock the app when app lock is turned on.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Moongate uses your local network to discover and connect directly to printers on the same Wi-Fi.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Moongate can use your location to detect the Wi-Fi network your printers are on, so it can find and connect to them on your local network. Your location is never stored or shared.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Moongate uses your photo library so you can choose a custom image for your dashboard background.</string>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## What will this PR change?

Adds a single key to the iOS `Info.plist`: `NSLocationWhenInUseUsageDescription` (a location purpose string). Nothing else changes. It is an iOS-only, store-metadata fix, and Android is unaffected.

## Gist

App Store validation started warning **ITMS-90683 ("Missing purpose string in Info.plist")** on the v0.9.45 upload. A bundled networking library links Apple's CoreLocation framework (Wi-Fi / network-info APIs reference it), so Apple requires a location purpose string even though Moongate never asks for or uses your location. Without the string, every future iOS build gets the same warning and risks a reviewer rejection.

## Why

- Build 117 came back from Apple with ITMS-90683.
- The Info.plist already declared camera, Face ID, local network and photo library, but not location.
- The location reference comes from a linked dependency, not app code, so the purpose string is required regardless of whether the feature is used.

## How

- Added `NSLocationWhenInUseUsageDescription` with a user-facing string framed around local-network printer discovery (honest, since the linked code is Wi-Fi network related), and stating that location is never stored or shared.

## Testing

- `plutil -lint` passes on Info.plist.
- Rebuilt as build 118 and uploaded to App Store Connect: processed with no ITMS warnings, build attached to v0.9.45, now Waiting for Review.
