### PR TITLE
Split Android into github + play build flavors (Play Store prep)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -54,9 +54,19 @@ jobs:
             echo "RELEASE_KEYSTORE secret not set - falling back to debug signing."
           fi
 
-      - name: Build release APK
+      - name: Build release APK (github flavor)
+        # The sideload/KIAUH channel: signed APK that keeps the self-updater.
+        # Flavors make --flavor mandatory; the artefact is now app-github-release.apk.
         working-directory: mobile
-        run: flutter build apk --release
+        run: flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github
+
+      - name: Build Play App Bundle (play flavor)
+        # The Play channel: an App Bundle with NO self-updater and NO
+        # REQUEST_INSTALL_PACKAGES (see the `play` flavor + src/github split).
+        # Uploaded as a workflow artifact for a MANUAL Play Console submission -
+        # it is never auto-published, mirroring the iOS altool/ASC flow.
+        working-directory: mobile
+        run: flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play
 
       - name: Stage APK + read version
         # The signed APK is published ONLY as a GitHub Release asset (next step)
@@ -66,7 +76,7 @@ jobs:
         run: |
           VERSION=$(grep '^version:' mobile/pubspec.yaml | sed 's/version:[[:space:]]*//' | cut -d'+' -f1)
           BUILD=$(grep '^version:' mobile/pubspec.yaml | sed 's/version:[[:space:]]*//' | cut -d'+' -f2)
-          cp mobile/build/app/outputs/flutter-apk/app-release.apk "Moongate-v${VERSION}.apk"
+          cp mobile/build/app/outputs/flutter-apk/app-github-release.apk "Moongate-v${VERSION}.apk"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "build=$BUILD"     >> "$GITHUB_OUTPUT"
           echo "Built Moongate-v${VERSION}.apk (build $BUILD)"
@@ -170,4 +180,13 @@ jobs:
         with:
           name: Moongate-release
           path: Moongate-v${{ steps.meta.outputs.version }}.apk
+          retention-days: 30
+
+      - name: Upload Play App Bundle artifact
+        # Manual upload to the Play Console (closed test -> production); never
+        # auto-published. This is the .aab you drag into the Play Console.
+        uses: actions/upload-artifact@v7
+        with:
+          name: Moongate-play-aab
+          path: mobile/build/app/outputs/bundle/playRelease/app-play-release.aab
           retention-days: 30

