### PR TITLE
docs: sync build docs for the github/play flavor split

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,7 +104,7 @@ mobile/android/app/src/main/
 └── app/proguard-rules.pro           # R8 keep-rules for ML Kit + mobile_scanner + CameraX
 ```
 
-`MainActivity` extends `FlutterFragmentActivity` (not the default `FlutterActivity`) because CameraX requires the activity to be a `LifecycleOwner`. Switching this fixed an earlier camera-binding crash on first launch. It also hosts two small `MethodChannel`s: `com.moongate.app/secure` (toggles `FLAG_SECURE` for the app-lock screen) and `com.moongate.app/install` (v0.9.17 - launches the system package installer on the APK the in-app updater downloaded, shared as a `content://` URI via the `FileProvider`).
+`MainActivity` extends `FlutterFragmentActivity` (not the default `FlutterActivity`) because CameraX requires the activity to be a `LifecycleOwner`. Switching this fixed an earlier camera-binding crash on first launch. It also hosts two small `MethodChannel`s: `com.moongate.app/secure` (toggles `FLAG_SECURE` for the app-lock screen) and `com.moongate.app/install` (v0.9.17 - launches the system package installer on the APK the in-app updater downloaded, shared as a `content://` URI via the `FileProvider`; compiled out of the Play flavor via `BuildConfig.SELF_UPDATE` - #178).
 
 ---
 
@@ -202,8 +202,10 @@ push to master
   ├─ setup-flutter@v2 (stable channel)
   ├─ flutter pub get
   ├─ Decode the keystore from GitHub Secrets → key.properties
-  ├─ flutter build apk --release
-  ├─ Publish the signed APK as a GitHub Release asset (Moongate-v<X.Y.Z>.apk)
+  ├─ flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github
+  ├─ flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play
+  ├─ Publish the signed github APK as a GitHub Release asset (Moongate-v<X.Y.Z>.apk)
+  ├─ Upload the play .aab as the "Moongate-play-aab" workflow artifact (manual Play upload)
   ├─ Regenerate APK/latest_version.json (apk_url → the Release asset)
   └─ git commit + push the manifest  →  "Release Moongate-vX.Y.Z [skip ci]"
 ```
@@ -211,6 +213,8 @@ push to master
 The `[skip ci]` suffix prevents the commit-back from re-triggering CI. The in-app update banner ([`UpdateService`](mobile/lib/services/update_service.dart)) polls `latest_version.json` on launch and shows the banner if the remote `build_number` exceeds the installed one.
 
 CI only fires on `master`. Feature branches (like `v0.4-secure-remote`) don't build APKs automatically - that's intentional, so unreleased branches stay out of the in-app updater.
+
+**Build flavors (#178).** The Android build has two flavors on a `distribution` dimension: `github` (the sideload APK for GitHub Releases + KIAUH, keeps the self-updater) and `play` (the App Bundle for Google Play, no self-updater and no `REQUEST_INSTALL_PACKAGES`, since Play forbids self-install). Both keep the same `applicationId` and signing key, so users move between channels in place with no wipe. A Dart flag ([`config/build_channel.dart`](mobile/lib/config/build_channel.dart), fed by the `MOONGATE_CHANNEL` dart-define) plus `BuildConfig.SELF_UPDATE` gate the updater code; the permission + `FileProvider` live in `src/github/AndroidManifest.xml`. Full rationale in [`docs/design/play-flavor-plan.md`](docs/design/play-flavor-plan.md).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,15 +81,21 @@ Debug builds are unsigned, slower, and have hot-reload. Press `r` in the termina
 
 ### Release build (production-equivalent)
 
+The app builds in two **distribution flavors** (added in #178 for the Play Store): `github` (the sideloaded APK for GitHub Releases + KIAUH, which keeps the in-app self-updater) and `play` (the App Bundle for Google Play, which ships **without** the self-updater or `REQUEST_INSTALL_PACKAGES`). Because flavors now exist, `--flavor` is **required** - a bare `flutter build apk` errors with "this app has flavors". Details in [`docs/design/play-flavor-plan.md`](docs/design/play-flavor-plan.md).
+
 ```bash
 cd mobile
-flutter build apk --release
-# Output: build/app/outputs/flutter-apk/app-release.apk
+# Sideload / dev APK (self-updating) - this is what you install on a device
+flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github
+# Output: build/app/outputs/flutter-apk/app-github-release.apk
+adb install -r build/app/outputs/flutter-apk/app-github-release.apk
 
-adb install -r build/app/outputs/flutter-apk/app-release.apk
+# Play App Bundle (no self-updater) - CI / work-box only, never sideload it
+flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play
+# Output: build/app/outputs/bundle/playRelease/app-play-release.aab
 ```
 
-Release builds are signed with the keystore configured in `mobile/android/key.properties` if present, otherwise they fall back to the debug key. CI uses GitHub Secrets - see [Release signing](#release-signing) below.
+Release builds are signed with the keystore configured in `mobile/android/key.properties` if present, otherwise they fall back to the debug key. Both flavors share the same key and `applicationId`, so a device moves between the sideload APK and the Play build in place with no wipe. CI uses GitHub Secrets - see [Release signing](#release-signing) below.
 
 > The QR scanner only works in **release** builds with the ProGuard rules in [`mobile/android/app/proguard-rules.pro`](mobile/android/app/proguard-rules.pro). Debug builds work fine too; R8 doesn't run in debug.
 
@@ -151,7 +157,7 @@ mobile/lib/
 
 > **v0.9.15-v0.9.16 services & deps.** `printer_webview_cache.dart` gained a **pre-warm** path that loads every printer's WebView in the background at startup (so the first open is instant), and a new `printer_liveness_service.dart` tracks each printer's online/offline state via **Supabase Realtime** on the `printers` table (plus a periodic RLS-scoped read) so the dashboard and the notification service stop requesting access for switched-off printers. A new `onMobileDataProvider` in `providers/settings_provider.dart` drives the connectivity-aware camera feed rate. New dependency: **`connectivity_plus`** (Wi-Fi vs. mobile-data detection). The liveness feature relies on the Realtime migration below being applied to the Supabase project.
 
-> **v0.9.17 services & native.** Two new app services: `print_progress.dart` - a pure helper that computes Mainsail-matching *file position (relative)* progress, now the **single source** for both the dashboard tile and the print notification (they used to disagree) - and `ota_installer.dart`, the in-app updater that streams the release APK to the cache dir with progress then triggers the system installer. The updater adds a native `MethodChannel` (`com.moongate.app/install`) in `MainActivity.kt`, a `FileProvider` + `res/xml/file_paths.xml`, and the `REQUEST_INSTALL_PACKAGES` permission in the manifest; it reuses the existing `http` / `path_provider` / `permission_handler` deps (no new package). The post-emergency-stop restart button keys off a new `klippyShutdown` flag on `PrinterStatus`, parsed from Moonraker's `webhooks.state`. Unit test: `mobile/test/print_progress_test.dart`.
+> **v0.9.17 services & native.** Two new app services: `print_progress.dart` - a pure helper that computes Mainsail-matching *file position (relative)* progress, now the **single source** for both the dashboard tile and the print notification (they used to disagree) - and `ota_installer.dart`, the in-app updater that streams the release APK to the cache dir with progress then triggers the system installer. The updater adds a native `MethodChannel` (`com.moongate.app/install`) in `MainActivity.kt`, a `FileProvider` + `res/xml/file_paths.xml`, and the `REQUEST_INSTALL_PACKAGES` permission (all now in the **`github` flavor** manifest and gated by `BuildConfig.SELF_UPDATE`, so the Play flavor omits them - #178); it reuses the existing `http` / `path_provider` / `permission_handler` deps (no new package). The post-emergency-stop restart button keys off a new `klippyShutdown` flag on `PrinterStatus`, parsed from Moonraker's `webhooks.state`. Unit test: `mobile/test/print_progress_test.dart`.
 
 For a guided tour of how these pieces fit together, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
@@ -279,8 +285,8 @@ The CI pipeline ([`.github/workflows/build-android.yml`](.github/workflows/build
 
 1. Sets up Flutter stable + JDK 17
 2. Decodes the keystore from Secrets and writes `key.properties`
-3. `flutter build apk --release`
-4. Publishes the signed APK as a **GitHub Release asset** (`Moongate-vX.Y.Z.apk`) - it is **not** committed to the repo (the ~73 MB binary tripped GitHub's 50 MB push warning on every push)
+3. `flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github` (the sideload APK) **and** `flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play` (the Play `.aab`, kept as the `Moongate-play-aab` workflow artifact for a manual Play upload)
+4. Publishes the signed github APK as a **GitHub Release asset** (`Moongate-vX.Y.Z.apk`) - it is **not** committed to the repo (the ~73 MB binary tripped GitHub's 50 MB push warning on every push)
 5. Generates a fresh `APK/latest_version.json` whose `apk_url` points at that Release asset, for the in-app update banner
 6. Commits **only the manifest** with `[skip ci]` and pushes back to `master`
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Your Pi runs Klipper, Moonraker, the Moongate plugin, and an **auth proxy** that
 | [CHANGELOG.md](CHANGELOG.md) | Every release with a one-line summary of what changed and why |
 | [Privacy policy](https://peekypaul.github.io/Moongate/privacy-policy.html) | What data the app handles and why - anonymous, no analytics, no tracking, no data sold |
 
-> **Building from source?** `cd mobile && flutter pub get && flutter build apk --release`. Full developer workflow in [DEVELOPMENT.md](DEVELOPMENT.md).
+> **Building from source?** `cd mobile && flutter pub get && flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github`. Full developer workflow in [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -216,7 +216,9 @@ The auth proxy is even more constrained - it doesn't talk to Klipper at all, it 
 
 ## In-app updater (v0.9.17)
 
-The update banner can now download and install a new version **without leaving the app** (Android only). That adds the `REQUEST_INSTALL_PACKAGES` permission and a `FileProvider`, so it's worth stating what it can and can't do:
+> Applies to the **GitHub / KIAUH sideload build** only. As of #178 the Google Play build is a separate flavor that ships **without** the self-updater and **without** `REQUEST_INSTALL_PACKAGES` - Google Play delivers its updates instead.
+
+The update banner can download and install a new version **without leaving the app** (Android only, sideload build). That adds the `REQUEST_INSTALL_PACKAGES` permission and a `FileProvider`, so it's worth stating what it can and can't do:
 
 - It downloads the APK over **HTTPS from the project's GitHub Releases** - the same artifact you'd get by tapping the download link yourself - into the app's private cache directory, then hands that file to **Android's system package installer** via a `content://` `FileProvider` URI.
 - The install is **not silent**: Android shows its standard "install this update?" confirmation, and the first time it requires the user to grant "install unknown apps" for Moongate. A sideloaded app cannot install anything without that interaction.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -97,8 +97,8 @@ For anything else, see the full [TROUBLESHOOTING.md](../TROUBLESHOOTING.md) at t
 git clone https://github.com/PEEKYPAUL/Moongate.git
 cd Moongate/mobile
 flutter pub get
-flutter build apk --release
-# APK: build/app/outputs/flutter-apk/app-release.apk
+flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github
+# APK: build/app/outputs/flutter-apk/app-github-release.apk
 ```
 
 See [DEVELOPMENT.md](../DEVELOPMENT.md) for the full developer workflow.


### PR DESCRIPTION
## What will this PR change?

Documentation only, no code or app behaviour. It brings the developer docs in line with the github/play build-flavor split that merged in #178.

The one that actually matters: after #178, a bare `flutter build apk --release` errors with "this app has flavors". Several docs still showed that old command, so anyone building from source would hit a wall. This fixes them to the flavored command and explains the sideload-vs-Play distinction.

## Why

#178 introduced two Android build flavors (`github` sideload with the self-updater, `play` App Bundle without it). That changed the build command and which build carries `REQUEST_INSTALL_PACKAGES`. The docs needed to catch up so they're not actively wrong.

## How

- **DEVELOPMENT.md / README.md / docs/setup-guide.md:** build command updated to `flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=github`; added the Play `.aab` build; noted that `--flavor` is now mandatory and both flavors share the key + package id (so no wipe moving between channels).
- **ARCHITECTURE.md:** CI flow diagram now shows both flavor builds + the `Moongate-play-aab` artifact; added a "Build flavors" note; flagged that the native install channel is compiled out of the Play flavor.
- **SECURITY.md:** the in-app updater / `REQUEST_INSTALL_PACKAGES` section now states it applies to the sideload build only; the Play flavor omits it.

## Testing

- No stale `flutter build apk --release` (without `--flavor`) remains in any `.md` (grep-verified).
- New relative links (`docs/design/play-flavor-plan.md`, `mobile/lib/config/build_channel.dart`) resolve to existing files.
- Docs-only, no version bump, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
