### PR TITLE
Show a friendly retrying overlay instead of Cloudflare's raw 502 page

### DIFF
--- a/mobile/lib/features/printer/printer_screen.dart
+++ b/mobile/lib/features/printer/printer_screen.dart
@@ -101,6 +101,10 @@ class _PrinterScreenState extends State<PrinterScreen>
   Future<void> _start() async {
     final l = AppLocalizations.of(context);
 
+    // An explicit (re)start supersedes any pending auto-retry - without this a
+    // manual Retry racing a scheduled one could fire two loads back to back.
+    _retryTimer?.cancel();
+
     // Warm? Re-attach to the live controller - instant, no reload, no
     // "Initializing…". Re-point the navigation delegate at this screen, then
     // revalidate in the background (a LAN session is dead if you've left home).
@@ -301,6 +305,29 @@ class _PrinterScreenState extends State<PrinterScreen>
         },
         onPageFinished: (_) {
           if (mounted) setState(() => _loading = false);
+        },
+        // A 5xx on the main document is a SUCCESSFUL load to the WebView, so
+        // without this it renders the upstream error page raw - typically
+        // Cloudflare's "Bad gateway" when the tunnel is up but the web stack
+        // behind it is still booting (a cold Pi answers 502/503 for its first
+        // moments; issue #180). Show our own overlay and retry until the page
+        // comes up. Main-document gate: only our loadRequest/reload requests
+        // the bare '/' path - every Mainsail asset/XHR is deeper - and iOS
+        // (which only reports main-frame responses here) may omit the request.
+        onHttpError: (err) {
+          if ((err.response?.statusCode ?? 0) < 500) return;
+          final path = err.request?.uri.path;
+          if (path != null && path != '/' && path != '') return;
+          if (!mounted) return;
+          final l = AppLocalizations.of(context);
+          _retryTimer?.cancel();
+          _retryTimer = Timer(const Duration(seconds: 5), () {
+            if (mounted) _webController?.reload();
+          });
+          setState(() {
+            _loading  = false;
+            _errorMsg = l.printerWebUiRetry(5);
+          });
         },
         onWebResourceError: (err) {
           if (err.isForMainFrame != true) return;

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "Benutzerdefinierte Adresse entfernt",
   "printerAddressUpdated": "Druckeradresse aktualisiert",
   "printerTunnelUnreachable": "Cloudflare-Tunnel nicht erreichbar.\n{description}",
+  "printerWebUiRetry": "Die Weboberfläche des Druckers antwortet noch nicht. Kurz nach dem Einschalten ist das für etwa eine Minute normal. Erneuter Versuch in {seconds}s…",
   "printerEdit": "Drucker bearbeiten",
   "printerLocalNetwork": "Lokales Netzwerk",
   "printerTunnelVia": "Tunnel über Moongate",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -717,6 +717,8 @@
   "@printerAddressUpdated": {"description": "Snackbar confirming the custom printer address override was saved."},
   "printerTunnelUnreachable": "Cloudflare tunnel unreachable.\n{description}",
   "@printerTunnelUnreachable": {"description": "Error-overlay text when the WebView fails to load over the Cloudflare tunnel. 'Cloudflare' is a product name.", "placeholders": {"description": {"type": "String"}}},
+  "printerWebUiRetry": "The printer's web interface isn't answering yet. This is normal for a minute or so after switching on. Retrying in {seconds}s…",
+  "@printerWebUiRetry": {"description": "Error-overlay text when the main page returns a server error (e.g. Cloudflare 502 while the Pi's web stack is still booting behind a live tunnel); auto-retries after the given number of seconds.", "placeholders": {"seconds": {"type": "int"}}},
   "printerEdit": "Edit printer",
   "@printerEdit": {"description": "Tooltip on the app-bar edit button and title of the edit-printer dialog."},
   "printerLocalNetwork": "Local network",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "Dirección personalizada borrada",
   "printerAddressUpdated": "Dirección de la impresora actualizada",
   "printerTunnelUnreachable": "Túnel de Cloudflare inaccesible.\n{description}",
+  "printerWebUiRetry": "La interfaz web de la impresora aún no responde. Es normal durante un minuto aproximadamente tras el encendido. Reintentando en {seconds} s…",
   "printerEdit": "Editar impresora",
   "printerLocalNetwork": "Red local",
   "printerTunnelVia": "Túnel vía Moongate",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "Adresse personnalisée effacée",
   "printerAddressUpdated": "Adresse de l'imprimante mise à jour",
   "printerTunnelUnreachable": "Tunnel Cloudflare injoignable.\n{description}",
+  "printerWebUiRetry": "L'interface web de l'imprimante ne répond pas encore. C'est normal pendant environ une minute après la mise en marche. Nouvelle tentative dans {seconds} s…",
   "printerEdit": "Modifier l'imprimante",
   "printerLocalNetwork": "Réseau local",
   "printerTunnelVia": "Tunnel via Moongate",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "Indirizzo personalizzato cancellato",
   "printerAddressUpdated": "Indirizzo stampante aggiornato",
   "printerTunnelUnreachable": "Tunnel Cloudflare irraggiungibile.\n{description}",
+  "printerWebUiRetry": "L'interfaccia web della stampante non risponde ancora. È normale per circa un minuto dopo l'accensione. Nuovo tentativo tra {seconds} s…",
   "printerEdit": "Modifica stampante",
   "printerLocalNetwork": "Rete locale",
   "printerTunnelVia": "Tunnel tramite Moongate",

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -2218,6 +2218,12 @@ abstract class AppLocalizations {
   /// **'Cloudflare tunnel unreachable.\n{description}'**
   String printerTunnelUnreachable(String description);
 
+  /// Error-overlay text when the main page returns a server error (e.g. Cloudflare 502 while the Pi's web stack is still booting behind a live tunnel); auto-retries after the given number of seconds.
+  ///
+  /// In en, this message translates to:
+  /// **'The printer\'s web interface isn\'t answering yet. This is normal for a minute or so after switching on. Retrying in {seconds}s…'**
+  String printerWebUiRetry(int seconds);
+
   /// Tooltip on the app-bar edit button and title of the edit-printer dialog.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/app_localizations_de.dart
+++ b/mobile/lib/l10n/app_localizations_de.dart
@@ -1198,6 +1198,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'Die Weboberfläche des Druckers antwortet noch nicht. Kurz nach dem Einschalten ist das für etwa eine Minute normal. Erneuter Versuch in ${seconds}s…';
+  }
+
+  @override
   String get printerEdit => 'Drucker bearbeiten';
 
   @override

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -1180,6 +1180,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'The printer\'s web interface isn\'t answering yet. This is normal for a minute or so after switching on. Retrying in ${seconds}s…';
+  }
+
+  @override
   String get printerEdit => 'Edit printer';
 
   @override

