### PR TITLE
LAN-only: cloud-free pairing (moongate://lan QR + token-free LAN status/control)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ MOONGATE_PORT=8080 bash -c "$(curl -fsSL https://raw.githubusercontent.com/PEEKY
 
 In the app's pair screen, set the **Port** field to match (leave it blank for 80).
 
+**LAN-only (own VPN, no tunnel)?** If you reach your printer over your own VPN / WireGuard and don't want an outbound Cloudflare tunnel or external exposure, install in LAN-only mode. It keeps Moonraker on the LAN (`0.0.0.0`) and skips cloudflared, the auth proxy, and the tunnel service. The plugin, `MOONGATE_PAIR` macro, and mDNS advertisement are still installed, and re-running without the flag later enables remote access.
+
+```bash
+# piped
+MOONGATE_LAN_ONLY=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/install.sh)"
+# or, from a local checkout
+bash install.sh --lan-only
+```
+
+Re-running with the flag on a box that already has the tunnel stack retires it (disables the tunnel + auth proxy) and converges to LAN-only.
+
 </details>
 
 ### 2. Install the app

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -555,10 +555,13 @@ PLUGIN_CFG_DIR="$HOME/.config/moongate"
 PLUGIN_CFG_FILE="$PLUGIN_CFG_DIR/config.json"
 mkdir -p "$PLUGIN_CFG_DIR"
 
+# In LAN-only mode we also flip the plugin's lan_only flag on; in tunnel mode
+# we flip it OFF, so re-running without --lan-only converts a box back.
+MG_PLUGIN_LAN_ONLY=$([[ -n "$MOONGATE_LAN_ONLY" ]] && echo true || echo false)
 if command -v python3 &>/dev/null; then
-    python3 - "$PLUGIN_CFG_FILE" "$MOONGATE_PORT" << 'PY'
+    python3 - "$PLUGIN_CFG_FILE" "$MOONGATE_PORT" "$MG_PLUGIN_LAN_ONLY" << 'PY'
 import json, sys
-path, port = sys.argv[1], int(sys.argv[2])
+path, port, lan_only = sys.argv[1], int(sys.argv[2]), sys.argv[3] == "true"
 try:
     with open(path) as f:
         data = json.load(f)
@@ -567,6 +570,7 @@ try:
 except (FileNotFoundError, ValueError):
     data = {}
 data["http_port"] = port
+data["lan_only"]  = lan_only
 with open(path, "w") as f:
     json.dump(data, f, indent=2)
 PY
@@ -574,11 +578,12 @@ else
     # Best-effort fallback when python3 isn't on PATH - overwrites other keys
     cat > "$PLUGIN_CFG_FILE" << EOF
 {
-  "http_port": $MOONGATE_PORT
+  "http_port": $MOONGATE_PORT,
+  "lan_only": $MG_PLUGIN_LAN_ONLY
 }
 EOF
 fi
-success "Plugin HTTP port saved to $PLUGIN_CFG_FILE"
+success "Plugin config saved to $PLUGIN_CFG_FILE (lan_only=$MG_PLUGIN_LAN_ONLY)"
 
 # ── 6-7. Remote-access stack: cloudflared + auth proxy + tunnel ──────────────
 # Skipped entirely in LAN-only mode. The `if` guard runs to just before the

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -53,6 +53,11 @@ done
 [[ "$MOONGATE_PORT" -ge 1 && "$MOONGATE_PORT" -le 65535 ]] \
     || die "Port out of range (1-65535): $MOONGATE_PORT"
 info "HTTP port: $MOONGATE_PORT"
+
+# Normalise to "1" (on) or "" (off) so MOONGATE_LAN_ONLY=0 opts OUT - matches
+# how uninstall.sh treats MOONGATE_YES. --lan-only above already set it to 1.
+# Every check below is an emptiness test, so "" reliably means tunnel mode.
+[[ "$MOONGATE_LAN_ONLY" == "1" ]] && MOONGATE_LAN_ONLY=1 || MOONGATE_LAN_ONLY=""
 [[ -n "$MOONGATE_LAN_ONLY" ]] \
     && info "LAN-only mode: no Cloudflare tunnel or auth proxy will be installed."
 
@@ -86,10 +91,11 @@ KLIPPER_CFG_DIR="$PRINTER_DATA/config"
 MG_TIME_HOST="${MG_TIME_HOST:-https://www.cloudflare.com}"
 MG_CLOCK_MAX_SKEW=30   # seconds; the server's hard cutoff is 60
 
-# Skipped in LAN-only mode: the clock check exists solely so the *cloud*
-# auth rejects nothing as a replay. LAN-only has no cloud path, so this makes
-# LAN-only a genuinely zero-external-call install. Guard body left un-indented
-# to keep the htpdate systemd heredocs byte-for-byte identical.
+# Skipped in LAN-only mode: this check (and the htpdate timer it can install)
+# exists solely to keep the *cloud* auth from rejecting signed heartbeats as
+# replays. LAN-only has no tunnel, so we skip the check and never stand up the
+# recurring htpdate timer. Guard body left un-indented to keep the htpdate
+# systemd heredocs byte-for-byte identical.
 if [[ -z "$MOONGATE_LAN_ONLY" ]]; then
 info "Checking the system clock (remote auth needs it within 60s of real time)..."
 MG_HTTP_DATE=$(curl -fsSI -k --max-time 10 "$MG_TIME_HOST" 2>/dev/null \
@@ -319,29 +325,39 @@ backup_once() {
 # via the Pi's local IP is unchanged because moonraker's `trusted_clients`
 # still allows the LAN subnet.
 #
-# LAN-only mode: bind to 0.0.0.0 so Moonraker stays reachable on the LAN / the
-# user's own VPN (there is no tunnel or auth proxy to front it). Setting it
-# explicitly also restores LAN access if a prior full install locked it to
-# loopback.
+# LAN-only mode: keep Moonraker reachable on the LAN / the user's own VPN
+# (there is no tunnel or auth proxy to front it). We only ever flip an explicit
+# `host: 127.0.0.1` (our own prior full install) back to 0.0.0.0 - we do NOT
+# append a host line where none exists (Moonraker already defaults to all
+# interfaces) and we do NOT overwrite a deliberate bind such as a WireGuard-
+# only interface IP. Default (tunnel) mode still force-sets 127.0.0.1.
 if [[ -n "$MOONGATE_LAN_ONLY" ]]; then
     MG_MOONRAKER_HOST="0.0.0.0"
-    info "Binding Moonraker to 0.0.0.0 (LAN-only mode)..."
+    MG_HOST_ONLY_IF_LOOPBACK=1
+    info "Ensuring Moonraker stays reachable on the LAN (LAN-only mode)..."
 else
     MG_MOONRAKER_HOST="127.0.0.1"
+    MG_HOST_ONLY_IF_LOOPBACK=""
     info "Binding Moonraker to 127.0.0.1 (v0.4 hardening)..."
 fi
 backup_once "$MOONRAKER_CONF" "moonraker.conf.orig"
 
-python3 - "$MOONRAKER_CONF" "$MG_MOONRAKER_HOST" << 'PYEOF'
+python3 - "$MOONRAKER_CONF" "$MG_MOONRAKER_HOST" "$MG_HOST_ONLY_IF_LOOPBACK" << 'PYEOF'
 import re, sys
 path = sys.argv[1]
 host = sys.argv[2]
+only_if_loopback = sys.argv[3] == "1"   # LAN-only: only touch host: 127.0.0.1
 with open(path) as f:
     content = f.read()
 
 # Find or create the [server] section.
 server_match = re.search(r'(?m)^\[server\]\s*$', content)
 if not server_match:
+    if only_if_loopback:
+        # LAN-only: no [server] block -> Moonraker binds all interfaces by
+        # default, which is already LAN-reachable. Nothing to change.
+        print("moonraker.conf: no [server] block - left as-is (LAN-only)")
+        sys.exit(0)
     # No [server] block at all - append one with our settings.
     content = content.rstrip() + f"\n\n[server]\nhost: {host}\nport: 7125\n"
 else:
@@ -351,7 +367,13 @@ else:
     end = start + next_section.start() if next_section else len(content)
     section = content[start:end]
 
-    if re.search(r'(?m)^\s*host\s*[:=]', section):
+    host_match = re.search(r'(?m)^\s*host\s*[:=]\s*(\S+)', section)
+    if host_match:
+        current = host_match.group(1)
+        if only_if_loopback and current != "127.0.0.1":
+            # LAN-only: leave a deliberate bind (e.g. a WireGuard IP) alone.
+            print(f"moonraker.conf: [server] host={current} - left as-is (LAN-only)")
+            sys.exit(0)
         # host: already set - force to our target host.
         new_section = re.sub(
             r'(?m)^(\s*host\s*[:=]\s*).*$',
@@ -360,6 +382,10 @@ else:
             count=1,
         )
     else:
+        if only_if_loopback:
+            # LAN-only: no host line -> default (all interfaces). Leave it.
+            print("moonraker.conf: [server] has no host - left as-is (LAN-only)")
+            sys.exit(0)
         # No host: line in [server] - inject one right after the header.
         new_section = f"\nhost: {host}" + section
 
@@ -369,7 +395,11 @@ with open(path, 'w') as f:
     f.write(content)
 print(f"moonraker.conf: [server] host={host}")
 PYEOF
-success "Moonraker bound to $MG_MOONRAKER_HOST"
+if [[ -n "$MOONGATE_LAN_ONLY" ]]; then
+    success "Moonraker [server] host ready for LAN access."
+else
+    success "Moonraker bound to 127.0.0.1"
+fi
 
 # NOTE: We intentionally do NOT patch nginx vhosts in v0.4.0. The original
 # v0.4 design considered binding nginx to 127.0.0.1 (defense in depth), but
@@ -726,16 +756,31 @@ success "moongate-tunnel service started"
 else
     # ── LAN-only: retire any tunnel stack from a prior full install ──────────
     # Converts an existing tunnel-mode box to LAN-only: stop + disable the
-    # tunnel and auth proxy and kill any orphan cloudflared. Moonraker was
-    # already rebound to 0.0.0.0 in §2e, so LAN access keeps working.
-    for svc in moongate-tunnel moongate-authproxy; do
-        if systemctl list-unit-files "$svc.service" &>/dev/null \
-           && systemctl cat "$svc.service" &>/dev/null; then
-            sudo systemctl disable --now "$svc" 2>/dev/null || true
-            info "Disabled $svc (LAN-only mode)"
+    # tunnel, auth proxy, and the htpdate time-sync timer (that one calls out
+    # every 30 min, so leaving it would defeat the no-external-traffic point).
+    # Moonraker was already rebound in §2e, so LAN access keeps working.
+    MG_RETIRED_TUNNEL=""
+    for unit in moongate-tunnel.service moongate-authproxy.service moongate-timesync.timer; do
+        if systemctl list-unit-files "$unit" &>/dev/null \
+           && systemctl cat "$unit" &>/dev/null; then
+            sudo systemctl disable --now "$unit" 2>/dev/null || true
+            info "Disabled $unit (LAN-only mode)"
+            [[ "$unit" == "moongate-tunnel.service" ]] && MG_RETIRED_TUNNEL=1
         fi
     done
-    pkill -f "cloudflared tunnel" 2>/dev/null || true
+
+    # Only clean up after OUR tunnel, and only if it existed. systemctl already
+    # stopped the managed process above; this catches a stray one from a crash
+    # or old run. The pattern is the exact moongate invocation so a user's own
+    # cloudflared (e.g. a Home Assistant tunnel) as the same user is left alone.
+    if [[ -n "$MG_RETIRED_TUNNEL" ]]; then
+        pkill -f "cloudflared tunnel --url http://localhost:$MG_AUTHPROXY_PORT" 2>/dev/null || true
+        # Drop the tunnel-URL logs: the plugin's _get_tunnel_url() reads these
+        # as a fallback, so a stale URL here would keep a paired printer
+        # heartbeating a dead tunnel to the server until the next reboot.
+        sudo rm -f /run/moongate-tunnel.log /tmp/moongate-tunnel.log
+        info "Cleared stale tunnel URL logs (LAN-only mode)"
+    fi
 fi
 
 # ── 7b. Avahi mDNS advertisement - sudoers + daemon (v0.4.4) ────────────────

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -26,6 +26,17 @@ die()     { echo -e "${RED}[moongate] ERROR:${NC} $*" >&2; exit 1; }
 # it in the QR URL and the pair-page link.
 MOONGATE_PORT="${MOONGATE_PORT:-80}"
 
+# ── LAN-only mode (--lan-only / MOONGATE_LAN_ONLY=1) ─────────────────────────
+# Skip the Cloudflare tunnel + auth proxy entirely and keep Moonraker on the
+# LAN. For users who reach their printer over their own VPN / WireGuard and
+# don't want an outbound tunnel or external exposure. The plugin, [moongate]
+# config, MOONGATE_PAIR macro, and mDNS advertisement are still installed, so
+# a later full re-run (without --lan-only) can enable remote access.
+#
+#   Locally:  bash install.sh --lan-only
+#   Piped:    MOONGATE_LAN_ONLY=1 bash -c "$(curl -fsSL <url>)"
+MOONGATE_LAN_ONLY="${MOONGATE_LAN_ONLY:-}"
+
 # Loopback port the v0.4 auth proxy binds to. cloudflared targets this
 # instead of Moonraker directly. Override with MG_AUTHPROXY_PORT=NNNN.
 MG_AUTHPROXY_PORT="${MG_AUTHPROXY_PORT:-8443}"
@@ -33,6 +44,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --port)      [[ -n "${2-}" ]] || die "--port needs a value"; MOONGATE_PORT="$2"; shift 2;;
         --port=*)    MOONGATE_PORT="${1#*=}"; shift;;
+        --lan-only)  MOONGATE_LAN_ONLY=1; shift;;
         *)           shift;;
     esac
 done
