### PR TITLE
fix(plugin): stop the auth proxy filling /run with access logs (0.6.14)

### DIFF
--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -608,8 +608,9 @@ Environment=MG_MAINSAIL=http://127.0.0.1:$MOONGATE_PORT
 Environment=MG_PLUGIN_DIR=$PLUGIN_DIR
 Environment=MG_LOG_LEVEL=INFO
 
-StandardOutput=append:/run/moongate-authproxy.log
-StandardError=append:/run/moongate-authproxy.log
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=moongate-authproxy
 
 NoNewPrivileges=true
 ProtectSystem=strict

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -650,6 +650,10 @@ fi
 # Use StandardOutput/StandardError instead of cloudflared's --logfile flag:
 # cloudflared prints the tunnel URL banner to stdout; systemd captures it
 # and appends it to /run/moongate-tunnel.log where the plugin can read it.
+# NOTE: unlike the authproxy unit (which logs to the journal, see step 6),
+# this one MUST stay an append: file - the plugin parses the tunnel URL from
+# it. That is safe only because cloudflared is quiet (a banner + occasional
+# reconnect lines, KBs over weeks); never point a chatty service at /run.
 #
 # v0.4: target is now the auth proxy ($MG_AUTHPROXY_PORT) instead of
 # Moonraker / Mainsail directly. Every request goes through the EdDSA gate

--- a/klipper-plugin/moongate-authproxy.service
+++ b/klipper-plugin/moongate-authproxy.service
@@ -50,10 +50,14 @@ Environment=MG_MAINSAIL=http://127.0.0.1:80
 # Where to find moongate_standalone.py for the shared verifier classes.
 Environment=MG_PLUGIN_DIR=REPLACE_PLUGIN_DIR
 
-# Logging
+# Logging goes to the journal (journalctl -u moongate-authproxy), which
+# journald rate-limits and size-caps. Never append to a file on /run: it
+# is a small tmpfs with no rotation, and an unbounded log there fills it
+# and breaks sudo + other daemons (seen live 2026-07-10).
 Environment=MG_LOG_LEVEL=INFO
-StandardOutput=append:/run/moongate-authproxy.log
-StandardError=append:/run/moongate-authproxy.log
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=moongate-authproxy
 
 # Hardening - proxy doesn't need any of these.
 NoNewPrivileges=true

--- a/klipper-plugin/moongate_authproxy.py
+++ b/klipper-plugin/moongate_authproxy.py
@@ -655,7 +655,12 @@ def main() -> None:
         level=getattr(logging, LOG_LEVEL, logging.INFO),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
-    web.run_app(make_app(), host=LISTEN_HOST, port=LISTEN_PORT)
+    # access_log=None: aiohttp's default access logger writes one INFO line
+    # per proxied request, and at the app's poll cadence that is ~13 MB/day
+    # into a log nothing rotates (it filled a Pi's /run tmpfs in ~2 weeks).
+    # The lines also carry the mg_token query parameter. Warnings/errors
+    # from the proxy itself still log normally.
+    web.run_app(make_app(), host=LISTEN_HOST, port=LISTEN_PORT, access_log=None)
 
 
 if __name__ == "__main__":

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -63,7 +63,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.13"
+MOONGATE_PLUGIN_VERSION = "0.6.14"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/klipper-plugin/update.sh
+++ b/klipper-plugin/update.sh
@@ -42,4 +42,35 @@ for webroot in "$HOME/mainsail" "$HOME/printer_data/www" "$HOME/fluidd"; do
 done
 [[ $DEPLOYED -eq 0 ]] && warn "No web-root found - pair page not deployed"
 
+# ── 3. One-time migration: move authproxy logging off /run ───────────────────
+# Units written before plugin 0.6.14 appended stdout/stderr to
+# /run/moongate-authproxy.log with no rotation; at the app's poll rate that
+# fills the /run tmpfs (~168 MB on a Pi) in a couple of weeks of uptime,
+# which breaks sudo and anything else that writes to /run. New installs log
+# to the journal; migrate old units here. Best effort only: this hook runs
+# from Moonraker with no terminal, so it can only sudo when passwordless
+# sudo is configured (the MainsailOS default) - otherwise print the manual
+# commands. Moonraker restarts itself right after this hook and PartOf=
+# propagates that restart to the authproxy, which picks up the new unit.
+UNIT_FILE=/etc/systemd/system/moongate-authproxy.service
+if grep -qs 'append:/run/moongate-authproxy\.log' "$UNIT_FILE"; then
+    if sudo -n true 2>/dev/null; then
+        sudo -n sed -i \
+            -e 's|^StandardOutput=append:/run/moongate-authproxy\.log$|StandardOutput=journal|' \
+            -e 's|^StandardError=append:/run/moongate-authproxy\.log$|StandardError=journal|' \
+            "$UNIT_FILE"
+        grep -q '^SyslogIdentifier=' "$UNIT_FILE" || sudo -n sed -i \
+            '/^StandardError=journal$/a SyslogIdentifier=moongate-authproxy' "$UNIT_FILE"
+        sudo -n rm -f /run/moongate-authproxy.log
+        sudo -n systemctl daemon-reload
+        ok "authproxy logging moved to the journal (journalctl -u moongate-authproxy)"
+    else
+        warn "authproxy still logs to /run/moongate-authproxy.log and will slowly fill /run."
+        warn "Fix manually:"
+        warn "  sudo sed -i 's|append:/run/moongate-authproxy.log|journal|' $UNIT_FILE"
+        warn "  sudo rm -f /run/moongate-authproxy.log"
+        warn "  sudo systemctl daemon-reload && sudo systemctl restart moongate-authproxy"
+    fi
+fi
+
 ok "Update complete."

