### PR TITLE
docs: v0.9.51 sweep - Direct (LAN/VPN) mode across every doc

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,6 +134,7 @@ Responsibilities:
 - **Status.** Aggregates Klipper / Moonraker objects into a single `/server/moongate/status` response - `print_stats`, temperatures, the discovered chamber sensor, webcam transforms, the current tunnel URL, and (0.6.4+) the plugin's own version, which the app compares against the version it shipped with to drive the dashboard's **plugin-update badge**.
 - **Control.** A small whitelist of safe actions: `pause`, `resume`, `cancel`, `firmware_restart`, `emergency_stop`, plus (0.6.16) `update_plugin` - which triggers Moonraker's **own update manager** for the Moongate component (the app's one-tap plugin update) and is refused while a print is running. There is no arbitrary G-code endpoint.
 - **Owner state.** Knows the user this Pi is paired to, persisted at `~/.config/moongate/owner.json`. The `MOONGATE_RESET_OWNER` macro wipes it.
+- **LAN-only mode (0.6.16+, set by `install.sh --lan-only`).** With `lan_only` in `~/.config/moongate/config.json` the plugin becomes fully cloudless: the heartbeat loop, print-event watcher, and signing-key fetch are **never started** (zero outbound calls), `MOONGATE_PAIR` and the pair page serve a static **`moongate://lan?ip=…&port=…&name=…`** QR instead of a cloud enrollment, and `/server/moongate/status` + `/control` **skip the access-token check** - a request only reaches them after clearing Moonraker's own `trusted_clients` gate, so the plugin trusts the LAN exactly as Moonraker itself does (the same reasoning as the already token-free `/reset-owner`). Re-running the installer without the flag converts the box back.
 
 ### The auth proxy (v0.4+)
 
@@ -150,6 +151,8 @@ LAN traffic doesn't go through the proxy - nginx still listens on the LAN interf
 ### The tunnel
 
 `cloudflared` Quick Tunnel runs as `moongate-tunnel.service`. It makes an outbound connection to the Cloudflare edge - no inbound ports opened on your router. The URL rotates each time the Pi reboots; the Moongate plugin heartbeats the current one to the cloud middleman so the app always knows where to reach the Pi.
+
+On a **LAN-only install** (`install.sh --lan-only`, v0.9.51) neither the tunnel nor the auth proxy exists: the installer skips cloudflared entirely (including its architecture check), never creates the two systemd units, skips the clock check and its htpdate timer, and leaves Moonraker bound to the LAN. Run on a box that already has the tunnel stack, the same flag **retires** it - units disabled, the stale tunnel-URL logs removed so the plugin can't heartbeat a dead URL.
 
 ### Where state lives on the Pi
 