@@ -41,6 +53,8 @@ done
 [[ "$MOONGATE_PORT" -ge 1 && "$MOONGATE_PORT" -le 65535 ]] \
     || die "Port out of range (1-65535): $MOONGATE_PORT"
 info "HTTP port: $MOONGATE_PORT"
+[[ -n "$MOONGATE_LAN_ONLY" ]] \
+    && info "LAN-only mode: no Cloudflare tunnel or auth proxy will be installed."
 
 # ── Detect environment ────────────────────────────────────────────────────────
 MOONGATE_REPO="https://github.com/PEEKYPAUL/moongate.git"
@@ -292,18 +306,30 @@ backup_once() {
     fi
 }
 
-# ── 2e. Bind Moonraker to 127.0.0.1 (v0.4 auth proxy fronts everything) ──────
-# In v0.4 the cloudflared tunnel terminates at moongate-authproxy (port 8443).
-# Moonraker becomes loopback-only so it cannot be reached via the tunnel
-# without passing the EdDSA gate. LAN access via the Pi's local IP is
-# unchanged because moonraker's `trusted_clients` still allows the LAN
-# subnet.
-info "Binding Moonraker to 127.0.0.1 (v0.4 hardening)..."
+# ── 2e. Bind Moonraker's [server] host ───────────────────────────────────────
+# Default (tunnel) mode: bind to 127.0.0.1. The cloudflared tunnel terminates
+# at moongate-authproxy (port 8443), so Moonraker becomes loopback-only and
+# cannot be reached via the tunnel without passing the EdDSA gate. LAN access
+# via the Pi's local IP is unchanged because moonraker's `trusted_clients`
+# still allows the LAN subnet.
+#
+# LAN-only mode: bind to 0.0.0.0 so Moonraker stays reachable on the LAN / the
+# user's own VPN (there is no tunnel or auth proxy to front it). Setting it
+# explicitly also restores LAN access if a prior full install locked it to
+# loopback.
+if [[ -n "$MOONGATE_LAN_ONLY" ]]; then
+    MG_MOONRAKER_HOST="0.0.0.0"
+    info "Binding Moonraker to 0.0.0.0 (LAN-only mode)..."
+else
+    MG_MOONRAKER_HOST="127.0.0.1"
+    info "Binding Moonraker to 127.0.0.1 (v0.4 hardening)..."
+fi
 backup_once "$MOONRAKER_CONF" "moonraker.conf.orig"
 
