### PR TITLE
Plugin 0.6.13: stop a failing Pi from re-fetching signing keys on every request

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -63,7 +63,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.12"
+MOONGATE_PLUGIN_VERSION = "0.6.13"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -258,13 +258,24 @@ class DeviceKey:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class JwksCache:
+    # Minimum spacing between /jwks fetch ATTEMPTS. A successful fetch is
+    # naturally rate-limited by `ttl` (it updates _fetched_at), but a FAILED
+    # one is not - fetch_now() leaves _fetched_at stale on failure, so before
+    # this guard a Pi whose fetch never succeeds (no network, or a broken
+    # cryptography lib yielding "no usable keys" from a 200) re-fetched on
+    # EVERY token verification. One such Pi was ~245 calls/hr - nearly all
+    # the jwks Edge Function invocations fleet-wide (2026-07-09 log audit).
+    # Worst case this adds ~2 min of 401s after an outage before keys land.
+    FETCH_RETRY_SECONDS = 120
+
     def __init__(self, supabase_url: str, anon_key: str, cache_path: Path, ttl: int) -> None:
         self.supabase_url = supabase_url.rstrip("/")
         self.anon_key     = anon_key
         self.cache_path   = cache_path
         self.ttl          = ttl
-        self._keys:       Dict[str, Ed25519PublicKey] = {}
-        self._fetched_at: float                       = 0.0
+        self._keys:        Dict[str, Ed25519PublicKey] = {}
+        self._fetched_at:  float                       = 0.0
+        self._attempt_at:  float                       = 0.0
         self._load_from_disk()
 
     def _load_from_disk(self) -> None:
@@ -292,6 +303,7 @@ class JwksCache:
 
     def fetch_now(self) -> bool:
         """Synchronously fetch /jwks. Returns True iff at least one key landed."""
+        self._attempt_at = time.time()
         url = f"{self.supabase_url}/functions/v1/jwks"
         req = urllib.request.Request(url, headers={"apikey": self.anon_key})
         try:
@@ -328,7 +340,9 @@ class JwksCache:
         return True
 
     def get_key(self, kid: str) -> Optional[Ed25519PublicKey]:
-        if time.time() - self._fetched_at > self.ttl:
+        now = time.time()
+        if (now - self._fetched_at > self.ttl
+                and now - self._attempt_at > self.FETCH_RETRY_SECONDS):
             self.fetch_now()
         return self._keys.get(kid)
 


### PR DESCRIPTION
## What will this PR change?

**A Pi that can't load the signing keys stops hammering the key server.** The plugin fetches Moongate's token-signing keys from the cloud about once an hour. If that fetch keeps failing (no network, or a Pi with a broken Python crypto install that can't parse the keys), the plugin used to retry on every single incoming request, forever. It now waits 2 minutes between attempts. Healthy Pis are completely unaffected.

## Why

Part of today's Supabase quota investigation ([PR #193](https://github.com/PEEKYPAUL/Moongate/pull/193) is the other half). The logs show one Pi in the US making ~245 key-fetch calls per hour, about 96% of all `jwks` Edge Function invocations, while every other Pi in the fleet fetches 1-4 times an hour exactly as designed. That one Pi gets a successful HTTP response but ends up with zero usable keys (the "broken cryptography install" case), which the cache treats as "still stale, try again on the next request".

## How

`klipper-plugin/moongate_standalone.py`, `JwksCache`: a new `_attempt_at` timestamp records every fetch attempt, and `get_key()` won't re-attempt within 120 seconds of the last one, successful or not. Success was already rate-limited by the 1-hour TTL, so this only bounds the failure loop: ~245/hr drops to a worst case of 30/hr. The trade-off is up to ~2 minutes of remote-access 401s after a network outage before the keys land, and only when the on-disk key cache was already stale (a freshly booted Pi with a fresh cache never hits it). The authproxy imports this same class, so both processes get the fix.

Plugin version 0.6.12 to 0.6.13. No app change, no protocol change; existing Pis pick it up through the Moonraker update panel.

## Testing

- Both plugin files compile clean (`py_compile`); the Moonraker plugin lint CI check covers style.
- NOT Pi-tested. To verify on a test Pi: stop the network, expire the cache (`rm ~/.config/moongate/jwks.json`, restart), hit the proxy repeatedly, and confirm the log shows one "JWKS fetch failed" per ~2 min instead of one per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
