### PR TITLE
Orphaned printers go dormant + releases become tombstones (plugin 0.6.15)

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -63,7 +63,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.14"
+MOONGATE_PLUGIN_VERSION = "0.6.15"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -580,13 +580,29 @@ class HeartbeatLoop:
         sb: SupabaseClient,
         interval: int,
         on_unpaired_cb=None,
+        on_dormant_cb=None,
     ) -> None:
         self.device      = device
         self.sb          = sb
         self.interval    = interval
         self.on_unpaired = on_unpaired_cb
+        self.on_dormant  = on_dormant_cb
         self._task: Optional[asyncio.Task] = None
         self._last_url_reported: Optional[str] = None
+        # Orphan dormancy (v0.6.15). A Pi whose cloud row is gone for good
+        # used to heartbeat forever - ~8.6k Edge Function calls/month each at
+        # the steady cadence, and one pre-0.6.10 spinner ≈ the whole free
+        # quota (2026-06-24 and 2026-07-13 log audits). Once the server has
+        # answered "no such printer" for a full day with no pairing activity,
+        # or has said outright that the owner released this printer (410),
+        # the loop drops to a 6-hourly pulse. Any poke (MOONGATE_PAIR, an
+        # owner bind) or an accepted heartbeat wakes it instantly, so every
+        # recovery path is untouched. In-memory only: a Moonraker restart
+        # buys one more day of steady-cadence probing before re-dorming,
+        # which is self-limiting and makes a stuck-dormant state impossible.
+        self._dormant:         bool            = False
+        self._notfound_streak: int             = 0
+        self._notfound_since:  Optional[float] = None
         # Wall-clock deadline until which we hold the fast bootstrap cadence
         # after a pairing poke, so a transient send failure (e.g. flaky WiFi)
         # doesn't drop us to the 5-minute interval mid-pair. 0 = not active.
@@ -621,6 +637,21 @@ class HeartbeatLoop:
     # 5-minute heartbeat cycle (flaky-WiFi boards like the CB1).
     _FAST_WINDOW_SECONDS = 180
 
+    # Dormancy trigger: this many CONSECUTIVE confirmed "not_found" answers
+    # spanning at least _DORMANT_AFTER_SECONDS, with no pairing activity in
+    # between. The count floor keeps a handful of stray 404s from qualifying;
+    # the time floor keeps a legitimate "reset tonight, re-pair tomorrow" gap
+    # from qualifying (waiting costs ~288 calls per orphan event - nothing
+    # next to the ~8.6k/month an orphan burns forever). Only bodies carrying
+    # the server's own {"error": "not_found"} marker count, so a proxy/CDN
+    # 404 during an outage can never dorm the fleet.
+    _DORMANT_MIN_STREAK    = 12
+    _DORMANT_AFTER_SECONDS = 24 * 3600
+
+    # Dormant pulse cadence. ~4 calls/day (vs ~288) keeps "the row came back"
+    # recovery alive without the cost - and means dormant never equals dead.
+    _DORMANT_INTERVAL = 6 * 3600
+
     async def _run(self) -> None:
         # First heartbeat after a brief delay so cloudflared has time to come up
         await asyncio.sleep(5)
@@ -643,11 +674,15 @@ class HeartbeatLoop:
             # (armed above), the post-poke window (request_immediate_send), or
             # the post-404 re-pair window. Each is capped by _FAST_WINDOW_SECONDS
             # so a Pi that never lands a cloud row falls back to the steady
-            # interval instead of polling every 5 s forever.
+            # interval instead of polling every 5 s forever. A dormant orphan
+            # sits below even the steady interval, on the 6-hourly pulse.
             fast = time.time() < self._fast_deadline
-            effective_interval = (
-                self._BOOTSTRAP_INTERVAL if fast else self.interval
-            )
+            if self._dormant:
+                effective_interval = self._DORMANT_INTERVAL
+            elif fast:
+                effective_interval = self._BOOTSTRAP_INTERVAL
+            else:
+                effective_interval = self.interval
             # Wait for either the scheduled interval OR a poke from
             # MOONGATE_PAIR. Poke wakes the loop early so the cloud sees
             # the current tunnel URL before the user's app calls