-python3 - "$MOONRAKER_CONF" << 'PYEOF'
+python3 - "$MOONRAKER_CONF" "$MG_MOONRAKER_HOST" << 'PYEOF'
 import re, sys
 path = sys.argv[1]
+host = sys.argv[2]
 with open(path) as f:
     content = f.read()
 
@@ -311,7 +337,7 @@ with open(path) as f:
 server_match = re.search(r'(?m)^\[server\]\s*$', content)
 if not server_match:
     # No [server] block at all - append one with our settings.
-    content = content.rstrip() + "\n\n[server]\nhost: 127.0.0.1\nport: 7125\n"
+    content = content.rstrip() + f"\n\n[server]\nhost: {host}\nport: 7125\n"
 else:
     # Locate the end of the [server] block (next [section] or EOF).
     start = server_match.end()
@@ -320,24 +346,24 @@ else:
     section = content[start:end]
 
     if re.search(r'(?m)^\s*host\s*[:=]', section):
-        # host: already set - force to 127.0.0.1.
+        # host: already set - force to our target host.
         new_section = re.sub(
             r'(?m)^(\s*host\s*[:=]\s*).*$',
-            r'\g<1>127.0.0.1',
+            r'\g<1>' + host,
             section,
             count=1,
         )
     else:
         # No host: line in [server] - inject one right after the header.
-        new_section = "\nhost: 127.0.0.1" + section
+        new_section = f"\nhost: {host}" + section
 
     content = content[:start] + new_section + content[end:]
 
 with open(path, 'w') as f:
     f.write(content)
-print("moonraker.conf: [server] host=127.0.0.1")
+print(f"moonraker.conf: [server] host={host}")
 PYEOF
-success "Moonraker bound to 127.0.0.1"
+success "Moonraker bound to $MG_MOONRAKER_HOST"
 
 # NOTE: We intentionally do NOT patch nginx vhosts in v0.4.0. The original
 # v0.4 design considered binding nginx to 127.0.0.1 (defense in depth), but
@@ -518,6 +544,12 @@ EOF
 fi
 success "Plugin HTTP port saved to $PLUGIN_CFG_FILE"
 
+# ── 6-7. Remote-access stack: cloudflared + auth proxy + tunnel ──────────────
+# Skipped entirely in LAN-only mode. The `if` guard runs to just before the
+# Avahi block (§7b); its body is left un-indented so the systemd/sudoers
+# heredocs below stay byte-for-byte identical to the tunnel-mode install.
+if [[ -z "$MOONGATE_LAN_ONLY" ]]; then
+
 # ── 6. Install cloudflared (skip if already installed) ───────────────────────
 # Two install paths so this works on the variety of SBCs Klipper runs on:
 #   • Debian-family (dpkg present): grab the matching .deb. Covers
@@ -685,6 +717,21 @@ sleep 1
 sudo systemctl restart moongate-tunnel
 success "moongate-tunnel service started"
 
+else
+    # ── LAN-only: retire any tunnel stack from a prior full install ──────────
+    # Converts an existing tunnel-mode box to LAN-only: stop + disable the
+    # tunnel and auth proxy and kill any orphan cloudflared. Moonraker was
+    # already rebound to 0.0.0.0 in §2e, so LAN access keeps working.
+    for svc in moongate-tunnel moongate-authproxy; do
+        if systemctl list-unit-files "$svc.service" &>/dev/null \
+           && systemctl cat "$svc.service" &>/dev/null; then
+            sudo systemctl disable --now "$svc" 2>/dev/null || true
+            info "Disabled $svc (LAN-only mode)"
+        fi
+    done
+    pkill -f "cloudflared tunnel" 2>/dev/null || true
+fi
+
 # ── 7b. Avahi mDNS advertisement - sudoers + daemon (v0.4.4) ────────────────
 # Lets the plugin advertise this Pi on the local network as _moongate._tcp
 # so the v0.5+ app can find it without depending on Supabase + Cloudflare.
@@ -764,17 +811,19 @@ else
     warn "Could not find Klipper service - please do a Firmware Restart in Mainsail."
 fi
 
-# ── 9. Show tunnel URL ────────────────────────────────────────────────────────
+# ── 9. Show access summary ────────────────────────────────────────────────────
 echo ""
-info "Waiting for Cloudflare tunnel (~20s)..."
-sleep 20
-
 LOCAL_IP=$(hostname -I | awk '{print $1}')
-TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' /run/moongate-tunnel.log 2>/dev/null || true)
 
 # Only show ":port" in the pair-page URL when it isn't the HTTP default
 PORT_SUFFIX=""
 [[ "$MOONGATE_PORT" -ne 80 ]] && PORT_SUFFIX=":$MOONGATE_PORT"
+
+if [[ -z "$MOONGATE_LAN_ONLY" ]]; then
+    info "Waiting for Cloudflare tunnel (~20s)..."
+    sleep 20
+    TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' /run/moongate-tunnel.log 2>/dev/null || true)
+fi
 
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -783,15 +832,21 @@ echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━
 echo ""
 echo -e "  Updates   : ${BLUE}Mainsail → Software Updates → Moongate${NC}"
 echo -e "  Pairing   : ${BLUE}http://$LOCAL_IP$PORT_SUFFIX/moongate-pair.html${NC} (LAN only)"
