### PR TITLE
Stop polling the cloud every 4s for printers that no longer exist

### DIFF
--- a/mobile/lib/services/printer_access_cache.dart
+++ b/mobile/lib/services/printer_access_cache.dart
@@ -15,14 +15,35 @@ class PrinterAccessCache {
 
   final Map<String, PrinterAccess>             _cached  = {};
   final Map<String, Future<PrinterAccess>>     _pending = {};
+  final Map<String, _NotFoundHold>             _notFound = {};
+
+  /// Back-off for cached 404 verdicts: first re-probe after 1 min, doubling
+  /// to a 15-min ceiling. At the ceiling a dead tile costs 4 Edge calls/hr
+  /// instead of ~900, and a printer that legitimately reappears (a restore
+  /// re-binding rows to this account) is picked up on the next probe.
+  static const _notFoundHoldFirst = Duration(minutes: 1);
+  static const _notFoundHoldMax   = Duration(minutes: 15);
 
   void _log(String msg) => dev.log(msg, name: 'MOONGATE/ACCESS');
 
   /// Returns a valid (fresh) `PrinterAccess` for [printerId]. Re-uses the
   /// cached entry if it's not stale; otherwise refreshes via Supabase.
+  ///
+  /// A 404 ("printer not found") is remembered and re-thrown locally until its
+  /// back-off expires, WITHOUT invoking the Edge Function again. A printer
+  /// whose cloud row is gone (deleted, or re-paired/restored onto another
+  /// account) is invisible to the liveness gate - its row is simply absent
+  /// from `last_seen`, which reads as "unknown" and fails open - so before
+  /// this hold every 4s dashboard poll minted-and-404'd forever. One such
+  /// install was ~⅔ of ALL Edge Function invocations (July 2026 quota blow).
   Future<PrinterAccess> get(String printerId) async {
     final cached = _cached[printerId];
     if (cached != null && !cached.isStale()) return cached;
+
+    final hold = _notFound[printerId];
+    if (hold != null && DateTime.now().isBefore(hold.until)) {
+      throw PrinterNotFoundException();
+    }
 
     // Coalesce concurrent refreshes
     final inflight = _pending[printerId];
@@ -33,7 +54,18 @@ class PrinterAccessCache {
     try {
       final access = await future;
       _cached[printerId] = access;
+      _notFound.remove(printerId);
       return access;
+    } on PrinterNotFoundException {
+      final next = hold?.nextHold ?? _notFoundHoldFirst;
+      final doubled = next * 2;
+      _notFound[printerId] = _NotFoundHold(
+        until:    DateTime.now().add(next),
+        nextHold: doubled > _notFoundHoldMax ? _notFoundHoldMax : doubled,
+      );
+      _log('404 for $printerId - holding printer-access probes for '
+          '${next.inSeconds}s');
+      rethrow;
     } finally {
       _pending.remove(printerId);
     }
@@ -45,14 +77,28 @@ class PrinterAccessCache {
   }
 
   /// Drop the cached entry for [printerId] - call after a 401 from the Pi
-  /// (the token may be stale despite our local clock saying otherwise).
+  /// (the token may be stale despite our local clock saying otherwise). Also
+  /// lifts any 404 hold: every call site is a user-driven retry (the error
+  /// overlay's Retry, the printer page's refresh), which deserves one real
+  /// probe immediately.
   void invalidate(String printerId) {
     _cached.remove(printerId);
+    _notFound.remove(printerId);
   }
 
   /// Wipe everything. Called on sign-out / user change.
   void clear() {
     _cached.clear();
     _pending.clear();
+    _notFound.clear();
   }
+}
+
+/// One remembered "the cloud says this printer doesn't exist" verdict:
+/// suppress further Edge calls until [until], and if the next probe 404s
+/// again, hold for [nextHold] (doubling toward the ceiling).
+class _NotFoundHold {
+  final DateTime until;
+  final Duration nextHold;
+  const _NotFoundHold({required this.until, required this.nextHold});
 }


### PR DESCRIPTION
## What will this PR change?

**The app stops hammering the cloud when a printer no longer exists.** If a printer tile points at a printer whose cloud registration is gone (it was deleted, or moved to another device via a restore), the app used to ask the server for access every 4 seconds, forever, getting "not found" every time. It now remembers that answer and waits before asking again, starting at 1 minute and backing off to once every 15 minutes. The tile shows offline exactly as before; nothing changes visually.

## Why

This is what's burning the Supabase quota. Today's log investigation found a single Android install making ~1,620 `printer-access` calls per hour, all 404s, about two thirds of ALL Edge Function invocations, running since ~6-7 July. Usage is at 340k of the 500k free tier with 15 days of the billing cycle left, and the grace period from last cycle's overage ends 22 July. It's the app-side twin of June's orphaned-Pi heartbeat spinner (plugin 0.6.10, #132).

The gap: the June liveness gate skips polling only on positive "offline" evidence from `last_seen`. A deleted row has no `last_seen` at all, which reads as "unknown", and unknown deliberately fails open. Every 4s poll then minted a token, got 404, and nothing cached the failure.

## How

One file, `mobile/lib/services/printer_access_cache.dart`: the cache now stores a per-printer "not found" verdict with an expiry and re-throws it locally instead of re-invoking the Edge Function. Back-off doubles from 1 minute to a 15-minute ceiling (4 calls/hr instead of ~900, a 99.6% cut per dead tile). Both hot paths (the 4s dashboard poll and the 24/7 notification service) already go through this cache and already handle the not-found error, so no call-site changes. `invalidate()` lifts the hold because its call sites are user-driven retries, and a printer that comes back (a restore onto this device) is picked up on the first probe after the hold expires.

Pure Dart, app-only, both platforms, no strings, no version bump (rides the next release's changelog).

## Testing

- `flutter analyze` clean, 11/11 tests pass.
- NOT device-tested (dev phone not connected). To verify after install: add a printer, delete its row from the cloud (or restore its backup onto a second device), and watch `MOONGATE/ACCESS` logs: one "404 ... holding" line per back-off step instead of a mint every 4 seconds. The affected user in the wild stops spinning as soon as they update to a build containing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