@@ -251,6 +254,17 @@ If the phone's camera doesn't work (permission denied, hardware fault, can't foc
 3. Try `POST /server/moongate/control?mg_token=...&action=pause` first; the auth proxy + plugin both verify the token.
 4. Return `true` as soon as the Pi answers 200.
 
+### Direct (LAN/VPN) status poll + control (v0.9.51)
+
+A printer added through the pairing screen's **Direct (LAN/VPN)** tab (or flipped to Direct in its edit dialog) short-circuits all of the above:
+
+1. `PrinterStatusService._doPoll()` sees the registry-live `lanOnly` flag and calls `_doPollLanOnly()` instead: one GET to `/server/moongate/status` at the stored LAN address with an **empty token** - no `PrinterAccessCache`, no middleman, no tunnel fallback. The response parses through the exact same code path as the cloud route.
+2. `PrintControlService` does the same for actions, and the printer page loads Mainsail/Fluidd straight from the LAN root with no token cookie.
+3. The background notification service **skips Direct printers entirely** (their cards would need the cloud path), so they cost zero middleman calls there too.
+4. Unreachable simply means offline - there is nothing to fall back to, which is the honest answer for a LAN/VPN-only machine that you're away from.
+
+Direct-added printers mint a **local id** (`lan-<address>`), so `PrinterConfig.cloudPaired` can tell them apart from cloud printers that merely have Direct mode switched on: only the former have no cloud row to release on removal or return to when toggled. Cloud-pairing a machine that already exists as a Direct tile **absorbs** the old tile (same LAN host + port) - the new cloud tile inherits its persisted settings and the Direct tile is retired.
+
 ### Tunnel URL rotation
 
 `cloudflared` Quick Tunnels get a fresh URL every time `cloudflared` restarts (so every Pi reboot, plus any manual restart). To make this transparent:
@@ -289,7 +303,11 @@ v0.9.49 closes the same gap on the **Pi side**: an orphaned plugin (its cloud re
 
 An opt-in top-bar toggle turns the tunnel off as a *transport*: while active, the status poller skips the tunnel fallback and its reachability probes, the printer WebView only loads over LAN (a kept-warm tunnel session is dropped rather than reused), the cameras inherit LAN-only from the poller, and the background notification isolate skips the tunnel base too - zero remote traffic. Printers with no reachable LAN address settle to offline. Pairing and cloud identity are untouched; the pref is re-read every poll (and each notification tick), so flipping it takes effect within ~4 s without restarting anything. The mode persists across restarts but is deliberately excluded from settings backups, so a restore can never silently cut remote access.
 
-### Persistent UI type detection
+### Direct (LAN/VPN) mode is per-printer, and distinct from Local-only (v0.9.51)
+
+**Local-only** (above) is a *transport* toggle for cloud printers: identity and pairing stay cloud-side, the tunnel is just not used while it's on. **Direct (LAN/VPN)** is a per-printer *identity* choice: the printer has no cloud existence at all (or ignores it while switched), and the trust model is Moonraker's own `trusted_clients` - the same thing that lets Mainsail on your desktop control the printer without a password. Moongate deliberately adds no second gate there: on the LAN you are exactly as trusted as any other Moonraker client, and remote access is whatever your own VPN provides.
+
+The flag lives on `PrinterConfig.lanOnly` and is read **registry-live** by the status/control services and the printer page, so the edit-dialog switch takes effect on the next poll with no restart and no service rebuild. The switch only shows for cloud-paired printers (both directions are meaningful there); a Direct-added `lan-` printer has no cloud row to switch back to - converting one to cloud is a real pairing, which then absorbs the old tile.
 
 When the dashboard tile can't render a webcam (camera off, printer powered off, etc.) it shows the printer's web-UI logo as a placeholder - Mainsail or Fluidd. Detection is a one-time HTML sniff of the root page. In v0.4 the result is persisted on `PrinterConfig`, so a fresh cold launch shows the correct logo immediately, even when the printer is currently offline. Before v0.4, detection had to re-run on every cold launch and the logo only appeared after the first successful poll.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,6 +183,15 @@ cd Moongate/klipper-plugin
 ./install.sh
 ```
 
+To develop against the cloud-free path (v0.9.51's Direct mode), install the box in **LAN-only mode** instead - no cloudflared, no auth proxy, no clock check, and the plugin's `lan_only` config flag set so `/status` + `/control` are token-free on the LAN:
+
+```bash
+./install.sh --lan-only          # or: MOONGATE_LAN_ONLY=1 ./install.sh
+./install.sh                     # re-run without the flag to convert back to tunnel mode
+```
+
+Converging an existing tunnel-mode box with `--lan-only` also retires the running tunnel + proxy units and clears the stale tunnel-URL logs.
+
 Iteration loop:
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,7 @@ What Moongate **does not** claim to protect:
 | Cloudflare is compromised or compelled (subpoena, court order) | Cloudflare terminates TLS at their edge. They see request URLs, headers, and bodies in plaintext for the leg between your phone and the edge. Their ToS apply. If this is unacceptable, swap `cloudflared` for any other tunnel that points at the auth proxy's port - Moongate doesn't care which tunnel you use |
 | HTTP traffic between your phone and the Pi is sniffed on your LAN | Local Moonraker is plain HTTP. This is the standard Klipper setup, not a Moongate choice. The access token is sent in headers; on LAN, anyone with the WiFi password who is actively MITM-ing your TCP can read it. If you need LAN encryption, put nginx + TLS in front of Moonraker (outside Moongate's scope) |
 | You port-forward port 80 / 7125 from your router to the Pi | Don't. The whole point of the tunnel + auth proxy is so you never need to. If you do anyway, the public LAN port bypasses the auth proxy and anyone who finds the IP can hammer Moonraker directly |
+| Someone on your own LAN (or inside your VPN) targets a **Direct (LAN/VPN)** printer | Direct mode deliberately trusts what Moonraker trusts: anyone your `[authorization] trusted_clients` admits has Moonraker-level control - the same standing Mainsail and Fluidd have on every stock install. Moongate adds no second gate on the LAN, and your VPN's membership *is* the remote perimeter. See [Direct (LAN/VPN) mode](#direct-lanvpn-mode-v0951) |
 | A malicious developer pushes a backdoored APK | All releases are GitHub Actions builds from `master`. You can read the commits. You can build the APK yourself (see [DEVELOPMENT.md](DEVELOPMENT.md)) |
 | You pair a friend's phone and they later misuse it | Once paired, a phone has full operator-level control over the printer. Same as handing them the Mainsail URL on your LAN. Un-pair the device from `Dashboard → Remove printer` when you no longer want them to have access |
 
@@ -178,6 +179,18 @@ Phone ──HTTPS/QUIC── Cloudflare edge ──TLS── cloudflared (on Pi)
 If you don't want Cloudflare in the picture, point the cloudflared step at any other tunneling layer that reaches the auth proxy's port (Tailscale Funnel, frp, ngrok paid, a self-hosted nginx-on-VPS reverse proxy, etc.). The auth proxy doesn't care what's in front of it.
 
 ---
+
+## Direct (LAN/VPN) mode (v0.9.51)
+
+An opt-in, per-printer alternative to everything above: a Pi installed with `install.sh --lan-only` runs **no tunnel, no auth proxy, and makes zero outbound calls** - and the app, in its **Direct (LAN/VPN)** mode, talks straight to Moonraker on the LAN (or across your own WireGuard / Tailscale VPN) with **no cloud account and no tokens**.
+
+What that changes, stated plainly:
+
+- **The trust boundary is Moonraker's `trusted_clients`, nothing else.** In LAN-only mode the plugin's `/status` and `/control` endpoints skip the access-token check; a request only reaches them after clearing Moonraker's own authorization, exactly like every Mainsail/Fluidd request on a stock install. On the LAN, Moongate is as trusted - and as unauthenticated - as any other Moonraker client. This is not a new exposure class: stock nginx already proxies Moonraker unauthenticated on port 80.
+- **Remote access is your VPN's perimeter.** There is no tunnel to leak and no token to steal; if your WireGuard/Tailscale subnet is in `trusted_clients`, VPN membership is the credential. Choose that subnet deliberately (Tailscale uses `100.64.0.0/10`).
+- **Nothing is stored in the cloud.** A Direct-added printer has no cloud row, sends no heartbeats, and mints no tokens - the middleman never learns it exists.
+- **The tunnel path is unaffected.** The token bypass applies only when the plugin itself runs `lan_only`. On a half-converged box (flag set but the tunnel stack somehow still running) the auth proxy still does its own independent token verification, so the internet-facing promise above - flat 401s without a valid broker-signed token - holds regardless of the plugin's mode.
+- **Switching modes is explicit.** A cloud-paired printer flipped to Direct in the app simply stops using its cloud identity (and can flip back); converting a box's *install* between modes is a deliberate re-run of the installer with or without `--lan-only`.
 
 ## What the plugin can see and do
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -141,6 +141,31 @@ In v0.4.0 the app retries LAN on every poll, so this should self-correct within 
 
 That's the **Local only** switch (v0.9.48): while it's on, Moongate deliberately makes no remote connections, so only printers on your current network connect and everything else settles to offline. Tap the orange crossed-out cloud in the top bar to turn remote back on (a snackbar confirms), or turn the whole button off under the menu's **Local-only button** switch - switching the menu entry off also turns the mode off. The state survives app restarts, so a toggle you flipped days ago is the usual culprit.
 
+## A Direct (LAN/VPN) printer shows offline
+
+A printer added through **Add Printer → Direct (LAN/VPN)** (v0.9.51+) has exactly one path to it - the address you gave it, over your network - so "offline" always means one of these:
+
+1. **The phone isn't on the printer's network.** On WiFi at home this is your LAN; away from home it means your **own VPN must be connected** (WireGuard, Tailscale). Direct printers have no tunnel to fall back to - that's the mode's whole point.
+2. **Moonraker is rejecting the phone.** The app talks straight to Moonraker, so the phone's network must be inside `[authorization] trusted_clients` in `moonraker.conf`. Home subnets usually already are; **VPN subnets usually are not** - WireGuard setups often use `10.x` ranges that happen to be covered, but **Tailscale's `100.64.0.0/10` almost never is**. Add the subnet and restart Moonraker:
+   ```ini
+   [authorization]
+   trusted_clients:
+       192.168.1.0/24
+       100.64.0.0/10   # Tailscale
+   ```
+3. **The Pi isn't actually in LAN-only mode.** Direct mode needs the plugin installed with `--lan-only` (see the README's LAN-only install section). Against a normal cloud-mode install the plugin still demands a token and answers `401`, so the tile sits offline. Check from any PC on the LAN:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}\n" "http://<pi-ip>/server/moongate/status?mg_token="
+   ```
+   `200` = LAN-only mode; `401` = cloud mode (re-run the installer with `--lan-only`, or pair the printer through the cloud instead).
+4. **The Pi's address changed** (DHCP handed it a new IP). The app stores the address a Direct printer was added with - fix it in the printer's edit dialog (the pencil on its page), and give the Pi a **DHCP reservation / static IP** so it stops moving.
+
+Also by design: Direct printers have **no print notifications** (there's no cloud to send them), so a quiet notification shade for one isn't a fault.
+
+## A Direct printer works at home but not over my VPN
+
+Same checklist as above with the VPN hat on: the VPN must be **connected on the phone**, its subnet must be in Moonraker's `trusted_clients` (point 2 above - this is the usual culprit, especially Tailscale's `100.64.0.0/10`), and the printer's stored address must be reachable *through* the VPN - for router-based WireGuard that's the printer's normal LAN IP; for Tailscale it's the Pi's Tailscale address, which is what you should have entered when adding the printer.
+
 ## Opening a printer shows "the web interface isn't answering yet"
 
 From v0.9.48 this friendly message (with an automatic retry every few seconds) replaces the raw Cloudflare **"Bad gateway / Error 502"** page you used to see when opening a printer whose Pi was still starting up - the tunnel comes up a little before Mainsail does, so the first moments after a Pi boot can answer 502. It normally clears by itself within a minute. If it doesn't: check Mainsail loads in a browser on the printer's own network, and that Moonraker/Klipper are actually running on the Pi - the tunnel being up only proves the Pi is powered, not that the web stack behind it is healthy.

--- a/docs/managing-moongate.md
+++ b/docs/managing-moongate.md
@@ -46,6 +46,8 @@ To reinstall cleanly:
 
 > **Just upgrading the app over the top?** None of this applies - your identity is kept and your printers stay paired.
 
+> **Direct (LAN/VPN) printers** (v0.9.51+) sit outside all of this: they have no cloud identity, so a fresh install plus **Restore config** brings them back **fully working** - the backup carries their address, which is all they need. No `MOONGATE_RESET_OWNER`, no re-pairing. Just keep the Pi on a fixed address (DHCP reservation).
+
 ---
 
 ## Removing Moongate


### PR DESCRIPTION
## What will this PR change?

Documentation only - the full v0.9.51 sweep. Every deep doc now tells the Direct (LAN/VPN) story that shipped today (the README and diagram already went in with #208).

**In plain English:** someone reading the repo's docs now finds Direct mode explained wherever they'd look for it - how it's built (ARCHITECTURE), what it does and doesn't protect (SECURITY), what to check when a Direct printer shows offline (TROUBLESHOOTING), how to develop against a LAN-only box (DEVELOPMENT), and how backups treat Direct printers (managing-moongate).

## Contents

- **ARCHITECTURE.md**: the plugin's `lan_only` mode, what `--lan-only` installs/retires, a Direct status+control data-flow walkthrough, and a design-decision entry spelling out Direct vs the v0.9.48 Local-only switch, the registry-live flag, the `cloudPaired` discriminator, and tile absorption.
- **SECURITY.md**: a dedicated Direct-mode section - `trusted_clients` is the boundary, your VPN is the remote perimeter, zero cloud data, and the tunnel's 401 promise is unaffected (the auth proxy verifies independently of the plugin's mode). Plus an honest new row in the "does not claim to protect" table.
- **TROUBLESHOOTING.md**: "A Direct (LAN/VPN) printer shows offline" (network/VPN, `trusted_clients` incl. Tailscale's `100.64.0.0/10` with a config snippet, a curl one-liner that distinguishes LAN-only from cloud-mode installs, DHCP drift) and "works at home but not over my VPN".
- **DEVELOPMENT.md**: the `--lan-only` install / convert-back loop for Pi-side development.
- **docs/managing-moongate.md**: Direct printers restore fully working from a backup - no reset, no re-pair.

## Verification

- Link audit across all Markdown: every internal link and `#anchor` resolves (scripted check), and the load-bearing external URLs (release, installer/uninstaller raw links, App Store) return 200.
- CHANGELOG.md and `changelog.json` for v0.9.51 were verified present (shipped in #209 per the changelog-guard process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