-echo -e "  Auth proxy: ${BLUE}127.0.0.1:$MG_AUTHPROXY_PORT${NC} (every tunnel request EdDSA-gated)"
-if [[ -n "$TUNNEL_URL" ]]; then
-    SUBDOMAIN="${TUNNEL_URL#https://}"
-    SUBDOMAIN="${SUBDOMAIN%.trycloudflare.com}"
-    echo -e "  Tunnel    : ${GREEN}$TUNNEL_URL${NC} ✓"
-    echo -e "  Subdomain : ${GREEN}$SUBDOMAIN${NC} (paste into app tunnel field)"
+if [[ -n "$MOONGATE_LAN_ONLY" ]]; then
+    echo -e "  Mode      : ${GREEN}LAN-only${NC} (no Cloudflare tunnel / auth proxy)"
+    echo -e "  Mainsail  : ${GREEN}http://$LOCAL_IP$PORT_SUFFIX/${NC}"
+    echo -e "  Moonraker : ${GREEN}http://$LOCAL_IP:7125${NC} (reach over your LAN / VPN)"
 else
-    echo -e "  Tunnel    : ${YELLOW}still starting - check in 30s:${NC}"
-    echo -e "    grep -o 'https://.*trycloudflare.com' /run/moongate-tunnel.log"
+    echo -e "  Auth proxy: ${BLUE}127.0.0.1:$MG_AUTHPROXY_PORT${NC} (every tunnel request EdDSA-gated)"
+    if [[ -n "$TUNNEL_URL" ]]; then
+        SUBDOMAIN="${TUNNEL_URL#https://}"
+        SUBDOMAIN="${SUBDOMAIN%.trycloudflare.com}"
+        echo -e "  Tunnel    : ${GREEN}$TUNNEL_URL${NC} ✓"
+        echo -e "  Subdomain : ${GREEN}$SUBDOMAIN${NC} (paste into app tunnel field)"
+    else
+        echo -e "  Tunnel    : ${YELLOW}still starting - check in 30s:${NC}"
+        echo -e "    grep -o 'https://.*trycloudflare.com' /run/moongate-tunnel.log"
+    fi
 fi
 echo ""
 echo -e "  Run ${YELLOW}MOONGATE_PAIR${NC} in Klipper console to pair."
@@ -833,7 +888,11 @@ mg_klipperscreen_box() {
     echo -e "${NC}"
 }
 
-if [[ -z "${MOONGATE_YES:-}" && -r /dev/tty ]]; then
+if [[ -n "$MOONGATE_LAN_ONLY" ]]; then
+    # LAN-only kept Moonraker on 0.0.0.0, so on-device clients (KlipperScreen)
+    # that reach it by IP are unaffected - nothing to warn about.
+    info "LAN-only mode: Moonraker stays on the LAN - KlipperScreen is unaffected."
+elif [[ -z "${MOONGATE_YES:-}" && -r /dev/tty ]]; then
     printf '%b' "${YELLOW}[moongate]${NC} Do you use KlipperScreen on this Pi? [y/N] "
     read -r MG_KS_ANS < /dev/tty || MG_KS_ANS=""
     case "$MG_KS_ANS" in

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -86,6 +86,11 @@ KLIPPER_CFG_DIR="$PRINTER_DATA/config"
 MG_TIME_HOST="${MG_TIME_HOST:-https://www.cloudflare.com}"
 MG_CLOCK_MAX_SKEW=30   # seconds; the server's hard cutoff is 60
 
+# Skipped in LAN-only mode: the clock check exists solely so the *cloud*
+# auth rejects nothing as a replay. LAN-only has no cloud path, so this makes
+# LAN-only a genuinely zero-external-call install. Guard body left un-indented
+# to keep the htpdate systemd heredocs byte-for-byte identical.
+if [[ -z "$MOONGATE_LAN_ONLY" ]]; then
 info "Checking the system clock (remote auth needs it within 60s of real time)..."
 MG_HTTP_DATE=$(curl -fsSI -k --max-time 10 "$MG_TIME_HOST" 2>/dev/null \
                | grep -i '^date:' | head -n1 | cut -d' ' -f2- || true)
@@ -148,6 +153,7 @@ UNIT
         fi
     fi
 fi
+fi  # end LAN-only clock-check guard
 
 ARCH=$(uname -m)
 

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -115,6 +115,11 @@ DEFAULT_CONFIG = {
     "heartbeat_interval_seconds": 300,   # 5 min
     "jwks_ttl_seconds":           3600,  # 1 hour
     "enrollment_ttl_seconds":     600,   # 10 min
+    # LAN-only mode: no cloud, no tunnel. Set true by install.sh --lan-only.
+    # Pairing becomes a cloud-free "add by LAN address" QR, and /status +
+    # /control skip the EdDSA token (LAN is trusted by subnet, exactly as
+    # Moonraker's own trusted_clients treats it). See _authenticate + _handle_qr.
+    "lan_only":                   False,
 }
 
 ACCESS_TOKEN_AUDIENCE = "moongate-printer"
@@ -360,6 +365,16 @@ class TokenClaims:
     exp:        int
     iat:        int
     jti:        str
+
+
+# Placeholder claims returned by _authenticate in LAN-only mode. The status and
+# control handlers only call _authenticate for its enforcement side-effect and
+# ignore the return, so the field values are never read - they just satisfy the
+# type. LAN-only has no owner/token concept.
+_LAN_ONLY_CLAIMS = TokenClaims(
+    sub="lan-only", printer_id="lan-only", aud=ACCESS_TOKEN_AUDIENCE,
+    iss=ACCESS_TOKEN_ISSUER, exp=0, iat=0, jti="lan-only",
+)
 
 
 class AccessTokenVerifier:
@@ -906,10 +921,15 @@ class MoongatePlugin:
         self.server.register_remote_method("moongate_generate_pair_code", self._klipper_pair)
         self.server.register_remote_method("moongate_reset_owner",        self._klipper_reset_owner)
 