@@ -673,8 +708,14 @@ class HeartbeatLoop:
         Now we keep retrying every few seconds until the cloud accepts it.
 
         Idempotent; the poke itself is a no-op until the loop has started (the
-        first 5 s post-boot), but the fast window is still armed."""
+        first 5 s post-boot), but the fast window is still armed.
+
+        A poke is also what wakes a dormant orphan: every pairing path runs
+        through here (MOONGATE_PAIR and the owner bind in _authenticate), so
+        dormancy ends the instant a user starts pairing - no special recovery
+        step to know about."""
         self._fast_deadline = time.time() + self._FAST_WINDOW_SECONDS
+        self._clear_orphan_state("pairing activity")
         if self._poke_event is not None:
             self._poke_event.set()
 
@@ -694,6 +735,7 @@ class HeartbeatLoop:
             # Got through - drop out of the post-poke fast window and resume the
             # steady cadence.
             self._fast_deadline = 0.0
+            self._clear_orphan_state("heartbeat accepted")
             if tunnel != self._last_url_reported:
                 logger.info("Heartbeat: reported tunnel URL %s", tunnel)
                 self._last_url_reported = tunnel
@@ -721,6 +763,25 @@ class HeartbeatLoop:
                     self.on_unpaired()
                 except Exception as exc:
                     logger.warning("on_unpaired callback failed: %s", exc)
+            # Count only the server's own answer towards dormancy - a generic
+            # gateway/CDN 404 (no marker body) stays a transient.
+            if body.get("error") == "not_found":
+                self._note_confirmed_notfound()
+            return
+        if status == 410:
+            # Explicit, server-verified answer: the owner deliberately released
+            # this printer (its tombstone row is still on the server). No
+            # guessing needed - stop the cloud chatter right away. MOONGATE_PAIR
+            # wakes us and pairs again as if nothing happened.
+            logger.warning("Heartbeat 410 - the owner released this printer")
+            self._last_url_reported = None
+            if self.on_unpaired:
+                try:
+                    self.on_unpaired()
+                except Exception as exc:
+                    logger.warning("on_unpaired callback failed: %s", exc)
+            if body.get("error") == "printer_released":
+                self._enter_dormant("released by its owner")
             return
         if status == 401:
             skew = self.sb.clock_skew_seconds()
@@ -736,6 +797,47 @@ class HeartbeatLoop:
                 logger.warning("Heartbeat 401 - signature or replay window failure")
             return
         logger.warning("Heartbeat HTTP %s: %s", status, body)
