### PR TITLE
Hold a tile's camera to open it full screen + Raw local feed default

### DIFF
--- a/mobile/lib/features/dashboard/printer_tile.dart
+++ b/mobile/lib/features/dashboard/printer_tile.dart
@@ -363,6 +363,26 @@ class _PrinterTileState extends ConsumerState<PrinterTile>
     );
   }
 
+  /// Wrap the webcam square so holding a finger anywhere on the feed opens the
+  /// same full-screen camera overlay as the corner eye (and the printer page's
+  /// camera button) - it runs at the printer's raw target FPS while open, and
+  /// the tile is back on its own throttled rate the moment it closes. Only when
+  /// the tile actually has a live feed, and never in the manual-reorder grid
+  /// ([PrinterTile.bounded]), where a long-press must stay the drag handle.
+  Widget _holdToFullscreen(Widget square) {
+    if (widget.bounded || (_status.webcamSnapshotUrl ?? '').isEmpty) {
+      return square;
+    }
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onLongPress: () {
+        HapticFeedback.mediumImpact();
+        showPrinterCameraOverlay(context, widget.printer);
+      },
+      child: square,
+    );
+  }
+
   /// The E-STOP triangle, or the firmware-restart button when Klipper is shut
   /// down. Shared by the single-hotend row and the multi-toolhead footer. The
   /// E-STOP carries the tutorial anchor (a no-op on non-tutorial tiles).
@@ -584,7 +604,7 @@ class _PrinterTileState extends ConsumerState<PrinterTile>
             // tile give height back rather than overflow.
             _anchor(
                 TutorialAnchors.instance.webcam,
-                _webcamCell(AspectRatio(
+                _webcamCell(_holdToFullscreen(AspectRatio(
               aspectRatio: 1.0,
               child: Stack(
                 fit: StackFit.expand,
@@ -675,7 +695,7 @@ class _PrinterTileState extends ConsumerState<PrinterTile>
                   ),
                 ],
               ),
-            ))),
+            )))),
 
             // ── Progress + buttons in ONE row ────────────────────────────
             // Hide action row when there's nothing to act on: offline,

--- a/mobile/lib/providers/settings_provider.dart
+++ b/mobile/lib/providers/settings_provider.dart
@@ -337,7 +337,8 @@ extension DashboardCameraRefreshX on DashboardCameraRefresh {
 /// Legacy single-rate key (pre-v0.9.14). A user who set it keeps that value:
 /// both the local and tunnel rates fall back to it when their own key is unset,
 /// so updating preserves the old behaviour. Fresh installs use the per-path
-/// defaults below (local 1 s; tunnel 3 s - throttled to save mobile data).
+/// defaults below (local raw - Wi-Fi can afford the printer's own FPS; tunnel
+/// 3 s - throttled to save mobile data).
 const _legacyCameraRefreshKey = 'dashboard_camera_refresh';
 
 /// Shared load/set for the two dashboard camera-refresh settings. A tile reads
@@ -373,7 +374,7 @@ class LocalCameraRefreshNotifier extends _CameraRefreshNotifier {
   @override
   String get key => 'dashboard_camera_refresh_local';
   @override
-  DashboardCameraRefresh get fallback => DashboardCameraRefresh.oneSecond;
+  DashboardCameraRefresh get fallback => DashboardCameraRefresh.raw;
 }
 
 class TunnelCameraRefreshNotifier extends _CameraRefreshNotifier {
@@ -383,7 +384,8 @@ class TunnelCameraRefreshNotifier extends _CameraRefreshNotifier {
   DashboardCameraRefresh get fallback => DashboardCameraRefresh.threeSeconds;
 }
 
-/// Tile webcam refresh rate while the phone is on Wi-Fi (default 1 s).
+/// Tile webcam refresh rate while the phone is on Wi-Fi (default Raw - the
+/// printer's own target FPS).
 final localCameraRefreshProvider =
     NotifierProvider<LocalCameraRefreshNotifier, DashboardCameraRefresh>(
   LocalCameraRefreshNotifier.new,


### PR DESCRIPTION
## What will this PR change?

**Hold your finger on a tile's camera and it opens full screen.** The same full-screen camera view you get from the little eye icon (or the camera button on the printer page) now also opens by pressing and holding anywhere on the camera square itself, with a small haptic buzz. That view already runs at the camera's maximum rate (the target FPS from your Klipper/Crowsnest config) regardless of the dashboard setting, and closing it with the back arrow puts the tile straight back on its normal Raw/1s/3s/5s rate, so nothing else needed changing.

**The Local feed rate now defaults to Raw.** On Wi-Fi the dashboard tiles default to the printer's own frame rate instead of 1 frame per second. If you ever picked a rate yourself you keep it, and the mobile-data (tunnel) rate stays at 3s to protect data plans.

## Why

User request: getting to the full-screen camera needed either a precise tap on the small eye icon or a trip into the printer page. Holding the camera itself is the natural gesture. The Raw local default was already on the v0.9.48 list, and it belongs with this change: Wi-Fi bandwidth is cheap, and a smooth tile makes the hold-to-expand gesture feel right.

## How

- `mobile/lib/features/dashboard/printer_tile.dart`: a new `_holdToFullscreen` wrapper around the webcam square adds `onLongPress` -> `showPrinterCameraOverlay` (the existing shared overlay). It is skipped when the tile has no live feed, and in the manual reorder grid, where long-press must stay the drag handle. Tap still opens the printer page, long-press on the name/temps still opens preheat, and all the corner buttons (gear, bulb, eye, power) keep working.
- `mobile/lib/providers/settings_provider.dart`: `LocalCameraRefreshNotifier`'s fallback changes `oneSecond` -> `raw`. The load path is unchanged: a stored per-path key, or the pre-v0.9.14 legacy key, still wins over the default.

Pure Dart, so iPhone gets both changes automatically. App-only, no plugin/server change, no new strings, no version bump (rides the next release PR's changelog).

## Testing

- `flutter analyze` clean, 11/11 tests pass.
- Release APK builds on the work box (release-signed, cert 8878da71).
- NOT yet device-tested: the dev phone wasn't connected this session. To verify after installing: hold a finger on a tile's camera picture (not the name/temps), expect the buzz + full-screen view; back arrow returns to the dashboard; in Reorder mode a long hold on the camera should still drag the tile, not open the camera; Menu -> Camera feeds on a fresh install should show Local = Raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