-        # Bootstrap JWKS (best effort) and start the heartbeat + print-watch loops
-        self.jwks.fetch_now()
-        self.heartbeat.start()
-        self.watcher.start()
+        # Bootstrap JWKS (best effort) and start the heartbeat + print-watch loops.
+        # LAN-only mode has no cloud: skip all of it so the plugin makes zero
+        # outbound calls (no Supabase JWKS fetch, no heartbeat, no print-event push).
+        if not self.lan_only:
+            self.jwks.fetch_now()
+            self.heartbeat.start()
+            self.watcher.start()
+        else:
+            logger.info("Moongate LAN-only mode: cloud loops disabled (no tunnel, no Supabase).")
 
         owner_str = (
             f"{self.owner.owner_user_id[:8]}.../{self.owner.printer_id[:8]}..."
@@ -945,6 +965,10 @@ class MoongatePlugin:
         except (TypeError, ValueError):
             return 80
 
+    @property
+    def lan_only(self) -> bool:
+        return bool(self._config.get("lan_only", False))
+
     # ── Pairing ───────────────────────────────────────────────────────────────
 
     @staticmethod
@@ -953,7 +977,41 @@ class MoongatePlugin:
         part2 = "".join(random.choices(CODE_CHARS, k=4))
         return f"GATE-{part1}-{part2}"
 
+    def _lan_qr_payload(self) -> Optional[str]:
+        """LAN-only QR: ``moongate://lan?v=1&ip=<lan-ip>&port=<http-port>&name=<host>``.
+
+        No cloud, no enrollment token - it just tells the app to add this
+        printer by its LAN address and talk to Moonraker directly. Static (the
+        IP/port), so it needs no pairing session and never expires. Returns
+        None only if the Pi's LAN IP can't be determined."""
+        import socket
+        local_ip = _get_local_ip()
+        if not local_ip or local_ip == "localhost":
+            return None
+        params = {"v": "1", "ip": local_ip, "port": str(self.http_port)}
+        try:
+            host = socket.gethostname()
+        except Exception:
+            host = ""
+        if host:
+            params["name"] = host
+        return "moongate://lan?" + urllib.parse.urlencode(params)
+
     def _start_pairing(self) -> Optional[PendingPair]:
+        if self.lan_only:
+            # LAN-only: no Supabase enrollment. The QR carries only the LAN
+            # address; the app adds the printer directly and talks to Moonraker
+            # over the LAN (no owner binding, no tunnel).
+            qr = self._lan_qr_payload()
+            if qr is None:
+                logger.error("LAN-only pair: could not determine the Pi's LAN IP")
+                return None
+            pending = PendingPair(
+                raw_token="", expires_at=time.time() + 3600, qr_payload=qr,
+            )
+            self._pending = pending
+            return pending
+
         raw  = self._generate_enrollment_token()
         hash_b64 = _b64std(hashlib.sha256(raw.encode()).digest())
 
@@ -993,6 +1051,10 @@ class MoongatePlugin:
 
     async def _klipper_pair(self) -> None:
         """MOONGATE_PAIR macro entry point."""
+        if self.lan_only:
+            await self._klipper_pair_lan()
+            return
+
         pending = self._start_pairing()
         await asyncio.sleep(0.3)
 
@@ -1047,6 +1109,43 @@ class MoongatePlugin:
             ]
             script = "\n".join(lines)
 
+        try:
+            klippy_apis: Any = self.server.lookup_component("klippy_apis")
+            await klippy_apis.run_gcode(script)
+        except Exception as exc:
+            logger.error("run_gcode failed: %s", exc)
+
+    async def _klipper_pair_lan(self) -> None:
+        """MOONGATE_PAIR in LAN-only mode: no cloud, no GATE code. Print the
+        pair-page URL (scan the QR) and the direct LAN address (manual add)."""
+        local_ip = _get_local_ip()
+        if not local_ip or local_ip == "localhost":
+            script = "\n".join([
+                "M118 ==========================================",
+                "M118 Moongate LAN-only: could not find the Pi's LAN IP.",
+                "M118 Check the network, then try MOONGATE_PAIR again.",
+                "M118 ==========================================",
+            ])
+        else:
+            port_sfx   = "" if self.http_port == 80 else f":{self.http_port}"
+            local_page = f"http://{local_ip}{port_sfx}/moongate-pair.html"
+            lan_addr   = f"http://{local_ip}{port_sfx}"
+            logger.info("MOONGATE LAN-only pair page: %s", local_page)
+            script = "\n".join([
+                "M118 ==========================================",
+                "M118 Moongate LAN-only (no tunnel, no cloud)",
+                "M118 ==========================================",
+                "M118 Option A - Scan the QR. Open this URL on a",
+                "M118 PC, tablet, or other phone:",
+                f"M118   {local_page}",
+                "M118 then scan it with the Moongate app",
+                "M118 (Add Printer > Scan QR code).",
+                "M118 ==========================================",
+                "M118 Option B - Add Printer > Advanced, enter:",
+                f"M118   {lan_addr}",
+                "M118 ==========================================",
+                "M118 Your phone must be on this LAN / your VPN.",
+            ])
         try:
             klippy_apis: Any = self.server.lookup_component("klippy_apis")
             await klippy_apis.run_gcode(script)
@@ -1216,6 +1315,14 @@ class MoongatePlugin:
         """Verify EdDSA token from ?mg_token= query param. Raises 401 on any
         failure. On first valid call when no owner is recorded, locks in the
         caller as the printer's permanent owner."""
+        # LAN-only mode: there is no cloud, so no EdDSA tokens exist. The plugin
+        # trusts the LAN exactly as Moonraker does - a request only reaches this
+        # endpoint after clearing Moonraker's own trusted_clients gate. No token,
+        # no owner binding. (_handle_status/_handle_control ignore the return, and
+        # _handle_reset_owner is already token-free by the same reasoning.)
+        if self.lan_only:
+            return _LAN_ONLY_CLAIMS
+
         args  = webrequest.get_args()
         token = args.get("mg_token", "")
         if not token:
@@ -1313,16 +1420,26 @@ class MoongatePlugin:
     async def _handle_pair(self, webrequest: Any) -> dict:
         pending = self._start_pairing()
         if pending is None:
-            raise self.server.error("Supabase /enroll-prepare unreachable", 502)
+            msg = ("Could not determine the Pi's LAN IP" if self.lan_only
+                   else "Supabase /enroll-prepare unreachable")
+            raise self.server.error(msg, 502)
         return {
             "code":               pending.raw_token,
             "qr_payload":         pending.qr_payload,
             "local_url":          f"http://{_get_local_ip()}:{self.http_port}",
-            "tunnel_url":         _get_tunnel_url(),
+            "tunnel_url":         None if self.lan_only else _get_tunnel_url(),
+            "lan_only":           self.lan_only,
             "expires_in_seconds": max(0, int(pending.expires_at - time.time())),
         }
 
     async def _handle_qr(self, webrequest: Any) -> dict:
+        # LAN-only: the QR is static (LAN address), so serve it directly - no
+        # pairing session required, the page shows it the moment it loads.
+        if self.lan_only:
+            qr = self._lan_qr_payload()
+            if qr is None:
+                raise self.server.error("Could not determine the Pi's LAN IP", 500)
+            return {"qr_url": qr, "tunnel_url": None, "lan_only": True}
         if self._pending is None or time.time() > self._pending.expires_at:
             raise self.server.error("No active pairing session. Run MOONGATE_PAIR first.", 404)
         return {
@@ -1331,6 +1448,15 @@ class MoongatePlugin:
         }
 
     async def _handle_pair_page(self, webrequest: Any) -> dict:
