### PR TITLE
installer: ask cloud vs Direct (LAN/VPN) when run interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,16 +109,28 @@ MOONGATE_PORT=8080 bash -c "$(curl -fsSL https://raw.githubusercontent.com/PEEKY
 
 In the app's pair screen, set the **Port** field to match (leave it blank for 80).
 
-**LAN-only (own VPN, no tunnel)?** If you reach your printer over your own VPN / WireGuard and don't want an outbound Cloudflare tunnel or external exposure, install in LAN-only mode. It keeps Moonraker on the LAN (`0.0.0.0`) and skips cloudflared, the auth proxy, and the tunnel service. The plugin, `MOONGATE_PAIR` macro, and mDNS advertisement are still installed, and re-running without the flag later enables remote access.
+**LAN-only (own VPN, no tunnel)?** If you reach your printer over your own VPN / WireGuard and don't want an outbound Cloudflare tunnel or external exposure, install in LAN-only mode. It keeps Moonraker on the LAN (`0.0.0.0`) and skips cloudflared, the auth proxy, and the tunnel service. The plugin, `MOONGATE_PAIR` macro, and mDNS advertisement are still installed, and a later cloud re-install enables remote access.
 
-```bash
-# piped
-MOONGATE_LAN_ONLY=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/install.sh)"
-# or, from a local checkout
-bash install.sh --lan-only
+**The installer asks.** Run it interactively (the normal `curl | bash` one-liner counts) and it offers the choice - answer `2` for Direct (LAN/VPN):
+
+```
+How will your phone connect to this printer?
+    1) Moongate cloud   - remote access from anywhere (secure tunnel)
+    2) Direct (LAN/VPN) - home network / your own VPN only, no cloud
 ```
 
-Re-running with the flag on a box that already has the tunnel stack retires it (disables the tunnel + auth proxy) and converges to LAN-only.
+On a box that already runs LAN-only the default keeps it LAN-only, so pressing Enter never converts your mode. To preselect an answer and skip the question (scripts, headless installs):
+
+```bash
+# LAN-only, piped
+MOONGATE_LAN_ONLY=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/install.sh)"
+# LAN-only, from a local checkout
+bash install.sh --lan-only
+# cloud, never prompt (automation)
+MOONGATE_LAN_ONLY=0 bash -c "$(curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/install.sh)"
+```
+
+Choosing LAN-only on a box that already has the tunnel stack retires it (disables the tunnel + auth proxy) and converges to LAN-only.
 
 In the app, add a LAN-only printer with **Add printer → Direct (LAN/VPN)** - scan the QR from `MOONGATE_PAIR` or type the printer's address. A LAN-only box can also be paired through the cloud as normal (while it has internet); Direct mode is for the fully cloud-free / internet-isolated case. Two networking notes:
 
@@ -160,7 +172,7 @@ Moongate gives every printer a choice of two connections - and you can mix them 
 
 | | ☁️ Moongate cloud (default) | 🔌 Direct (LAN/VPN) |
 |---|---|---|
-| Setup | pair once with the QR / GATE code | install the Pi with `--lan-only`, add by QR or address |
+| Setup | pair once with the QR / GATE code | pick **Direct** when the installer asks, add by QR or address |
 | Away from home | automatic - secure tunnel, zero config | through **your own VPN** (WireGuard, Tailscale) |
 | Print notifications | ✅ | ❌ (no cloud to send them) |
 | What touches the cloud | pairing, a heartbeat, short-lived tokens | **nothing - zero calls, ever** |

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -35,6 +35,13 @@ MOONGATE_PORT="${MOONGATE_PORT:-80}"
 #
 #   Locally:  bash install.sh --lan-only
 #   Piped:    MOONGATE_LAN_ONLY=1 bash -c "$(curl -fsSL <url>)"
+#
+# No flag and no env var at all -> the interactive chooser below asks. Any
+# explicit setting (either value, or the flag) skips the question, so
+# automation that wants the tunnel default unchanged sets MOONGATE_LAN_ONLY=0.
+# Set-ness must be captured before the :- default collapses "unset" and
+# "empty" into the same thing.
+MG_LAN_MODE_EXPLICIT="${MOONGATE_LAN_ONLY+x}"
 MOONGATE_LAN_ONLY="${MOONGATE_LAN_ONLY:-}"
 
 # Loopback port the v0.4 auth proxy binds to. cloudflared targets this
@@ -44,7 +51,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --port)      [[ -n "${2-}" ]] || die "--port needs a value"; MOONGATE_PORT="$2"; shift 2;;
         --port=*)    MOONGATE_PORT="${1#*=}"; shift;;
-        --lan-only)  MOONGATE_LAN_ONLY=1; shift;;
+        --lan-only)  MOONGATE_LAN_ONLY=1; MG_LAN_MODE_EXPLICIT=x; shift;;
         *)           shift;;
     esac
 done
@@ -53,6 +60,39 @@ done
 [[ "$MOONGATE_PORT" -ge 1 && "$MOONGATE_PORT" -le 65535 ]] \
     || die "Port out of range (1-65535): $MOONGATE_PORT"
 info "HTTP port: $MOONGATE_PORT"
+
+# ── Connection-mode chooser ──────────────────────────────────────────────────
+# Runs only when the caller expressed no preference (no --lan-only flag,
+# MOONGATE_LAN_ONLY unset) AND a terminal is reachable. The answer is read
+# from /dev/tty, not stdin: under `curl ... | bash` stdin is the script
+# itself, so a plain `read` would swallow script text - /dev/tty still
+# reaches the keyboard. Headless runs (no controlling terminal: CI,
+# provisioning tools) skip the question and get the full cloud install,
+# exactly the pre-chooser behaviour.
+#
+# The default answer keeps an existing install's current mode: this script
+# doubles as the mode CONVERTER (re-running without --lan-only flips a box
+# back to cloud), so a LAN-only user re-running it to repair must not be
+# converted - and handed an internet tunnel - by an idle Enter. Fresh
+# installs default to cloud.
+if [[ -z "$MG_LAN_MODE_EXPLICIT" ]] && ( : </dev/tty ) 2>/dev/null; then
+    MG_MODE_DEFAULT=1
+    # Existing LAN-only box -> keep its mode (§5b writes this file).
+    grep -qs '"lan_only"[[:space:]]*:[[:space:]]*true' "$HOME/.config/moongate/config.json" \
+        && MG_MODE_DEFAULT=2
+    echo
+    info "How will your phone connect to this printer?"
+    echo "    1) Moongate cloud   - remote access from anywhere (secure tunnel)"
+    echo "    2) Direct (LAN/VPN) - home network / your own VPN only, no cloud"
+    while :; do
+        read -r -p "Choose 1 or 2 [default: $MG_MODE_DEFAULT]: " MG_MODE_CHOICE </dev/tty \
+            || MG_MODE_CHOICE=""   # EOF (e.g. ctrl-D) -> take the default
+        MG_MODE_CHOICE="${MG_MODE_CHOICE:-$MG_MODE_DEFAULT}"
+        [[ "$MG_MODE_CHOICE" == "1" || "$MG_MODE_CHOICE" == "2" ]] && break
+        warn "Please answer 1 or 2."
+    done
+    [[ "$MG_MODE_CHOICE" == "2" ]] && MOONGATE_LAN_ONLY=1 || MOONGATE_LAN_ONLY=""
+fi
 
 # Normalise to "1" (on) or "" (off) so MOONGATE_LAN_ONLY=0 opts OUT - matches
 # how uninstall.sh treats MOONGATE_YES. --lan-only above already set it to 1.


### PR DESCRIPTION
# What will this PR change?

Run interactively, the installer now asks which connection mode you want, so nobody has to know the `--lan-only` flag to get Direct (LAN/VPN) mode:

```
How will your phone connect to this printer?
    1) Moongate cloud   - remote access from anywhere (secure tunnel)
    2) Direct (LAN/VPN) - home network / your own VPN only, no cloud
