### PR TITLE
Mute lever: prefix support for rotating spinner IPs

### DIFF
--- a/supabase/functions/printer-heartbeat/index.ts
+++ b/supabase/functions/printer-heartbeat/index.ts
@@ -48,10 +48,18 @@ const MAX_TUNNEL_URL_LENGTH = 256;
 // re-pairs has a live row again and takes the normal 'ok' path, so a mute
 // never blocks a comeback. (Designed 2026-06-24 during the Schlonky spinner
 // hunt; built 2026-07-13 for the 87.122.x spinner.)
-const MUTED_IPS = new Set(
-  (Deno.env.get("MOONGATE_MUTED_IPS") ?? "")
-    .split(",").map((s) => s.trim()).filter((s) => s.length > 0),
-);
+//
+// An entry ending in "." is a PREFIX match ("87.122.16." mutes that whole
+// block): residential IPs rotate, so an exact IP goes stale overnight (the
+// 87.122.x spinner moved .205 -> .219 within a day, 2026-07-14).
+const MUTED_ENTRIES  = (Deno.env.get("MOONGATE_MUTED_IPS") ?? "")
+  .split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+const MUTED_IPS      = new Set(MUTED_ENTRIES.filter((e) => !e.endsWith(".")));
+const MUTED_PREFIXES = MUTED_ENTRIES.filter((e) => e.endsWith("."));
+
+const isMuted = (ip: string) =>
+  ip.length > 0 &&
+  (MUTED_IPS.has(ip) || MUTED_PREFIXES.some((p) => ip.startsWith(p)));
 
 Deno.serve(async (req) => {
   const preflight = handleCorsPreflight(req);
@@ -135,7 +143,7 @@ Deno.serve(async (req) => {
   // Rowless outcome. A muted spinner gets a calming 204 before anything else.
   const callerIp = req.headers.get("cf-connecting-ip")
                 ?? req.headers.get("x-real-ip") ?? "";
-  if (MUTED_IPS.has(callerIp)) return emptyResponse(204);
+  if (isMuted(callerIp)) return emptyResponse(204);
 
   if (data === "revoked") return gone("printer_released");
   return notFound();


### PR DESCRIPTION
## What will this PR change?

The MOONGATE_MUTED_IPS lever (the calming 204 for orphaned spinning Pis) currently only matches exact IPs. This PR lets an entry ending in a dot act as a prefix, so `87.122.16.` mutes the whole block.

**Plain English:** the German spinner we built the lever for changed IP overnight (87.122.16.205 became 87.122.16.219, same household, German ISPs rotate home IPs daily). Muting one exact IP would stop working every time their router reconnects. A prefix entry covers the whole rotating range in one go.

## Why now

Tonight's daily meter watch caught the spinner back at 706 heartbeat-404s per hour on the new IP. That is ~17k invocations a day from one Pi, safe on Pro but it blocks the downgrade-back-to-free goal.

## How

- The secret is split into exact entries (a Set, as before) and prefix entries (anything ending in ".").
- A caller is muted on an exact hit or a startsWith hit.
- The mute still applies ONLY to the rowless path: a muted household that re-pairs gets a live row again and is completely unaffected.
- Collateral within the muted block is limited to other ORPHANED Pis (which is what the mute is for anyway); paired Pis there behave normally.

## Testing

- Deployed to prod via the dashboard function editor alongside setting the secret to `87.122.16.` (same flow as the #203 tombstone deploy); watching the heartbeat 404 line collapse in the Logs Explorer confirms it live.
- No app or plugin change; no version bump; changelog not applicable (server-side only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)