--- a/klipper-plugin/update.sh
+++ b/klipper-plugin/update.sh
@@ -70,7 +70,12 @@ if grep -qs 'append:/run/moongate-authproxy\.log' "$UNIT_FILE"; then
         warn "  sudo sed -i 's|append:/run/moongate-authproxy.log|journal|' $UNIT_FILE"
         warn "  sudo rm -f /run/moongate-authproxy.log"
         warn "  sudo systemctl daemon-reload && sudo systemctl restart moongate-authproxy"
+        warn "If /run is already full, a single power-cycle also clears it (/run is a"
+        warn "RAM disk, emptied on every boot) - the updated proxy then stays quiet."
     fi
 fi
+# /run/moongate-tunnel.log intentionally stays a file: the plugin reads the
+# cloudflared tunnel URL out of it, and cloudflared only writes a banner plus
+# occasional reconnect lines (KBs over weeks, cleared on every boot).
 
 ok "Update complete."


### PR DESCRIPTION
## What will this PR change?

Plain English: the Pi-side helper that guards remote access (the auth proxy) has been writing a log line for every single status check the app makes. That log lives on a small RAM disk (`/run`) that nothing ever empties. After a couple of weeks of printer uptime the RAM disk fills up completely, and then unrelated things on the Pi start failing in confusing ways (sudo breaks, for one). This PR makes the proxy stop logging routine requests (real errors still log), moves its logging into the system journal which cleans up after itself, and teaches the updater to repair printers that already have the old setup.

Concretely:
- `moongate_authproxy.py` passes `access_log=None` to aiohttp, so per-request lines stop. This is the load-bearing fix and ships to every install via the normal plugin update (Moonraker restarts after the update, and `PartOf=` restarts the proxy with it, verified live).
- New installs write the authproxy unit with `StandardOutput=journal` / `StandardError=journal` plus a `SyslogIdentifier`, instead of appending to `/run/moongate-authproxy.log`. The reference `.service` file and the `install.sh` heredoc are kept in lockstep.
- `update.sh` gains a one-time migration for existing installs: rewrite the unit to journal logging, delete the stale `/run` log, `daemon-reload`. Best effort: it only acts when passwordless sudo is available (the update hook has no terminal); otherwise it prints the exact manual commands, plus the hint that a single power-cycle also clears `/run` (it is a RAM disk, emptied on every boot).
- Plugin version 0.6.13 -> 0.6.14.

## How this reaches the whole fleet

- Every machine: the Python change (stop writing access lines) needs no privileges and deploys through the ordinary Moongate update. This alone ends the growth everywhere, even where the old unit file remains.
- Machines with passwordless sudo (the Raspberry Pi OS / MainsailOS default): `update.sh` also migrates the unit to the journal and deletes the stale log automatically.
- Machines without passwordless sudo: the update console shows the manual commands and the reboot hint. Until then the old file target stays but receives almost nothing (warnings/errors only).

## Scope note: the tunnel log stays a file, on purpose

`/run/moongate-tunnel.log` is not migrated: the plugin parses the cloudflared tunnel URL out of that file, so pointing the tunnel unit at the journal would break URL discovery. cloudflared is quiet (a startup banner plus occasional reconnect lines; 12 KB after 24 days on the machine this was found on), and the file clears on every boot. Both scripts now carry a comment explaining this. Possible follow-up, not in this PR: read the URL via `journalctl -u moongate-tunnel` and move that unit to the journal too.

## Why

Found this morning on the RatRig (24 days uptime) while investigating a "stuck updater" report: `/run` was 100% full, and 167 MB of its 168 MB was `/run/moongate-authproxy.log`. The log had actually been full since 28 June, silently failing to write since then. A full `/run` is what made sudo misbehave during diagnosis, and it can bite other daemons too. Every Moongate install with a few weeks of uptime will hit this.

Two extra reasons beyond the disk-space bug:
- The access lines include the `mg_token` JWT in the URL, landing short-lived auth tokens in a world-readable file. Killing the access log removes that.
- Even with quiet logging, an append-to-file unit on tmpfs can never be made safe against error spam; the journal is rate-limited and size-capped by journald, so it cannot fill `/run` by design.

## Testing

- Live forensics and remediation on the affected Pi (mainsailos, Pi 4): confirmed the file was the entire `/run` usage, confirmed `PartOf=` propagates the Moonraker restart to the proxy (service timestamps), ran the exact migration commands from `update.sh`, verified the unit now shows `journal` lines, the proxy restarted `active`, answers 401 to tokenless requests as designed, and `/run` is back to 1% used.
- Also verified the no-passwordless-sudo fallback path fires correctly (this Pi needs a sudo password, so the `sudo -n` gate correctly declined and the warn path ran).
- `bash -n` on `install.sh` and `update.sh`; `py_compile` on both Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