--- a/docs/design/play-flavor-plan.md
+++ b/docs/design/play-flavor-plan.md
@@ -1,0 +1,113 @@
+# Play Store vs sideload: build-flavor split
+
+## Why
+
+Moongate is distributed three ways from one Flutter codebase:
+
+- **GitHub Releases** (sideloaded APK) and **KIAUH** - the app self-updates by
+  downloading the latest release APK and handing it to the system installer.
+- **Google Play** (new) - Play **forbids** apps that download and install their
+  own APKs, and restricts the `REQUEST_INSTALL_PACKAGES` permission. Play
+  delivers updates itself.
+
+Both must come from the same code, keep the same package name
+(`com.moongate.app.moongate`) and the **same signing key** (cert `8878da71`), so
+a user can move between the sideloaded APK and the Play build **in place, with no
+re-pair and no wipe**. That continuity is the whole reason we registered the
+existing key with Play App Signing.
+
+## How: one Gradle flavor dimension, two flavors
+
+`mobile/android/app/build.gradle.kts` defines a `distribution` dimension with two
+flavors. Neither sets an `applicationIdSuffix`; both use the single `release`
+buildType, so **package id and signing key are identical**. The flavor changes
+only two things:
+
+| | `github` (default) | `play` |
+|---|---|---|
+| Self-updater | kept | removed |
+| `REQUEST_INSTALL_PACKAGES` | present | absent |
+| Updater `FileProvider` | present | absent |
+| `BuildConfig.SELF_UPDATE` | `true` | `false` |
+| Ships as | `.apk` (GitHub Releases) | `.aab` (Play) |
+| Updates via | in-app download + install | Google Play |
+
+### The two mechanisms
+
+1. **Manifest split.** `REQUEST_INSTALL_PACKAGES` and the updater `FileProvider`
+   were moved out of `src/main/AndroidManifest.xml` into a new
+   `src/github/AndroidManifest.xml`. The merger unions them into the github
+   build (its final manifest is equivalent to pre-split); the play `.aab` simply
+   never has them.
+
+2. **Dart channel flag.** `mobile/lib/config/build_channel.dart` exposes
+   `kSelfUpdateEnabled`, driven by `--dart-define=MOONGATE_CHANNEL` (paired with
+   `--flavor`). It gates three spots:
+   - `update_service.dart` - `checkForUpdate()` returns null on the play channel.
+     This is the **primary gate**: with no update, the dashboard banner, the
+     installer dialog, and the whole download path are unreachable (dead-code
+     eliminated, since the flag is `const`).
+   - `main.dart` - skips the leftover-APK cleanup (nothing is ever written).
+   - `MainActivity.kt` - the native install `MethodChannel` is compiled out when
+     `BuildConfig.SELF_UPDATE == false`, so the package-installer intent isn't
+     even present in the Play binary.
+
+## Build commands
+
+```
+# GitHub / KIAUH sideload (signed APK, self-updating) - behaviour identical to before
+flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github
+#   -> mobile/build/app/outputs/flutter-apk/app-github-release.apk
+
+# Play (App Bundle, no self-update, no install permission)
+flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play
+#   -> mobile/build/app/outputs/bundle/playRelease/app-play-release.aab
+
+# Local dev - flavors make --flavor MANDATORY now (a bare `flutter run` errors)
+flutter run --flavor github
+```
+
+CI (`.github/workflows/build-android.yml`) builds the github APK (published to
+GitHub Releases exactly as before) and the play `.aab` (uploaded as the
+`Moongate-play-aab` workflow artifact for **manual** Play Console upload, never
+auto-published - same posture as the iOS submit flow).
+
+## What the Play build does about updates
+
+Nothing active. Google Play auto-updates in the background. That is the correct,
+policy-safe default. A nicer in-app nudge via Google's Play In-App Update API
+(`in_app_update`, flavor-gated) is a good fast-follow once the app is live on
+Play, but is not needed for v1.
+
+## Operational caveats (read before shipping)
+
+1. **Play App Signing key MUST be `8878da71`.** When creating the Play app,
+   choose "use your own key" and upload the release keystore. If Google
+   generates a fresh key, Play installs get a different signature and
+   sideload<->Play becomes a **forced-uninstall wipe** (printers + cloud identity
+   lost). Play Console action, do not get it wrong.
+
+2. **Shared versionCode across channels.** Both flavors read the one build
+   number from `pubspec.yaml`. Android only updates to a **strictly higher**
+   build number, so cross-moving to the *same* build is a no-op (not a wipe).
+   Let one channel lead on versioning if this matters.
+
+3. **Foreground-service special-use is the most likely Play *rejection*.** The
+   `FOREGROUND_SERVICE_SPECIAL_USE` service ships to Play too; it needs a Play
+   Console review declaration for the subtype, and Google may push back toward
+   `dataSync` (which reintroduces the Android 15 6h/day cap that breaks long
+   prints). Prepare the justification.
+
+4. **Debug-signing fallback unchanged (deliberate).** A `--release` build with no
+   `key.properties` still falls back to debug signing (existing behaviour, for
+   local `flutter run --release`). Play refuses debug-signed `.aab` uploads, so
+   the Play path is safe; but only ever build the Play `.aab` in CI or on the
+   work box (CDG-3D-TECH) that holds the keystore - never the psych box.
+
+5. **`flutter run` / `flutter build` now require `--flavor github`.** Once
+   flavors exist, the bare commands error "this app has flavors". Update local
+   muscle-memory and any scripts.
+
+6. **iOS is unaffected.** Android product flavors do not create iOS schemes;
+   `flutter build ipa` needs no `--flavor`. Watch the (non-required) `Build iOS`
+   check on the first CI run regardless.

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -80,6 +80,32 @@ android {
             )
         }
     }
