### PR TITLE
Show live temps on the print card before 2% progress

### DIFF
--- a/mobile/lib/services/print_notification_service.dart
+++ b/mobile/lib/services/print_notification_service.dart
@@ -1103,8 +1103,11 @@ class _PrintTaskHandler extends TaskHandler {
   }
 
   /// The card's text for a running / paused print: the user-chosen detail
-  /// segments (progress / remaining / finish-time / temps), or "Printing
-  /// started" until the print is far enough along to estimate.
+  /// segments (progress / remaining / finish-time / temps). Below 2% progress
+  /// the time/progress segments are withheld (Klipper's early estimates are
+  /// wild), but the card still reads "Printing started" plus live heat: the
+  /// ramp ("25→210°") while warming, else the enabled temperature fields - so
+  /// it never looks stalled between the start alert and the first estimate.
   String _cardBody(_Poll s) {
     final segs = _enabledSegments(s);
     if (s.state == 'paused') {
@@ -1114,8 +1117,8 @@ class _PrintTaskHandler extends TaskHandler {
     }
     // printing
     if (s.progress < 0.02) {
-      final warm = _warming(s) ? _heatingSegs(s) : const <String>[];
-      return [_l.printNotifStarted, ...warm].join(' · ');
+      final heat = _warming(s) ? _heatingSegs(s) : _tempSegments(s);
+      return [_l.printNotifStarted, ...heat].join(' · ');
     }
     return segs.isEmpty ? _l.printStatusPrinting : segs.join(' · ');
   }
@@ -1138,6 +1141,20 @@ class _PrintTaskHandler extends TaskHandler {
         if (s.hotendTarget > 0) '${s.hotend.round()}→${s.hotendTarget.round()}°',
         if (s.bedTarget > 0) '${s.bed.round()}→${s.bedTarget.round()}°',
       ];
+
+  /// Just the enabled temperature fields (hotend / bed, in the user's chosen
+  /// order) - the early-print card shows these once the heaters are at target,
+  /// while the time/progress segments are still withheld.
+  List<String> _tempSegments(_Poll s) {
+    final segs = <String>[];
+    for (final f in _fields.order) {
+      if (f != NotifField.hotend && f != NotifField.bed) continue;
+      if (!_fields.enabled.contains(f)) continue;
+      final seg = _fieldSegment(f, s);
+      if (seg != null) segs.add(seg);
+    }
+    return segs;
+  }
 
   /// Localised wall-clock now ("3:45 PM" / "15:45") for the finished card, or
   /// null if the locale's date symbols didn't load.


### PR DESCRIPTION
## What will this PR change?

A small polish to the per-print notification card, from live testing today: below 2% progress the card deliberately hides the detail line because Klipper's early time estimates are nonsense, but that left a bare "Printing started" sitting next to a dashboard already showing 220°/55°, which reads as "notifications are broken".

In plain English: the card now shows the heat from the very first tick. While the heaters ramp it shows the climb ("Printing started · 25→220°", as before), and once they're at temperature it shows the user's enabled hotend/bed fields ("Printing started · 🔥220° · 🟧55°"). Progress, time remaining and finish time still appear at 2% exactly as they do now, so the junk early estimates stay hidden.

Respects the Notification content settings: only enabled temperature fields appear, in the user's chosen order, including the multi-toolhead "🔥210° 205°" form.

**No version bump** - ships with v0.9.47. No new strings, so nothing for translations.

## Testing

- `flutter analyze`: no issues.
- Logic: `_tempSegments` mirrors `_enabledSegments` filtered to the two temperature fields; hotend/bed segments never return null, and a user with both temp fields disabled gets today's bare "Printing started".
- Will be visible on the next real print's first two percent (the exact scenario reported).