--- a/mobile/lib/l10n/app_localizations_es.dart
+++ b/mobile/lib/l10n/app_localizations_es.dart
@@ -1207,6 +1207,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'La interfaz web de la impresora aún no responde. Es normal durante un minuto aproximadamente tras el encendido. Reintentando en $seconds s…';
+  }
+
+  @override
   String get printerEdit => 'Editar impresora';
 
   @override

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -1209,6 +1209,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'L\'interface web de l\'imprimante ne répond pas encore. C\'est normal pendant environ une minute après la mise en marche. Nouvelle tentative dans $seconds s…';
+  }
+
+  @override
   String get printerEdit => 'Modifier l\'imprimante';
 
   @override

--- a/mobile/lib/l10n/app_localizations_it.dart
+++ b/mobile/lib/l10n/app_localizations_it.dart
@@ -1202,6 +1202,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'L\'interfaccia web della stampante non risponde ancora. È normale per circa un minuto dopo l\'accensione. Nuovo tentativo tra $seconds s…';
+  }
+
+  @override
   String get printerEdit => 'Modifica stampante';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pl.dart
+++ b/mobile/lib/l10n/app_localizations_pl.dart
@@ -1196,6 +1196,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'Interfejs WWW drukarki jeszcze nie odpowiada. Przez około minutę po włączeniu to normalne. Ponawianie za $seconds s…';
+  }
+
+  @override
   String get printerEdit => 'Edytuj drukarkę';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pt.dart
+++ b/mobile/lib/l10n/app_localizations_pt.dart
@@ -1200,6 +1200,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'A interface web da impressora ainda não está respondendo. Isso é normal por cerca de um minuto depois de ligar. Tentando novamente em ${seconds}s…';
+  }
+
+  @override
   String get printerEdit => 'Editar impressora';
 
   @override

--- a/mobile/lib/l10n/app_localizations_ru.dart
+++ b/mobile/lib/l10n/app_localizations_ru.dart
@@ -1196,6 +1196,11 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return 'Веб-интерфейс принтера пока не отвечает. В течение минуты после включения это нормально. Повтор через $seconds с…';
+  }
+
+  @override
   String get printerEdit => 'Изменить принтер';
 
   @override