+
+    # ── Orphan dormancy (v0.6.15) ────────────────────────────────────────────
+
+    @property
+    def dormant(self) -> bool:
+        return self._dormant
+
+    def _note_confirmed_notfound(self) -> None:
+        """Advance the orphan evidence: one more confirmed "no such printer"
+        answer. Network errors and 401s neither count nor reset - only an
+        accepted heartbeat or pairing activity clears the streak."""
+        now = time.time()
+        if self._notfound_since is None:
+            self._notfound_since = now
+        self._notfound_streak += 1
+        if (not self._dormant
+                and self._notfound_streak >= self._DORMANT_MIN_STREAK
+                and now - self._notfound_since >= self._DORMANT_AFTER_SECONDS
+                and now >= self._fast_deadline):
+            self._enter_dormant("unknown to the cloud for a day")
+
+    def _clear_orphan_state(self, reason: str) -> None:
+        self._notfound_streak = 0
+        self._notfound_since  = None
+        if self._dormant:
+            self._dormant = False
+            logger.info("Heartbeat waking from dormant (%s)", reason)
+
+    def _enter_dormant(self, why: str) -> None:
+        if self._dormant:
+            return
+        self._dormant = True
+        logger.warning(
+            "Heartbeat going dormant (this printer was %s): dropping to one "
+            "pulse every %d h. Run MOONGATE_PAIR to pair again at any time.",
+            why, self._DORMANT_INTERVAL // 3600)
+        if self.on_dormant:
+            try:
+                self.on_dormant(why)
+            except Exception as exc:
+                logger.warning("on_dormant callback failed: %s", exc)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -760,10 +862,15 @@ class PrintEventWatcher:
     # catch a finished print promptly without being chatty.
     _POLL_INTERVAL = 20
 
-    def __init__(self, device: DeviceKey, sb: SupabaseClient, moonraker_port: int = 7125) -> None:
+    def __init__(self, device: DeviceKey, sb: SupabaseClient,
+                 moonraker_port: int = 7125, is_dormant=None) -> None:
         self.device = device
         self.sb     = sb
         self.port   = moonraker_port
+        # Callable answering "is cloud contact dormant?" (see HeartbeatLoop).
+        # A dormant Pi's row is gone server-side, so a send could only 404 -
+        # skip it and keep the orphan's cloud footprint at the pulse alone.
+        self._is_dormant = is_dormant
         self._task: Optional[asyncio.Task] = None
         # Last print_stats.state we saw. None until the first poll, which only
         # establishes a baseline - we never fire an event for whatever state
@@ -786,7 +893,10 @@ class PrintEventWatcher:
                 if state is not None and state != self._last_state:
                     event = self._event_for(self._last_state, state)
                     self._last_state = state
-                    if event:
+                    if event and self._is_dormant is not None and self._is_dormant():
+                        logger.debug(
+                            "Push event '%s' skipped - cloud contact dormant", event)
+                    elif event:
                         await loop.run_in_executor(None, self._send_event, event, filename)
             except asyncio.CancelledError:
                 return
@@ -885,8 +995,12 @@ class MoongatePlugin:
             self.device, self.sb,
             int(self._config["heartbeat_interval_seconds"]),
             on_unpaired_cb=self._on_unpaired,
+            on_dormant_cb=self._on_dormant,
         )
-        self.watcher   = PrintEventWatcher(self.device, self.sb)
+        self.watcher   = PrintEventWatcher(
+            self.device, self.sb,
+            is_dormant=lambda: self.heartbeat.dormant,
+        )
 
         self._pending: Optional[PendingPair]   = None
         self._chamber_key: Optional[str]       = None
@@ -1138,6 +1252,30 @@ class MoongatePlugin:
         if self.owner is not None:
             logger.warning("Server has no record of this printer - wiping local owner state")
             self._wipe_owner()
+
+    def _on_dormant(self, why: str) -> None:
+        """Heartbeat callback: cloud contact just went dormant. Put a notice in
+        the Klipper console (best effort - Klipper may be down or mid-restart)
+        so someone standing at the printer knows why the app can't see it and
+        how to bring it back; moonraker.log always carries the same message."""
+        async def _notify() -> None:
+            script = "\n".join([
+                "M118 ============================================",
+                f"M118 Moongate: this printer was {why},",
+                "M118 so cloud contact is paused.",
+                "M118 The printer itself is unaffected.",
+                "M118 Run MOONGATE_PAIR to pair again.",
+                "M118 ============================================",
+            ])
+            try:
+                klippy_apis: Any = self.server.lookup_component("klippy_apis")
+                await klippy_apis.run_gcode(script)
+            except Exception as exc:
+                logger.info("Dormant console notice skipped: %s", exc)
+        try:
+            asyncio.get_event_loop().create_task(_notify())
+        except RuntimeError:
+            pass
 
     # ── v0.4.4: Avahi mDNS advertisement ──────────────────────────────────────
     # See docs/v0.5-lan-discovery-design.md §6. The plugin owns the lifecycle

--- a/supabase/functions/_shared/responses.ts
+++ b/supabase/functions/_shared/responses.ts
@@ -29,6 +29,17 @@ export function forbidden(): Response {
   return jsonResponse({ error: "forbidden" }, 403);
 }
 
