### PR TITLE
docs: /run-full trap + frozen KlipperScreen update console (plugin 0.6.14 session)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -190,7 +190,7 @@ Practical implications:
 - **The plugin does not run arbitrary G-code on behalf of token holders.** There is no `POST /server/moongate/gcode` endpoint. Print control is restricted to the five whitelisted actions; adding more requires editing [`klipper-plugin/moongate_standalone.py`](klipper-plugin/moongate_standalone.py) and auditing the new behaviour.
 - **The plugin reads its own state from `~/.config/moongate/`** and calls `systemctl` / `journalctl` to discover the current tunnel URL when its own log lookup fails. It does not read `printer.cfg` or any other Klipper internals beyond what Moonraker exposes.
 
-The auth proxy is even more constrained - it doesn't talk to Klipper at all, it just routes HTTP / WebSocket between Cloudflare and nginx. The verifier classes it uses for token checks are imported from the plugin file, not duplicated, so signature semantics stay single-source.
+The auth proxy is even more constrained - it doesn't talk to Klipper at all, it just routes HTTP / WebSocket between Cloudflare and nginx. The verifier classes it uses for token checks are imported from the plugin file, not duplicated, so signature semantics stay single-source. Since plugin **0.6.14** it also keeps **no per-request access log**: earlier versions wrote one to `/run/moongate-authproxy.log` on the Pi, including the short-lived `mg_token` query values (local to the Pi and cleared on reboot, but more than a proxy needs to record); now only its own warnings and errors are emitted, into the systemd journal.
 
 ---
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -47,6 +47,22 @@ sudo systemctl restart KlipperScreen
 
 `127.0.0.1` is also sturdier than a LAN IP - it survives the Pi's address changing on a DHCP renewal. A client on a **separate device** (a standalone KlipperScreen tablet, a second Pi) can't use localhost and is fundamentally incompatible with the rebind; run it on the printer Pi instead.
 
+## Updating Moongate from KlipperScreen looks stuck on "create mode 100644"
+
+Cosmetic - the update has actually completed. A Moongate plugin update restarts Moonraker as its final step, and KlipperScreen's update console watches the update through a live Moonraker connection. The restart cuts that connection mid-scroll, so the console freezes on the last line it received (usually one of git's `create mode 100644` file lines) and the "finished" message never arrives. Close the dialog and carry on, or restart KlipperScreen from Mainsail's **Services** panel if it won't dismiss. You can confirm the update landed under **Machine → Software Updates**: Moongate shows up to date.
+
+(Klipper itself is left alone on purpose: the plugin lives inside Moonraker, so a plugin update never needs to touch a running print.)
+
+## The Pi acts strangely after weeks of uptime (failed updates, sudo password errors)
+
+Plugin versions before **0.6.14** kept the remote-access proxy's request log on a small memory-backed disk (`/run`) that nothing trimmed. A printer left powered on for a few weeks could fill it completely, and a full `/run` makes unrelated things on the Pi misbehave: `sudo` fails with odd errors, updates act up, services get flaky. Check with:
+
+```bash
+df -h /run
+```
+
+If it shows 100% (and `du -sh /run/*` blames `moongate-authproxy.log`), that's this. Fix: **update the Moongate plugin to 0.6.14 or later** (Mainsail → Machine → Software Updates), which stops the log growing for good, then **reboot the Pi once** to empty the memory disk. After that it can't recur: the proxy now logs almost nothing, and what it does log goes to the system journal, which cleans up after itself.
+
 ## All your printers suddenly show offline (and you use a VPN)
 
 If every printer goes offline at once, especially after reinstalling the app or changing networks, and trying to connect shows a `trycloudflare.com` address failing, check whether a **VPN** on your phone is in the way.

--- a/docs/managing-moongate.md
+++ b/docs/managing-moongate.md
@@ -18,6 +18,8 @@ Prefer to do it by hand? Tap **What's new** on the banner to read the changes fi
 
 Pi-side updates appear automatically in **Mainsail → Machine → Software Updates → Moongate** - click **Update** there, no SSH needed.
 
+> Updating from **KlipperScreen** instead? If the update console seems to freeze on a line like `create mode 100644`, the update has completed - the console just loses its connection when Moonraker restarts at the end. See [Troubleshooting](../TROUBLESHOOTING.md#updating-moongate-from-klipperscreen-looks-stuck-on-create-mode-100644).
+
 Prefer the command line? SSH in and re-run the installer - it pulls the latest and restarts the services:
 
 ```bash


### PR DESCRIPTION
## What will this PR change?

Plain English: documents today's plugin 0.6.14 fix for users. Two new Troubleshooting entries (the full RAM-disk problem on long-running printers, and the KlipperScreen update console that looks frozen but isn't), a note in the plugin update guide pointing at the second one, and a line in SECURITY.md recording that the proxy no longer logs request URLs or tokens.

- **TROUBLESHOOTING.md**: "The Pi acts strangely after weeks of uptime" (df -h /run check, update to 0.6.14, reboot once) and "Updating Moongate from KlipperScreen looks stuck on create mode 100644" (cosmetic; why Klipper is never restarted by a plugin update).
- **docs/managing-moongate.md**: pointer to the KlipperScreen entry in the plugin-update section.
- **SECURITY.md**: the auth proxy keeps no per-request access log since 0.6.14; earlier versions recorded mg_token query values in a Pi-local file.

## Why

Both issues were hit live on a real printer this morning (the "stuck updater" report that led to #199). Users will hit them too: every install older than 0.6.14 grows the log, and every KlipperScreen user who updates the plugin sees the frozen console.

## Testing

- Link audit across all 20 Markdown files passed, including the new cross-doc anchor.
- Text mirrors what was verified live on the affected Pi today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