+
+    buildFeatures {
+        // Generate BuildConfig so MainActivity can compile the APK-installer
+        // channel out of the Play flavor (SELF_UPDATE == false). AGP 8+/9
+        // defaults this OFF, so enable it explicitly.
+        buildConfig = true
+    }
+
+    // Distribution channels. BOTH keep the same applicationId and are built by
+    // the single `release` buildType (so the same signing key, cert 8878da71),
+    // which is what lets a device move between the sideloaded APK and the Play
+    // build in place - no re-pair, no wipe. The flavor changes ONLY the merged
+    // manifest (REQUEST_INSTALL_PACKAGES + the updater FileProvider live in
+    // src/github) and the SELF_UPDATE BuildConfig flag - never the package id
+    // or the key. Do NOT add an applicationIdSuffix to either.
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("github") {
+            dimension = "distribution"
+            buildConfigField("boolean", "SELF_UPDATE", "true")
+        }
+        create("play") {
+            dimension = "distribution"
+            buildConfigField("boolean", "SELF_UPDATE", "false")
+        }
+    }
 }
 
 kotlin {

--- a/mobile/android/app/src/github/AndroidManifest.xml
+++ b/mobile/android/app/src/github/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- GitHub / KIAUH sideload channel ONLY. The in-app updater downloads a new
+         release APK and hands it to the system package installer. These entries
+         are deliberately ABSENT from src/main so the Play App Bundle (the `play`
+         flavor) ships without them - Google Play forbids self-update and
+         restricts REQUEST_INSTALL_PACKAGES. The manifest merger unions this into
+         the github build, making its final manifest equivalent to pre-split. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <application>
+        <!-- FileProvider for the in-app updater: shares the downloaded APK with
+             the system package installer as a content:// URI (with a temporary
+             read grant), since file:// URIs are blocked from Android 7+. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+    </application>
+</manifest>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -9,9 +9,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!-- In-app updater: download a new release APK and hand it to the system
-         package installer (the install still shows Android's own confirmation). -->
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <!-- REQUEST_INSTALL_PACKAGES (the in-app updater) lives in src/github's
+         manifest, so it is present only in the GitHub/KIAUH sideload build and
+         absent from the Play App Bundle. -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
     <application
@@ -56,8 +56,10 @@
 
         <!-- flutter_foreground_task: hosts the background isolate that polls
              /status for print notifications. specialUse (not dataSync) avoids
-             Android 15's 6h/day cap on a long print; we sideload, so the Play
-             Console review that specialUse would otherwise need doesn't apply. -->
+             Android 15's 6h/day cap on a long print. NOTE: the Play build ships
+             this service too, so the special-use subtype requires a Play Console
+             review declaration (justified by long prints exceeding dataSync's
+             6h cap). The GitHub/KIAUH sideload channel needs no such review. -->
         <service
             android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
             android:foregroundServiceType="specialUse"
@@ -67,19 +69,6 @@
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Live 3D-print progress and status notifications" />
         </service>
-
-        <!-- FileProvider for the in-app updater: shares the downloaded APK with
-             the system package installer as a content:// URI (with a temporary
-             read grant), since file:// URIs are blocked from Android 7+. -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
-        </provider>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/mobile/android/app/src/main/kotlin/com/moongate/app/moongate/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/moongate/app/moongate/MainActivity.kt
@@ -37,41 +37,44 @@ class MainActivity : FlutterFragmentActivity() {
                 }
             }
 