+        if self.lan_only:
+            return {
+                "qr_url":     self._lan_qr_payload(),
+                "tunnel_url": None,
+                "subdomain":  None,
+                "local_ip":   _get_local_ip(),
+                "ready":      True,
+                "lan_only":   True,
+            }
         tunnel_url = _get_tunnel_url()
         return {
             "qr_url":     self._pending.qr_payload if self._pending else None,

--- a/mobile/lib/features/auth/pairing_screen.dart
+++ b/mobile/lib/features/auth/pairing_screen.dart
@@ -271,13 +271,14 @@ class _PairingScreenState extends State<PairingScreen> {
     if (uri.host == 'lan') {
       final ip   = uri.queryParameters['ip'];
       final port = uri.queryParameters['port'];
-      if (ip == null || ip.isEmpty) {
+      // Validate the scanned address through the same normaliser as manual
+      // entry so a malformed QR can't create a garbage printer entry.
+      final raw    = (port == null || port.isEmpty) ? (ip ?? '') : '$ip:$port';
+      final lanUrl = PrinterConfig.parseLanUrl(raw);
+      if (lanUrl == null) {
         setState(() => _error = l.pairingErrorNotMoongateQr);
         return;
       }
-      final lanUrl = (port == null || port.isEmpty || port == '80')
-          ? 'http://$ip'
-          : 'http://$ip:$port';
       final name = uri.queryParameters['name'];
       setState(() {
         _scannedLanOnly         = true;

--- a/mobile/lib/features/auth/pairing_screen.dart
+++ b/mobile/lib/features/auth/pairing_screen.dart
@@ -76,6 +76,12 @@ class _PairingScreenState extends State<PairingScreen> {
   // here - server uses its stored value from enrollment_tokens.
   String? _manualEnrollmentToken;
 
+  // Cloudless LAN-only path: scanned a `moongate://lan` QR from a Pi installed
+  // with --lan-only. No enrollment token, no Supabase claim - we just add the
+  // printer by its LAN address. `_scannedLanUrl` above holds the address.
+  bool    _scannedLanOnly = false;
+  String? _scannedLanName;
+
   @override
   void dispose() {
     _barcodeSub?.cancel();
@@ -259,6 +265,30 @@ class _PairingScreenState extends State<PairingScreen> {
       setState(() => _error = l.pairingErrorNotMoongateQr);
       return;
     }
+    // Cloudless LAN-only QR: `moongate://lan?v=1&ip=<ip>&port=<port>&name=<host>`.
+    // No enrollment token - it just carries the LAN address. Handled here,
+    // before the cloud-pairing v=3 check below.
+    if (uri.host == 'lan') {
+      final ip   = uri.queryParameters['ip'];
+      final port = uri.queryParameters['port'];
+      if (ip == null || ip.isEmpty) {
+        setState(() => _error = l.pairingErrorNotMoongateQr);
+        return;
+      }
+      final lanUrl = (port == null || port.isEmpty || port == '80')
+          ? 'http://$ip'
+          : 'http://$ip:$port';
+      final name = uri.queryParameters['name'];
+      setState(() {
+        _scannedLanOnly         = true;
+        _scannedLanUrl          = lanUrl;
+        _scannedLanName         = (name != null && name.isNotEmpty) ? name : null;
+        _scannedPubKey          = null;
+        _scannedEnrollmentToken = null;
+        _error                  = null;
+      });
+      return;
+    }
     final version = uri.queryParameters['v'];
     final pk      = uri.queryParameters['pk'];
     final et      = uri.queryParameters['et'];
@@ -289,6 +319,43 @@ class _PairingScreenState extends State<PairingScreen> {
 
   Future<void> _claim() async {
     final l = AppLocalizations.of(context);
+
+    // Cloudless LAN-only path: no Supabase claim. Mint a local id from the LAN
+    // address (stable, so re-scanning the same Pi dedupes) and add it directly.
+    // The status/control services see lanOnly and poll the plugin over the LAN
+    // with no cloud token.
+    if (_scannedLanOnly) {
+      final manualLanUrl = PrinterConfig.parseLanUrl(_addressController.text);
+      if (_addressController.text.trim().isNotEmpty && manualLanUrl == null) {
+        setState(() => _error = l.pairingErrorBadAddress);
+        return;
+      }
+      final effectiveLan = manualLanUrl ?? _scannedLanUrl;
+      if (effectiveLan == null) {
+        setState(() => _error = l.pairingErrorBadAddress);
+        return;
+      }
+      final name = _nameController.text.trim().isEmpty
+          ? (_scannedLanName ?? 'My Printer')
+          : _nameController.text.trim();
+      setState(() { _loading = true; _error = null; });
+      try {
+        final id = 'lan-${effectiveLan.replaceAll(RegExp(r'[^A-Za-z0-9]'), '-')}';
+        await PrinterRegistry.instance.addClaimed(
+          PrinterConfig(id: id, name: name, lanUrl: effectiveLan, lanOnly: true),
+        );
+        if (!mounted) return;
+        if (context.canPop()) {
+          context.pop();
+        } else {
+          context.go('/dashboard');
+        }
+      } catch (e) {
+        if (mounted) setState(() { _error = l.pairingErrorFailed(e.toString()); _loading = false; });
+      }
+      return;
+    }
+
     // QR-scan path wins if present (it carries the pubkey for the
     // defense-in-depth server check). Manual path is the fallback.
     final scannedEt = _scannedEnrollmentToken;
@@ -437,6 +504,9 @@ class _PairingScreenState extends State<PairingScreen> {
     setState(() {
       _scannedPubKey         = null;
       _scannedEnrollmentToken = null;
+      _scannedLanOnly        = false;
+      _scannedLanName        = null;
+      _scannedLanUrl         = null;
       _error                 = null;
     });
   }
@@ -447,9 +517,10 @@ class _PairingScreenState extends State<PairingScreen> {
   Widget build(BuildContext context) {
     final l         = AppLocalizations.of(context);
     final cs        = Theme.of(context).colorScheme;
-    final hasScan   = _scannedPubKey != null && _scannedEnrollmentToken != null;
-    final hasManual = !hasScan && _manualEnrollmentToken != null;
-    final hasInput  = hasScan || hasManual;
+    final hasScan    = _scannedPubKey != null && _scannedEnrollmentToken != null;
+    final hasLanScan = _scannedLanOnly;
+    final hasManual  = !hasScan && !hasLanScan && _manualEnrollmentToken != null;
+    final hasInput   = hasScan || hasLanScan || hasManual;
 
     return Scaffold(
       appBar: AppBar(
@@ -659,7 +730,7 @@ class _PairingScreenState extends State<PairingScreen> {
               ),
             ],
 
-            if (hasScan) ...[
+            if (hasScan || hasLanScan) ...[
               const SizedBox(height: 8),
               Container(
                 padding: const EdgeInsets.all(14),
@@ -673,7 +744,10 @@ class _PairingScreenState extends State<PairingScreen> {
                     const SizedBox(width: 10),
                     Expanded(
                       child: Text(
-                        l.pairingQrScanned(_scannedEnrollmentToken!),
+                        // TODO(l10n): add a dedicated LAN-only string.
+                        hasLanScan
+                            ? 'LAN printer scanned - ${_scannedLanUrl ?? ''}'
+                            : l.pairingQrScanned(_scannedEnrollmentToken!),
                         style: TextStyle(
                           color: cs.onPrimaryContainer,
                           fontWeight: FontWeight.w600,

--- a/mobile/lib/features/printer/printer_screen.dart
+++ b/mobile/lib/features/printer/printer_screen.dart
@@ -135,6 +135,35 @@ class _PrinterScreenState extends State<PrinterScreen>
       return;
     }
 
+    // Cloudless LAN-only printer: load Mainsail straight from the LAN. No
+    // Supabase access, no EdDSA cookie - the Pi serves nginx/Moonraker on the
+    // LAN directly.
+    if (widget.printer.lanOnly) {
+      setState(() { _loading = true; _errorMsg = null; });
+      final lanUrl = widget.printer.lanUrl;
+      if (lanUrl == null || !await _isLanReachable(lanUrl)) {
+        if (!mounted) return;
+        setState(() { _loading = false; _errorMsg = l.printerLocalOnlyNoLan; });
+        return;
+      }
+      if (!mounted) return;
+      _usingLan  = true;
+      _tunnelUrl = null;
+      _initControllerIfNeeded();
+      await _webController!.loadRequest(Uri.parse('$lanUrl/'));
+      PrinterWebViewCache.instance.store(
+        widget.printer.id,
+        LiveWebSession(
+          controller: _webController!,
+          baseUrl:    lanUrl,
+          usingLan:   true,
+          tunnelUrl:  null,
+        ),
+      );
+      _maybeShowCameraHint();
+      return;
+    }
+
     setState(() { _loading = true; _errorMsg = null; });
     try {
       final access = await PrinterAccessCache.instance.get(widget.printer.id);

--- a/mobile/lib/features/printer/printer_screen.dart
+++ b/mobile/lib/features/printer/printer_screen.dart
@@ -78,7 +78,13 @@ class _PrinterScreenState extends State<PrinterScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _start();
+    // Defer to after the first frame: _start() reads AppLocalizations.of(context)
+    // synchronously, which can throw a null-check in initState before the
+    // localization ancestor is available (seen as an endless spinner + default
+    // "Tunnel" subtitle because _start aborted before loading anything).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _start();
+    });
   }
 
   @override
@@ -137,18 +143,27 @@ class _PrinterScreenState extends State<PrinterScreen>
 
     // Cloudless LAN-only printer: load Mainsail straight from the LAN. No
     // Supabase access, no EdDSA cookie - the Pi serves nginx/Moonraker on the
-    // LAN directly.
+    // LAN directly. We don't pre-probe /server/info here (that check is
+    // unreliable from a routed/off-subnet client, and a failed probe would
+    // wrongly show "not on this network"); we just load the page and let the
+    // WebView's onWebResourceError surface a genuine failure.
     if (widget.printer.lanOnly) {
-      setState(() { _loading = true; _errorMsg = null; });
       final lanUrl = widget.printer.lanUrl;
-      if (lanUrl == null || !await _isLanReachable(lanUrl)) {
-        if (!mounted) return;
-        setState(() { _loading = false; _errorMsg = l.printerLocalOnlyNoLan; });
+      if (lanUrl == null) {
+        if (mounted) {
+          setState(() { _loading = false; _errorMsg = l.printerLocalOnlyNoLan; });
+        }
         return;
       }
       if (!mounted) return;
-      _usingLan  = true;
-      _tunnelUrl = null;
+      // setState so the app-bar subtitle flips to "Local network" immediately,
+      // not just after the first onPageStarted callback.
+      setState(() {
+        _usingLan  = true;
+        _tunnelUrl = null;
+        _loading   = true;
+        _errorMsg  = null;
+      });
       _initControllerIfNeeded();
       await _webController!.loadRequest(Uri.parse('$lanUrl/'));
       PrinterWebViewCache.instance.store(

--- a/mobile/lib/models/printer_config.dart
+++ b/mobile/lib/models/printer_config.dart
@@ -30,6 +30,12 @@ class PrinterConfig {
   /// Format: `http://192.168.1.157:80`. Null until first successful poll.
   final String? lanUrl;
 
+  /// LAN-only / cloudless printer: added from a `moongate://lan` QR (or manual
+  /// LAN entry) against a Pi installed with `--lan-only`. There is no Supabase
+  /// row and no tunnel; the status/control services poll the plugin over the
+  /// LAN with no cloud token (the Pi trusts the LAN). See PrinterStatusService.
+  final bool lanOnly;
+
   /// Cached webcam display-transform settings, populated from the Moongate
   /// /status response after each successful poll. Persisted so the tile
   /// renders correctly on the very first frame after a cold launch.
@@ -97,6 +103,7 @@ class PrinterConfig {
     required this.id,
     required this.name,
     this.lanUrl,
+    this.lanOnly         = false,
     this.webcamFlipH     = false,
     this.webcamFlipV     = false,
     this.webcamRotation  = 0,
@@ -119,6 +126,7 @@ class PrinterConfig {
   PrinterConfig copyWith({
     String? name,
     Object? lanUrl = _sentinel, // sentinel so we can copy null in
+    bool?   lanOnly,
     bool?   webcamFlipH,
     bool?   webcamFlipV,
     int?    webcamRotation,
@@ -141,6 +149,7 @@ class PrinterConfig {
         id:              id,
         name:            name            ?? this.name,
         lanUrl:          identical(lanUrl, _sentinel) ? this.lanUrl : lanUrl as String?,
+        lanOnly:         lanOnly         ?? this.lanOnly,
         webcamFlipH:     webcamFlipH     ?? this.webcamFlipH,
         webcamFlipV:     webcamFlipV     ?? this.webcamFlipV,
         webcamRotation:  webcamRotation  ?? this.webcamRotation,
@@ -237,6 +246,7 @@ class PrinterConfig {
         'id':              id,
         'name':            name,
         if (lanUrl != null) 'lanUrl': lanUrl,
+        if (lanOnly) 'lanOnly': lanOnly,
         'webcamFlipH':     webcamFlipH,
         'webcamFlipV':     webcamFlipV,
         'webcamRotation':  webcamRotation,
@@ -265,6 +275,7 @@ class PrinterConfig {
       id:              j['id']   as String,
       name:            j['name'] as String,
       lanUrl:          j['lanUrl']          as String?,
+      lanOnly:         j['lanOnly']         as bool? ?? false,
       webcamFlipH:     j['webcamFlipH']     as bool? ?? false,
       webcamFlipV:     j['webcamFlipV']     as bool? ?? false,
       webcamRotation:  j['webcamRotation']  as int?  ?? 0,

--- a/mobile/lib/services/print_control_service.dart
+++ b/mobile/lib/services/print_control_service.dart
@@ -22,7 +22,24 @@ class PrintControlService {
   /// Send a print control action.
   /// [action]: `pause` | `resume` | `cancel` | `firmware_restart` | `emergency_stop`
   /// Returns `true` if the Pi accepted the command.
+  /// Freshest LAN base for this printer: what the status service last learned
+  /// (registry-live), else the construction-time config. Used by the LAN-only
+  /// (cloudless) path, which has no tunnel to fall back to.
+  String? _liveLanUrl() =>
+      PrinterRegistry.instance.printers
+          .firstWhere((p) => p.id == config.id, orElse: () => config)
+          .lanUrl ??
+      config.lanUrl;
+
   Future<bool> sendAction(String action) async {
+    // Cloudless LAN-only printer: hit the plugin over the LAN with no token
+    // (the lan_only plugin trusts the LAN). No Supabase, no tunnel fallback.
+    if (config.lanOnly) {
+      final lanUrl = _liveLanUrl();
+      if (lanUrl == null) return false;
+      return _send(lanUrl, '', action, timeout: const Duration(seconds: 3));
+    }
+
     if (!SupabaseService.instance.ready) return false;
 
     PrinterAccess access;
@@ -496,14 +513,19 @@ class PrintControlService {
   /// null on failure (logged for diagnosis).
   Future<Uint8List?> fetchThumbnail(GcodeFile file,
       {required String base, required bool isLan}) async {
-    final PrinterAccess access;
-    try {
-      access = await PrinterAccessCache.instance.get(config.id);
-    } catch (_) {
-      return null;
+    // The token is only needed for the tunnel's Bearer header; on LAN Moonraker
+    // trusts the subnet, so skip the Supabase fetch entirely (a LAN-only
+    // printer has no cloud row to fetch, and it saves an Edge call otherwise).
+    Map<String, String>? headers;
+    if (!isLan) {
+      final PrinterAccess access;
+      try {
+        access = await PrinterAccessCache.instance.get(config.id);
+      } catch (_) {
+        return null;
+      }
+      headers = {'Authorization': 'Bearer ${access.accessToken}'};
     }
-    final headers =
-        isLan ? null : {'Authorization': 'Bearer ${access.accessToken}'};
     final where = isLan ? 'lan' : 'tunnel';
     try {
       final metaUri = Uri.parse('$base/server/files/metadata'
@@ -556,6 +578,12 @@ class PrintControlService {
   /// less) printer still works on LAN and a stale token self-heals.
   Future<T?> _viaLanThenTunnel<T>(
       Future<T?> Function(String base, String token, bool isLan) call) async {
+    // Cloudless LAN-only printer: LAN only, token-free, no Supabase.
+    if (config.lanOnly) {
+      final lanUrl = _liveLanUrl();
+      if (lanUrl == null) return null;
+      return call(lanUrl, '', true);
+    }
     if (!SupabaseService.instance.ready) return null;
 
     PrinterAccess access;

--- a/mobile/lib/services/print_notification_service.dart
+++ b/mobile/lib/services/print_notification_service.dart
@@ -559,6 +559,11 @@ class _PrintTaskHandler extends TaskHandler {
   // ── Polling ───────────────────────────────────────────────────────────────
 
   Future<_Poll?> _poll(PrinterConfig p) async {
+    // Cloudless LAN-only printer: no cloud row exists, so minting a
+    // printer-access token here just 404s on every tick. Skip it outright -
+    // zero cloud calls. (LAN-side notification polling is a separate follow-up.)
+    if (p.lanOnly) return null;
+
     // Liveness gate (mirrors the dashboard): skip the token mint - an Edge call
     // - for a printer with positive evidence of being offline (stale cloud
     // last_seen) and no token-free LAN answer. Fails open on unknown last_seen.

--- a/mobile/lib/services/printer_status_service.dart
+++ b/mobile/lib/services/printer_status_service.dart
@@ -252,6 +252,13 @@ class PrinterStatusService {
   }
 
   Future<void> _doPoll() async {
+    // Cloudless LAN-only printer: no Supabase, no tunnel. Poll the plugin over
+    // the LAN with an empty token (the lan_only plugin skips auth) and reuse
+    // the exact same /status parsing as the cloud path.
+    if (config.lanOnly) {
+      await _doPollLanOnly();
+      return;
+    }
     _firstPollAt ??= DateTime.now();
     _pollDiag = {};
     if (!SupabaseService.instance.ready) {
@@ -438,6 +445,36 @@ class PrinterStatusService {
             : PrinterStatus.offline,
       );
     }
+  }
+
+  // ── LAN-only (cloudless) poll ────────────────────────────────────────────
+  // A printer added from a `moongate://lan` QR has no Supabase row and no
+  // tunnel. We hit the plugin's /status directly on the LAN with an empty
+  // token; the lan_only plugin trusts the LAN and skips the EdDSA check, so the
+  // response (and all the supplementary LAN queries, which already send no auth
+  // header) come back exactly as on the cloud LAN path. No Edge calls, ever.
+  Future<void> _doPollLanOnly() async {
+    _firstPollAt ??= DateTime.now();
+    _pollDiag = {};
+    final lanUrl = _currentLanUrl;
+    if (lanUrl == null) {
+      if (!_disposed) _controller.add(PrinterStatus.offline);
+      return;
+    }
+    final access = PrinterAccess(
+      tunnelUrl:   null,
+      accessToken: '',
+      expiresAt:   DateTime.now().add(const Duration(days: 365)),
+    );
+    _lastEndpointReason = null;
+    final status = await _tryMoongateEndpoint(
+        baseUrl: lanUrl, access: access, isLan: true, tunnelReady: false);
+    _recordPollDiag({
+      'lan_only':   true,
+      'lan_url':    lanUrl,
+      'lan_status': _lastEndpointReason ?? 'unknown',
+    });
+    if (!_disposed) _controller.add(status ?? PrinterStatus.offline);
   }
 
   // ── Reachability probe ───────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #201, and a direct answer to *"something genuinely cloud-free is worth thinking about separately … it's an app feature"*: this adds a **cloud-free LAN-only pairing** path across the plugin and the app, for internet-isolated Pis / a zero-cloud setup.

> **Stacks on #201** (based on that branch). Until #201 merges, the diff here also shows its commits; it'll reduce to just the three below afterward. No functional dependency beyond the `lan_only` flag #201's installer sets.

## How it works

A Pi installed with `--lan-only` sets `lan_only` in the plugin config. In that mode:

**Plugin (`moongate_standalone.py`)**
- `MOONGATE_PAIR` and the pair page serve a static **`moongate://lan?v=1&ip=…&port=…&name=…`** QR — no Supabase `enroll-prepare`, no GATE code. The pair page renders it with **no internet** and needs no active session.
- `/status` and `/control` **skip the EdDSA token**: the plugin trusts the LAN exactly as Moonraker's `trusted_clients` does (mirrors the already-token-free `/reset-owner`). `_authenticate` returns a placeholder in `lan_only`.
- The heartbeat, print-event watcher, and JWKS fetch are **not started**, so the plugin makes zero outbound calls.

**App**
- `PrinterConfig.lanOnly` (persisted). The pairing screen parses `moongate://lan` and adds the printer **directly** (local id from the LAN address, no `claimPrinter`).
- `PrinterStatusService` polls the plugin `/status` over the LAN with an empty token — reusing the **exact same** parser as the cloud path, no Supabase, no tunnel, zero Edge calls. `PrintControlService` and the printer webview go LAN-direct too.

## Validated end-to-end (real hardware)

Klipper Pi + Pixel 6a: cloud-free `moongate://lan` QR (curl-verified, renders offline), scan → add with no Supabase, **live tile ("Idle")** and the **in-app Mainsail webview** both on **"Local network"** — no cloud, no tunnel, no outbound connections from the plugin.

## Deployment requirement (please fold into the LAN-only docs)

The app hits Moonraker directly, so **the client's subnet — the phone's LAN/VLAN or the VPN subnet — must be in Moonraker's `[authorization] trusted_clients`**, else Moonraker 401s before the plugin runs. (This is the `trusted_clients` note you already flagged for #201; it's load-bearing for cloud-free mode.)

## Known limitations
- No cloud push / background print notifications for `lanOnly` printers (they skip the cloud path gracefully).
- The pair page draws its QR from a CDN, so a *truly* offline box can't render it on that page — a bundled QR lib would close that; the plugin's QR payload itself is fully offline.
- One l10n `TODO` for the LAN-scanned confirmation string.