+// 410 deliberately DOES distinguish "deliberately released" from "never
+// existed" - the exception to the header rule above. Its one caller
+// (printer-heartbeat) verifies the requester's Ed25519 signature against the
+// claimed pi_public_key BEFORE the lookup, so a caller can only ever probe a
+// key whose private half it already holds - nothing about other users leaks.
+// The explicit answer is what lets plugin 0.6.15 stop heartbeating the moment
+// its owner releases it, instead of guessing at 404s for a day.
+export function gone(reason: string): Response {
+  return jsonResponse({ error: reason }, 410);
+}
+
 export function conflict(detail: string): Response {
   return jsonResponse({ error: "conflict", detail }, 409);
 }

--- a/supabase/functions/printer-heartbeat/index.ts
+++ b/supabase/functions/printer-heartbeat/index.ts
@@ -25,11 +25,13 @@
 //   400 - malformed body
 //   401 - signature invalid OR timestamp out of window
 //   404 - no printer with this pi_public_key (Pi should treat as unpaired)
+//   410 - the owner deliberately released this printer (revoked_at tombstone,
+//         kept 1 week) - plugin 0.6.15 stops heartbeating immediately on this
 //   500 - internal
 
 import { handleCorsPreflight } from "../_shared/cors.ts";
 import {
-  emptyResponse, badRequest, unauthorized, notFound,
+  emptyResponse, badRequest, unauthorized, notFound, gone,
   methodNotAllowed, internalError,
 } from "../_shared/responses.ts";
 import { adminClient } from "../_shared/supabaseClients.ts";
@@ -37,6 +39,19 @@ import { encryptTunnelUrl, verifyEd25519, base64ToBytes } from "../_shared/crypt
 
 const REPLAY_WINDOW_SECONDS = 60;
 const MAX_TUNNEL_URL_LENGTH = 256;