-        // In-app updater: launch the system package installer on an APK the Dart
-        // side has already downloaded. The file is shared as a content:// URI
-        // via our FileProvider with a temporary read grant (file:// is blocked
-        // from Android 7+); Android then shows its standard install
-        // confirmation. The REQUEST_INSTALL_PACKAGES permission is requested by
-        // Dart before this is called.
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, INSTALL_CHANNEL)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "installApk" -> {
-                        val path = call.argument<String>("path")
-                        if (path == null) {
-                            result.error("no_path", "Missing apk path", null)
-                            return@setMethodCallHandler
-                        }
-                        try {
-                            val file = File(path)
-                            val uri = FileProvider.getUriForFile(
-                                this, "$packageName.fileprovider", file
-                            )
-                            val intent = Intent(Intent.ACTION_VIEW).apply {
-                                setDataAndType(
-                                    uri, "application/vnd.android.package-archive"
-                                )
-                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        // In-app updater (GitHub/KIAUH sideload channel only): launch the system
+        // package installer on an APK the Dart side has already downloaded. The
+        // file is shared as a content:// URI via our FileProvider with a
+        // temporary read grant (file:// is blocked from Android 7+); Android then
+        // shows its standard install confirmation. Compiled OUT of the Play build
+        // (BuildConfig.SELF_UPDATE == false), which ships no
+        // REQUEST_INSTALL_PACKAGES and lets Google Play deliver updates.
+        if (BuildConfig.SELF_UPDATE) {
+            MethodChannel(flutterEngine.dartExecutor.binaryMessenger, INSTALL_CHANNEL)
+                .setMethodCallHandler { call, result ->
+                    when (call.method) {
+                        "installApk" -> {
+                            val path = call.argument<String>("path")
+                            if (path == null) {
+                                result.error("no_path", "Missing apk path", null)
+                                return@setMethodCallHandler
                             }
-                            startActivity(intent)
-                            result.success(true)
-                        } catch (e: Exception) {
-                            result.error("install_failed", e.message, null)
+                            try {
+                                val file = File(path)
+                                val uri = FileProvider.getUriForFile(
+                                    this, "$packageName.fileprovider", file
+                                )
+                                val intent = Intent(Intent.ACTION_VIEW).apply {
+                                    setDataAndType(
+                                        uri, "application/vnd.android.package-archive"
+                                    )
+                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                                startActivity(intent)
+                                result.success(true)
+                            } catch (e: Exception) {
+                                result.error("install_failed", e.message, null)
+                            }
                         }
+                        else -> result.notImplemented()
                     }
-                    else -> result.notImplemented()
                 }
-            }
+        }
     }
 }

--- a/mobile/lib/config/build_channel.dart
+++ b/mobile/lib/config/build_channel.dart
@@ -1,0 +1,36 @@
+/// Which distribution channel this build targets.
+///
+/// Moongate ships the SAME Flutter codebase down two Android channels that must
+/// behave differently around app updates:
+///
+///  * [github] - the sideloaded APK from GitHub Releases (and the KIAUH
+///    installer). It self-updates: checks APK/latest_version.json, downloads the
+///    new release APK, and hands it to the system package installer. This build
+///    carries REQUEST_INSTALL_PACKAGES (added by the `github` flavor's manifest).
+///
+///  * [play] - the Google Play App Bundle. Play forbids apps that download and
+///    install their own APKs, so this build ships WITHOUT the self-updater and
+///    WITHOUT REQUEST_INSTALL_PACKAGES; Google Play delivers updates itself.
+///
+/// The channel is chosen at build time with `--dart-define=MOONGATE_CHANNEL`,
+/// paired with the matching Gradle `--flavor` (which selects the manifest):
+///
+///   flutter build apk       --release --flavor github --dart-define=MOONGATE_CHANNEL=github
+///   flutter build appbundle --release --flavor play   --dart-define=MOONGATE_CHANNEL=play
+///
+/// The default is [github], so a bare `flutter run --flavor github` (and the
+/// existing CI command, once it passes the flavor) behaves exactly as before.
+enum BuildChannel { github, play }
+
+const String _rawChannel =
+    String.fromEnvironment('MOONGATE_CHANNEL', defaultValue: 'github');
+
+const BuildChannel kBuildChannel =
+    _rawChannel == 'play' ? BuildChannel.play : BuildChannel.github;
+
+/// True only on the GitHub/KIAUH sideload build, where the app may download and
+/// install its own APK. False on the Play build, which suppresses the update
+/// check, the update banner, and the in-app installer - updates arrive through
+/// Google Play instead. Being a compile-time `const`, the disabled path is
+/// tree-shaken out of the Play binary.
+const bool kSelfUpdateEnabled = kBuildChannel == BuildChannel.github;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'config/build_channel.dart';
 import 'providers/custom_theme_provider.dart';
 import 'providers/dashboard_background_provider.dart';
 import 'providers/settings_provider.dart';
@@ -89,8 +90,9 @@ void main() async {
   // Clean up the APK left behind by a previous in-app update. By now its install
   // has finished (or was declined), so the ~80 MB file is just dead weight in
   // the cache - users were seeing it as the app eating storage. Best-effort, off
-  // the startup path.
-  OtaInstaller.clearDownloadedApks().ignore();
+  // the startup path. Only the self-updating GitHub build ever writes one; the
+  // Play build has nothing to clean (OtaInstaller stays dormant there).
+  if (kSelfUpdateEnabled) OtaInstaller.clearDownloadedApks().ignore();
 
   runApp(UncontrolledProviderScope(container: container, child: const MoongateApp()));
 }

--- a/mobile/lib/services/update_service.dart
+++ b/mobile/lib/services/update_service.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
 
+import '../config/build_channel.dart';
+
 /// Information about an available update fetched from GitHub.
 class UpdateInfo {
   final String version;
@@ -34,7 +36,11 @@ class UpdateService {
     // (you can't install an APK) and pointing users at an off-store download is
     // an App Store review risk. Returning null suppresses the update banner and
     // the in-app updater on iOS; the "What's new" changelog still shows.
-    if (!Platform.isAndroid) return null;
+    //
+    // Same on the Play channel (kSelfUpdateEnabled == false): Google Play
+    // delivers updates and REQUEST_INSTALL_PACKAGES is absent from that build's
+    // manifest, so the self-updater must stay dark. See config/build_channel.dart.
+    if (!Platform.isAndroid || !kSelfUpdateEnabled) return null;
     try {
       final info          = await PackageInfo.fromPlatform();
       final installedBuild = int.tryParse(info.buildNumber) ?? 0;


### PR DESCRIPTION
## What will this PR change?

Nothing changes for people using Moongate today. The app you sideload from GitHub (and install via KIAUH) behaves exactly as before, self-updater and all. What this adds is a **second way to build the same app for the Google Play Store**, where Google does not allow an app to download and install its own updates.

In plain English: one codebase, two "flavours" of the Android build.

- **github flavour** (what ships to GitHub Releases / KIAUH): keeps the in-app updater, unchanged.
- **play flavour** (the App Bundle for the Play Store): the self-updater is stripped out, and the permission that lets an app install APKs is removed. Google Play handles updates instead.

Both are the same app, same package name, and signed with the **same key (8878da71)**, so a user can move between the sideloaded version and the Play version with no reinstall, no re-pair, and no data wipe.

## Why

The Play Store rejects apps that self-download and install APKs and restricts the `REQUEST_INSTALL_PACKAGES` permission. To publish on Play without abandoning the GitHub/KIAUH sideload channel, the Play build has to physically ship without that permission and without the updater, while the sideload build keeps both.

## How

- New `distribution` Gradle flavour dimension: `github` (default) and `play`. Same `applicationId`, same `release` signing config for both. No `applicationIdSuffix`, so the package id and key never change.
- `REQUEST_INSTALL_PACKAGES` and the updater `FileProvider` moved out of the shared `src/main` manifest into a new `src/github/AndroidManifest.xml`, so only the sideload build merges them in.
- New `mobile/lib/config/build_channel.dart` exposes `kSelfUpdateEnabled`, driven by `--dart-define=MOONGATE_CHANNEL` (paired with `--flavor`). It gates the update check (`update_service.dart`) and the leftover-APK cleanup (`main.dart`). Because the flag is `const`, the whole updater path is tree-shaken out of the Play binary.
- `MainActivity.kt` compiles the native APK-installer channel out of the Play build via `BuildConfig.SELF_UPDATE`.
- CI (`build-android.yml`) builds the github APK (published to GitHub Releases exactly as before) and the play `.aab` (uploaded as the `Moongate-play-aab` workflow artifact for a manual Play upload, never auto-published).
- `docs/design/play-flavor-plan.md` records the decision and the operational caveats.

## Operational caveats (in the design doc, repeated here as they bite outside the code)

1. When creating the Play app, set Play App Signing to **use the existing 8878da71 key**. A Google-generated key would make sideload<->Play a forced-uninstall wipe.
2. The `FOREGROUND_SERVICE_SPECIAL_USE` service now ships to Play too and needs a Play Console review declaration (this is the most likely Play rejection vector, not the updater).
3. Local `flutter run` / `flutter build` now **require `--flavor github`** once flavours exist (a bare command errors).

## Testing

- `flutter analyze`: no issues.
- Built **both** flavours on the work box (release-signed): `app-github-release.apk` (82.8 MB) and `app-play-release.aab` (74 MB).
- Verified the merged manifests: the real `REQUEST_INSTALL_PACKAGES` uses-permission element is **present in github** and **absent in play**; the updater FileProvider is present in github only.
- No version bump and no user-facing behaviour change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