```

In plain English: today the cloud-free mode is hidden behind a flag that only people who read the README's fine print find. After this PR the normal `curl | bash` one-liner offers the choice to everyone, and every existing command keeps working exactly as before.

# Why

Direct (LAN/VPN) mode shipped in v0.9.51 but is only reachable via `install.sh --lan-only` or `MOONGATE_LAN_ONLY=1`. That is a discoverability wall: the users the mode is for (VPN owners, isolated networks) have to already know it exists. The installer is the natural place to surface it.

# How

- The answer is read from `/dev/tty`, not stdin. Under `curl ... | bash`, stdin is the script itself, so a plain `read` would swallow script text; `/dev/tty` still reaches the keyboard (same pattern rustup uses).
- The question only appears when the caller expressed no preference: no `--lan-only` flag and `MOONGATE_LAN_ONLY` unset. Any explicit setting skips it, so:
  - `--lan-only` / `MOONGATE_LAN_ONLY=1` preselect Direct, never prompt (unchanged)
  - `MOONGATE_LAN_ONLY=0` preselects cloud, never prompts (new, for automation; the KIAUH extension will pass this once the companion KIAUH PR lands)
  - headless runs (no controlling terminal): no prompt, full cloud install, byte-for-byte the old default
- **The default answer keeps an existing install's current mode** (read from `~/.config/moongate/config.json`). install.sh doubles as the mode converter, so a LAN-only user re-running it to repair something must not be flipped to cloud, and handed an internet tunnel, by an idle Enter. Fresh installs default to cloud.
- Invalid input re-asks; EOF (ctrl-D) takes the default; the chooser sits before the existing normalise step so everything downstream is untouched.
- README: the LAN-only section now leads with the chooser and documents `MOONGATE_LAN_ONLY=0`; the mode-comparison table points at the chooser instead of the flag.

# Testing

- `bash -n` clean.
- Headless paths exercised on this box (env unset, `MOONGATE_LAN_ONLY=0`, `--lan-only`): no prompt in any of them, correct mode announced, identical to pre-PR behaviour.
- The chooser block was extracted verbatim (tty reads swapped for stdin) and run through 7 cases: fresh+2 -> LAN-only, fresh+Enter -> cloud, junk input re-asks then accepts, immediate EOF -> cloud with no hang, existing LAN-only box+Enter -> stays LAN-only, existing LAN-only box+1 -> converts to cloud, existing cloud box+Enter -> cloud. All passed.
- **Verified on a real Pi (the RatRig, 15/07/2026)** with a pseudo-terminal driving this exact branch's install.sh, aborted harmlessly at the Moonraker check (`MOONRAKER_DIR=/nonexistent`) so nothing was installed. Six cases, all pass: choose 2 -> LAN-only; Enter -> cloud default; junk input re-asks then accepts; **the real `curl | bash` form prompts and reads the answer via `/dev/tty`**; headless (no terminal) never prompts and keeps the old cloud default; an existing `lan_only: true` config flips the default to 2 so an idle Enter keeps LAN-only.

No app change, no plugin component change, no version bump (install.sh is not versioned; `update_manager` tracks master). Companion PR to dw-0/kiauh adds the same question KIAUH-natively and passes the env var through, which suppresses this prompt there.

PEEKYPAUL 15/07/2026