+
+// MOONGATE_MUTED_IPS: comma-separated caller IPs whose ROWLESS heartbeats get
+// a 204 instead of 404/410. Surgical mute for an orphaned Pi spinning on an
+// old (pre-0.6.10) plugin, which treats any non-success as "keep retrying
+// fast" - it reads the 204 as success and settles to its steady cadence, no
+// owner cooperation needed. Only the rowless path is muted: a muted Pi that
+// re-pairs has a live row again and takes the normal 'ok' path, so a mute
+// never blocks a comeback. (Designed 2026-06-24 during the Schlonky spinner
+// hunt; built 2026-07-13 for the 87.122.x spinner.)
+const MUTED_IPS = new Set(
+  (Deno.env.get("MOONGATE_MUTED_IPS") ?? "")
+    .split(",").map((s) => s.trim()).filter((s) => s.length > 0),
+);
 
 Deno.serve(async (req) => {
   const preflight = handleCorsPreflight(req);
@@ -102,19 +117,26 @@ Deno.serve(async (req) => {
 
   // Update the printer row (lookup by pi_public_key)
   const db = adminClient();
-  const { data, error } = await db.rpc("record_heartbeat", {
+  const { data, error } = await db.rpc("record_heartbeat_v2", {
     p_pi_public_key:        piPubKey,
     p_tunnel_url_enc_b64:   ciphertextB64,
     p_tunnel_url_nonce_b64: nonceB64,
   });
 
   if (error) {
-    console.error("record_heartbeat rpc error", error);
+    console.error("record_heartbeat_v2 rpc error", error);
     return internalError();
   }
 
-  // record_heartbeat returns the printer_id (uuid) on success, null if no row
-  if (!data) return notFound();
+  // record_heartbeat_v2 answers 'ok' (row updated), 'revoked' (owner released
+  // this Pi; tombstone still present) or 'not_found' (no row at all).
+  if (data === "ok") return emptyResponse(204);
 
-  return emptyResponse(204);
+  // Rowless outcome. A muted spinner gets a calming 204 before anything else.
+  const callerIp = req.headers.get("cf-connecting-ip")
+                ?? req.headers.get("x-real-ip") ?? "";
+  if (MUTED_IPS.has(callerIp)) return emptyResponse(204);
+
+  if (data === "revoked") return gone("printer_released");
+  return notFound();
 });

--- a/supabase/migrations/20260713120000_release_tombstones_and_heartbeat_v2.sql
+++ b/supabase/migrations/20260713120000_release_tombstones_and_heartbeat_v2.sql
@@ -1,0 +1,159 @@
+-- Moongate - releases become 1-week tombstones + the heartbeat learns to say why.
+--
+-- Context (2026-07-13 Edge Function quota work): an orphaned Pi - one whose
+-- cloud row is gone - heartbeats forever, because a 404 cannot tell it whether
+-- the row is gone for good (owner released it) or gone for ninety seconds
+-- (a re-pair is mid-flight). Plugin 0.6.15 goes dormant the moment the server
+-- answers "the owner released this printer", and the schema has had the
+-- machinery for that answer since day one: printers.revoked_at is documented
+-- as 'Soft delete. Set by MOONGATE_RESET_OWNER. Hard-deleted by cleanup cron
+-- after 1 week.', and every read path already filters revoked_at IS NULL
+-- (RLS "select own printers", claim_printer, get_printer_access,
+-- record_heartbeat, send-push, restore grants) - the cleanup cron already
+-- prunes revoked rows too. The two release RPCs just never set it: they
+-- hard-deleted, so no revoked row has ever existed, and the 2026-06-24 /
+-- 2026-07-13 spinner hunts also lost the released row's name instantly.
+--
+-- This migration:
+--   1. release_printer / release_printer_by_pubkey: soft-delete
+--      (revoked_at = now()) instead of DELETE. The existing cleanup cron
+--      hard-deletes tombstones after 1 week. Account deletion
+--      (delete-account) still hard-deletes via the FK CASCADE - personal
+--      data does not tombstone. Tombstones never block a re-pair:
+--      printers.pi_public_key has no unique constraint and claim_printer
+--      only refuses on a LIVE row for the pubkey.
+--   2. record_heartbeat_v2: same UPDATE as record_heartbeat but answers
+--      'ok' / 'revoked' / 'not_found', so the printer-heartbeat Edge
+--      Function can return 204 / 410 / 404. record_heartbeat (v1) is kept
+--      until the function deploy has switched over - deploy order is
+--      MIGRATION FIRST, THEN `supabase functions deploy printer-heartbeat`.
+--
+-- Enumeration note: distinguishing revoked from never-existed is safe here
+-- because the Edge Function verifies the caller's Ed25519 signature against
+-- the claimed pi_public_key BEFORE the lookup, so a caller can only ever
+-- probe a key whose private half it already holds.
+
+BEGIN;
+
+-- ============================================================================
+-- 1a. release_printer (user-JWT "Remove printer" path) - now a tombstone
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.release_printer(
+  p_printer_id uuid,
+  p_user_id    uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner uuid;
+  v_pubkey text;
+BEGIN
+  SELECT owner_user_id, pi_public_key
+    INTO v_owner, v_pubkey
+  FROM printers
+  WHERE id = p_printer_id AND revoked_at IS NULL;
+
+  IF NOT FOUND THEN
+    -- Idempotent: the row is already gone or already a tombstone.
+    RETURN 'ok';
+  END IF;
+
+  IF v_owner <> p_user_id THEN
+    RETURN 'not_found';
+  END IF;
+
+  UPDATE printers SET revoked_at = now() WHERE id = p_printer_id;
+  DELETE FROM enrollment_tokens WHERE pi_public_key = v_pubkey;
+
+  RETURN 'ok';
+END;
+$$;
+
+COMMENT ON FUNCTION public.release_printer IS
+  'Called by Edge Function release-printer. Owner-checked soft delete (revoked_at tombstone; cleanup cron hard-deletes after 1 week) + removes any pending enrollment token for the same Pi pubkey.';
+
+-- ============================================================================
+-- 1b. release_printer_by_pubkey (Pi-signed MOONGATE_RESET_OWNER path)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.release_printer_by_pubkey(
+  p_pi_public_key text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Idempotent. The row may already be gone or tombstoned; the Pi might be
+  -- retrying after a transient error, or the user may have triggered the
+  -- app-side release flow first.
+  UPDATE printers SET revoked_at = now()
+  WHERE pi_public_key = p_pi_public_key AND revoked_at IS NULL;
+  DELETE FROM enrollment_tokens WHERE pi_public_key = p_pi_public_key;
+  RETURN 'ok';
+END;
+$$;
+
+COMMENT ON FUNCTION public.release_printer_by_pubkey IS
+  'Called by Edge Function release-printer on the Pi-signed force-release path. Authentication happens before the RPC call (Ed25519 signature verified against pi_public_key); this RPC is just the soft delete (revoked_at tombstone).';
+
+-- ============================================================================
+-- 2. record_heartbeat_v2 - distinguishes live / revoked / never-existed
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.record_heartbeat_v2(
+  p_pi_public_key        text,
+  p_tunnel_url_enc_b64   text,
+  p_tunnel_url_nonce_b64 text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_printer_id uuid;
+BEGIN
+  UPDATE printers
+  SET tunnel_url_enc   = decode(p_tunnel_url_enc_b64,   'base64'),
+      tunnel_url_nonce = decode(p_tunnel_url_nonce_b64, 'base64'),
+      last_seen        = now()
+  WHERE pi_public_key = p_pi_public_key
+    AND revoked_at IS NULL
+  RETURNING id INTO v_printer_id;
+
+  IF v_printer_id IS NOT NULL THEN
+    RETURN 'ok';
+  END IF;
+
+  -- No live row. A tombstone means the owner deliberately released this Pi
+  -- within the last week (before the cleanup cron prunes it) - the caller
+  -- turns that into a 410 so plugin 0.6.15 can stop heartbeating instantly
+  -- instead of probing a dead row for a day.
+  IF EXISTS (SELECT 1 FROM printers
+             WHERE pi_public_key = p_pi_public_key
+               AND revoked_at IS NOT NULL) THEN
+    RETURN 'revoked';
+  END IF;
+
+  RETURN 'not_found';
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_heartbeat_v2 IS
+  'Called by Edge Function printer-heartbeat. Updates tunnel URL ciphertext from a Pi-signed payload; answers ok / revoked / not_found so the plugin can tell a deliberate release from a mid-repair gap. Supersedes record_heartbeat, which is kept until the function deploy switches over.';
+
+-- Same least-privilege locking as the other internal RPCs (see
+-- 20260619170000_lock_rpc_execute_to_service_role.sql). CREATE OR REPLACE
+-- preserves the existing grants on the two release functions.
+REVOKE EXECUTE ON FUNCTION public.record_heartbeat_v2(text, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_heartbeat_v2(text, text, text)
+  TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## What will this PR change?

**The gist:** a printer whose cloud registration is gone forever (an "orphan") currently keeps calling home every 5 minutes until the end of time, and one such printer on an old plugin can burn most of our monthly Supabase quota on its own. After this PR, the printer itself notices it has been forgotten and goes quiet: it drops to one call every 6 hours, tells the user why in the Klipper console, and wakes up instantly the moment anyone runs MOONGATE_PAIR. On top of that, when an owner removes a printer in the app, the server now tells the Pi so directly, and we get a kill switch for old-plugin spinners that can never be fixed client-side.

Three pieces:

1. **Plugin 0.6.15, orphan dormancy.** After 24 hours of uninterrupted, server-confirmed "no such printer" answers (at least 12 of them, with no pairing activity in between), or instantly when the server says "the owner released this printer", the heartbeat drops from every 5 minutes to a 6-hourly pulse and print-event push sends are skipped. A console notice (M118) and a moonraker.log warning explain what happened and that MOONGATE_PAIR brings it back. Any pairing activity or accepted heartbeat wakes it instantly.
2. **Releases become 1-week tombstones.** "Remove printer" in the app and MOONGATE_RESET_OWNER now set `revoked_at` instead of hard-deleting the row. This is what the schema always documented (`revoked_at`: "Soft delete... Hard-deleted by cleanup cron after 1 week") but the release RPCs never implemented. Every read path already filters `revoked_at IS NULL` (the RLS select policy, claim, access, heartbeat, send-push, restore grants) and the cleanup cron already prunes tombstones after a week, so nothing else changes behaviour. The new `record_heartbeat_v2` RPC distinguishes ok / revoked / not_found, and the heartbeat function turns "revoked" into an explicit `410 {"error":"printer_released"}`.
3. **MOONGATE_MUTED_IPS (the June IP-mute lever, now built).** Rowless heartbeats from IPs listed in this env secret get a calming 204 instead of 404, which settles pre-0.6.10 spinners to their steady cadence with no owner cooperation. Muting only affects the rowless path, so a muted Pi that re-pairs works normally.

## Why

The 2026-07-13 log audit found the quota at 484k/500k with one Pi (87.122.16.205, pre-0.6.10 plugin) sending 394 heartbeat-404s per hour, plus seven polite orphans at 12/hr each that would otherwise idle forever (~8.6k calls/month each). The two fixes shipped on 2026-07-09 (#193, #194) killed that day's spinners, but nothing today ever tells an orphaned Pi to stop. This PR makes the fleet self-governing (new plugins), gives deliberate releases an instant, unambiguous signal (server), and adds a surgical mute for old plugins that will never update (server).

## Safety design (the false-positive question)

The dangerous failure mode for any self-silencing client is a fleet-wide false trigger. Guards:

- Only responses whose body carries the server's own `{"error":"not_found"}` marker count towards dormancy, so a CDN/proxy 404 during an outage can never dorm the fleet.
- The 24 h + 12-answer double floor means an overnight "reset now, re-pair tomorrow" gap never qualifies (waiting costs ~288 calls per orphan event, which is 0.06% of a month's quota).
- The instant path (410) only fires on a server-verified fact: a tombstone row this Pi's own signed key matches.
- Dormancy is in-memory: a Moonraker restart re-probes for a day before re-dorming, so a stuck-dormant state is impossible.
- Every recovery path already runs through `request_immediate_send()`, which clears dormancy, so re-pairing needs no new user knowledge.
- Old plugins see 410 as an unknown status and keep their current steady-cadence behaviour; no regression.
- Enumeration safety: the heartbeat function verifies the Pi's Ed25519 signature against the claimed key before any lookup, so a caller can only ever learn revoked-vs-never-existed about a key it already holds.
- Account deletion still hard-deletes (FK CASCADE); personal data does not tombstone.

Bonus: a released row's name stays visible for a week, so the next spinner hunt can actually identify the printer (the June hunt lost the name to the hard delete).

## Rollout order (matters)

1. Merge this PR **with `[skip ci]` in the merge commit subject** (no app version bump; avoids rebuilding the v0.9.48 release APK).
2. Apply the migration (`supabase db push`). Safe on its own: the currently-deployed function keeps calling the old `record_heartbeat`, which still exists and treats tombstones as 404.
3. Deploy the function (`supabase functions deploy printer-heartbeat`). Must come **after** the migration (it calls `record_heartbeat_v2`).
4. Optional: `supabase secrets set MOONGATE_MUTED_IPS=87.122.16.205` to calm the current spinner.
5. Plugin 0.6.15 reaches Pis through Moonraker's update panel with the next tagged app release; the changelog row for that release should mention the plugin update.

## Testing

- `python -m py_compile` and `ruff check klipper-plugin/` (same as CI) both clean.
- State machine walked against every known flow: fresh pair, re-pair after reset, restore-driven ownership transfer, Pi reboot mid-orphanhood, clock-skew 401s (not counted), network errors (not counted, not reset), Supabase outage (no marker body, not counted).
- Not yet exercised against prod: needs the migration + function deploy, then a real release/re-pair cycle on the RatRig can verify the 410 path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
