### PR TITLE
ci: workflow_dispatch input to override the Play .aab build number

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      play_build_number:
+        description: "Play .aab versionCode override (e.g. 121). Empty = pubspec's build number. Only affects the .aab artifact; the APK, Release and manifest are untouched."
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -65,8 +71,14 @@ jobs:
         # REQUEST_INSTALL_PACKAGES (see the `play` flavor + src/github split).
         # Uploaded as a workflow artifact for a MANUAL Play Console submission -
         # it is never auto-published, mirroring the iOS altool/ASC flow.
+        # play_build_number exists so a corrected bundle can be cut from exact
+        # master when Play has consumed a versionCode on a bad upload (the
+        # 2026-07-09 incident: a stale work-box checkout shipped v0.9.46 code
+        # labelled 0.9.48/120). Always prefer this over local .aab builds.
         working-directory: mobile
-        run: flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play
+        env:
+          PLAY_BUILD_NUMBER: ${{ github.event.inputs.play_build_number }}
+        run: flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play ${PLAY_BUILD_NUMBER:+--build-number=$PLAY_BUILD_NUMBER}
 
       - name: Stage APK + read version
         # The signed APK is published ONLY as a GitHub Release asset (next step)


### PR DESCRIPTION
## What will this PR change?

Adds a way to rebuild the Play Store bundle from the correct code with a manually chosen internal version number, straight from GitHub's own build servers. Plain English: tonight we found the bundle Play is serving as "0.9.48 (120)" actually contains v0.9.46 code, and since Play refuses to ever accept the number 120 again, we need to ship the real 0.9.48 code as number 121. This PR makes that a two-click GitHub Actions job instead of a hand-run build on the work box (a hand-run build from a stale checkout is exactly what caused this).

## Why

The Play closed-test build 120 was verified on the dev phone to be mislabelled: the compiled app binary contains none of the v0.9.47/v0.9.48 strings (Local-only button, the "isn't answering yet" overlay, the restore Keep/Remove dialog, Portuguese), while old strings are present. The GitHub sideload release of v0.9.48 is unaffected (built by CI from the final merge). Consequence: Play testers are effectively still on v0.9.46 and the printer-access 404 back-off (#193) is NOT deployed on the Play channel.

## How

- New optional `workflow_dispatch` input `play_build_number`; when set, the Build Play App Bundle step appends `--build-number=<n>`.
- Implemented as a shell default-expansion (`${VAR:+...}`), so push/PR builds see an empty env var and behave byte-identically to before.
- The Release-publish, manifest-push and prune steps remain gated on `push` to master, so a manual dispatch run only produces the two workflow artifacts and cannot touch the GitHub release chain.

## Testing / rollout

After merge: Actions -> Build Android APK -> Run workflow (branch master, play_build_number = 121) -> download the `Moongate-play-aab` artifact -> upload to the Play closed track as build 121 (0.9.48). Same-track uploads do not reset the 14-day clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