--- a/mobile/lib/l10n/app_localizations_zh.dart
+++ b/mobile/lib/l10n/app_localizations_zh.dart
@@ -1138,6 +1138,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String printerWebUiRetry(int seconds) {
+    return '打印机的网页界面尚未响应。开机后一分钟左右属于正常现象。将在 $seconds 秒后重试…';
+  }
+
+  @override
   String get printerEdit => '编辑打印机';
 
   @override

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "Wyczyszczono niestandardowy adres",
   "printerAddressUpdated": "Zaktualizowano adres drukarki",
   "printerTunnelUnreachable": "Tunel Cloudflare nieosiągalny.\n{description}",
+  "printerWebUiRetry": "Interfejs WWW drukarki jeszcze nie odpowiada. Przez około minutę po włączeniu to normalne. Ponawianie za {seconds} s…",
   "printerEdit": "Edytuj drukarkę",
   "printerLocalNetwork": "Sieć lokalna",
   "printerTunnelVia": "Tunel przez Moongate",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -366,6 +366,7 @@
   "printerAddressCleared": "Endereço personalizado limpo",
   "printerAddressUpdated": "Endereço da impressora atualizado",
   "printerTunnelUnreachable": "Túnel da Cloudflare inacessível.\n{description}",
+  "printerWebUiRetry": "A interface web da impressora ainda não está respondendo. Isso é normal por cerca de um minuto depois de ligar. Tentando novamente em {seconds}s…",
   "printerEdit": "Editar impressora",
   "printerLocalNetwork": "Rede local",
   "printerTunnelVia": "Túnel via Moongate",

--- a/mobile/lib/l10n/app_ru.arb
+++ b/mobile/lib/l10n/app_ru.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "Свой адрес сброшен",
   "printerAddressUpdated": "Адрес принтера обновлён",
   "printerTunnelUnreachable": "Туннель Cloudflare недоступен.\n{description}",
+  "printerWebUiRetry": "Веб-интерфейс принтера пока не отвечает. В течение минуты после включения это нормально. Повтор через {seconds} с…",
   "printerEdit": "Изменить принтер",
   "printerLocalNetwork": "Локальная сеть",
   "printerTunnelVia": "Туннель через Moongate",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -378,6 +378,7 @@
   "printerAddressCleared": "已清除自定义地址",
   "printerAddressUpdated": "已更新打印机地址",
   "printerTunnelUnreachable": "无法连接 Cloudflare 隧道。\n{description}",
+  "printerWebUiRetry": "打印机的网页界面尚未响应。开机后一分钟左右属于正常现象。将在 {seconds} 秒后重试…",
   "printerEdit": "编辑打印机",
   "printerLocalNetwork": "本地网络",
   "printerTunnelVia": "通过 Moongate 隧道",


### PR DESCRIPTION
## What will this PR change?

**No more raw Cloudflare error pages inside the printer view.** When you open a printer and the page comes back with a server error (the "Bad gateway / Error 502" page from issue #180), the app now shows its own message in plain English, "The printer's web interface isn't answering yet. This is normal for a minute or so after switching on. Retrying in 5s", and quietly retries every 5 seconds until Mainsail loads. The moment the Pi's web stack is up, the page appears on its own, no tapping needed. The manual Retry and Use tunnel buttons are still there.

## Why

[#180](https://github.com/PEEKYPAUL/Moongate/issues/180): a user opened their MK3S+ over the tunnel and got Cloudflare's raw 502 page. That page means the tunnel itself was up but Mainsail behind it wasn't answering, which is exactly what a freshly booted Pi looks like for its first moments (the tunnel starts before the web interface). Showing a scary third-party error page for a normal boot window is what made this feel like a Moongate bug.

## How

- `mobile/lib/features/printer/printer_screen.dart`: the WebView treats an HTTP error page as a successful load, so `onWebResourceError` never fired for this. Added the `NavigationDelegate.onHttpError` handler: a main-document response with status 500+ shows the error overlay with the new message and schedules a reload in 5s. Loop continues until a load succeeds. Gated to the main document only (only our own load/reload requests the bare `/` path; every Mainsail asset and API call is deeper), so a failing sub-request can never hide a working page. `_start()` now cancels any pending auto-retry first, so a manual Retry racing the timer can't double-load.
- New `printerWebUiRetry` string translated into all 9 languages (machine-grade, native review owed), generated l10n files regenerated and committed as usual.

Pure Dart, so iPhone gets it automatically (on iOS the callback only reports main-frame responses, which is the same gate). App-only, no plugin/server change, no version bump (rides the next release PR's changelog).

## Testing

- `flutter analyze` clean, 11/11 tests pass, no mojibake in the arb files (checked after the l10n edits).
- NOT device-tested: the dev phone wasn't connected this session. To reproduce on device: power the Pi off and on, open the printer page within the first seconds while "Tunnel via Moongate" shows, expect the Moongate overlay with the retry countdown instead of the Cloudflare page, and the real page to appear by itself once the Pi is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
