### PR TITLE
fix(webcam): go2rtc cameras - frame endpoint rewrite, WebView autoplay, broken-image hardening

### DIFF
--- a/mobile/lib/features/printer/printer_screen.dart
+++ b/mobile/lib/features/printer/printer_screen.dart
@@ -436,7 +436,7 @@ class _PrinterScreenState extends State<PrinterScreen>
 
   void _initControllerIfNeeded() {
     if (_webController != null) return;
-    _webController = WebViewController()
+    _webController = createWebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setNavigationDelegate(_navDelegate());
   }

--- a/mobile/lib/services/printer_status_service.dart
+++ b/mobile/lib/services/printer_status_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as dev;
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -962,6 +963,27 @@ class PrinterStatusService {
     return null;
   }
 
+  /// go2rtc rewrite: a go2rtc camera configured in Mainsail (or pasted as a
+  /// custom URL) points at the PLAYER PAGE - `.../stream.html?src=NAME` with
+  /// an optional `mode=` - which is HTML, so the snapshot loop can never
+  /// render a frame from it. go2rtc serves a single JPEG of the same source
+  /// at `.../api/frame.jpeg?src=NAME`, so rewrite to that. Path handled
+  /// segment-wise so a reverse-proxy subpath (e.g. `/go2rtc/stream.html`)
+  /// survives. Anything that isn't a go2rtc player URL returns null.
+  @visibleForTesting
+  static String? go2rtcFrameUrl(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) return null;
+    final segs = uri.pathSegments;
+    if (segs.isEmpty || segs.last.toLowerCase() != 'stream.html') return null;
+    final src = uri.queryParameters['src'];
+    if (src == null || src.isEmpty) return null;
+    return uri.replace(
+      pathSegments:    [...segs.sublist(0, segs.length - 1), 'api', 'frame.jpeg'],
+      queryParameters: {'src': src},
+    ).toString();
+  }
+
   // ── Shared status parser (unchanged from v0.2.x logic) ───────────────────
 
   PrinterStatus _parseStatus({
@@ -1083,13 +1105,20 @@ class PrinterStatusService {
     final customUrl    = _liveCustomCameraUrl?.trim();
     final autoSnapshot = (moongateResult?['webcam_snapshot_external'] as String?)?.trim();
     final autoStream   = (moongateResult?['webcam_stream_external']   as String?)?.trim();
-    final externalUrl = (customUrl != null && customUrl.isNotEmpty)
+    var externalUrl = (customUrl != null && customUrl.isNotEmpty)
         ? customUrl
         : (autoSnapshot != null && autoSnapshot.isNotEmpty)
             ? autoSnapshot
             : (autoStream != null && autoStream.isNotEmpty)
                 ? autoStream
                 : null;
+
+    // A go2rtc player-page URL (from Mainsail's webcam config or pasted as a
+    // custom URL) is HTML, not an image - swap it for go2rtc's single-frame
+    // endpoint so the tile and the full-screen camera actually get frames.
+    if (externalUrl != null) {
+      externalUrl = go2rtcFrameUrl(externalUrl) ?? externalUrl;
+    }
 
     bool webcamIsExternal = false;
     if (externalUrl != null && externalUrl.isNotEmpty) {

--- a/mobile/lib/services/printer_webview_cache.dart
+++ b/mobile/lib/services/printer_webview_cache.dart
@@ -4,11 +4,38 @@ import 'dart:developer' as dev;
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 
 import '../models/printer_config.dart';
 import 'lan_discovery_service.dart';
 import 'printer_access_cache.dart';
 import 'supabase_service.dart';
+
+/// Build a [WebViewController] with media autoplay enabled - the one factory
+/// behind both the printer screen and the prewarm below, so every Mainsail/
+/// Fluidd WebView behaves the same. Mainsail renders a go2rtc / WebRTC webcam
+/// as a muted autoplaying <video> element; Android's WebView blocks ANY
+/// scripted playback without a user gesture by default and iOS additionally
+/// forces fullscreen-only playback, so those webcam cards sat black in the
+/// app while working fine in a desktop browser.
+WebViewController createWebViewController() {
+  late final PlatformWebViewControllerCreationParams params;
+  if (WebViewPlatform.instance is WebKitWebViewPlatform) {
+    params = WebKitWebViewControllerCreationParams(
+      allowsInlineMediaPlayback:     true,
+      mediaTypesRequiringUserAction: const <PlaybackMediaTypes>{},
+    );
+  } else {
+    params = const PlatformWebViewControllerCreationParams();
+  }
+  final controller = WebViewController.fromPlatformCreationParams(params);
+  final platform = controller.platform;
+  if (platform is AndroidWebViewController) {
+    platform.setMediaPlaybackRequiresUserGesture(false);
+  }
+  return controller;
+}
 
 /// One warm Mainsail/Fluidd WebView, kept alive between visits to the dashboard
 /// so re-opening a printer is instant. Holds the loaded SPA and its live
@@ -157,7 +184,7 @@ class PrinterWebViewCache with WidgetsBindingObserver {
       // also makes prewarm self-validating: if a headless WebView can't load on
       // this device, the wait times out, nothing is stored, and opening falls
       // back to the normal cold load - no regression.
-      final controller = WebViewController()
+      final controller = createWebViewController()
         ..setJavaScriptMode(JavaScriptMode.unrestricted);
       final loaded = Completer<bool>();
       controller.setNavigationDelegate(NavigationDelegate(

--- a/mobile/lib/widgets/webcam_view.dart
+++ b/mobile/lib/widgets/webcam_view.dart
@@ -164,7 +164,7 @@ class _WebcamViewState extends ConsumerState<WebcamView>
       final resp =
           await http.get(Uri.parse(url)).timeout(const Duration(seconds: 8));
       if (!mounted) return;
-      if (resp.statusCode == 200 && resp.bodyBytes.isNotEmpty) {
+      if (resp.statusCode == 200 && _looksLikeImage(resp.bodyBytes)) {
         setState(() => _currentBytes = resp.bodyBytes);
       }
     } catch (_) {
@@ -203,7 +203,7 @@ class _WebcamViewState extends ConsumerState<WebcamView>
       // frame): use whatever bytes we collected if they look usable.
       if (!isMultipart) {
         final bytes = buffer.toBytes();
-        if (bytes.isNotEmpty && mounted) {
+        if (_looksLikeImage(bytes) && mounted) {
           setState(() => _currentBytes = bytes);
         }
       }
@@ -212,6 +212,26 @@ class _WebcamViewState extends ConsumerState<WebcamView>
     } finally {
       client.close(); // aborts an MJPEG stream still in flight
     }
+  }
+
+  /// True when [d] starts like an image the engine can decode (JPEG, PNG,
+  /// GIF, WebP, BMP). A camera URL that answers 200 with something else -
+  /// typically a go2rtc / WebRTC player PAGE, which is HTML - must never be
+  /// stored: Image.memory can't decode it, so it would replace the
+  /// placeholder (or the last good frame) with a broken-image error box.
+  static bool _looksLikeImage(Uint8List d) {
+    if (d.length < 12) return false;
+    if (d[0] == 0xFF && d[1] == 0xD8) return true;                    // JPEG
+    if (d[0] == 0x89 && d[1] == 0x50 && d[2] == 0x4E && d[3] == 0x47) {
+      return true;                                                    // PNG
+    }
+    if (d[0] == 0x47 && d[1] == 0x49 && d[2] == 0x46) return true;    // GIF
+    if (d[0] == 0x52 && d[1] == 0x49 && d[2] == 0x46 && d[3] == 0x46 &&
+        d[8] == 0x57 && d[9] == 0x45 && d[10] == 0x42 && d[11] == 0x50) {
+      return true;                                                    // WebP
+    }
+    if (d[0] == 0x42 && d[1] == 0x4D) return true;                    // BMP
+    return false;
   }
 
   /// Find the first complete JPEG (SOI ff d8 … EOI ff d9) in [d], or null if

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1227,7 +1227,7 @@ packages:
     source: hosted
     version: "4.14.1"
   webview_flutter_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_android
       sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
@@ -1243,7 +1243,7 @@ packages:
     source: hosted
     version: "2.15.1"
   webview_flutter_wkwebview:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
       sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -47,8 +47,14 @@ dependencies:
   flutter_riverpod: ^2.5.0
   go_router: ^13.0.0
 
-  # WebView (full Mainsail/Fluidd UI per printer)
+  # WebView (full Mainsail/Fluidd UI per printer). The two platform packages
+  # are direct dependencies (same versions the lock already resolves) so the
+  # controller factory can relax each platform's media-autoplay default -
+  # go2rtc/WebRTC webcams render as muted autoplaying <video> elements that
+  # both platforms otherwise block.
   webview_flutter: ^4.14.1
+  webview_flutter_android: ^4.12.0
+  webview_flutter_wkwebview: ^3.25.1
 
   # Persistent settings
   shared_preferences: ^2.2.0

--- a/mobile/test/go2rtc_url_test.dart
+++ b/mobile/test/go2rtc_url_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moongate/services/printer_status_service.dart';
+
+void main() {
+  group('PrinterStatusService.go2rtcFrameUrl', () {
+    test('rewrites a go2rtc player page to the frame endpoint', () {
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'https://cameratrident.domain.xyz/stream.html?src=chamber&mode=webrtc'),
+        'https://cameratrident.domain.xyz/api/frame.jpeg?src=chamber',
+      );
+    });
+
+    test('survives a reverse-proxy subpath', () {
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://192.168.1.50/go2rtc/stream.html?src=cam1'),
+        'http://192.168.1.50/go2rtc/api/frame.jpeg?src=cam1',
+      );
+    });
+
+    test('keeps an explicit port', () {
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://192.168.1.50:1984/stream.html?src=cam1&mode=mse'),
+        'http://192.168.1.50:1984/api/frame.jpeg?src=cam1',
+      );
+    });
+
+    test('is case-insensitive on the page name', () {
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://cam.local:1984/Stream.HTML?src=x'),
+        'http://cam.local:1984/api/frame.jpeg?src=x',
+      );
+    });
+
+    test('leaves non-go2rtc URLs alone', () {
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://192.168.0.107:8080/video'),
+        isNull,
+      );
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://192.168.1.20/webcam/?action=stream'),
+        isNull,
+      );
+    });
+
+    test('requires a src parameter', () {
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://cam.local:1984/stream.html'),
+        isNull,
+      );
+      expect(
+        PrinterStatusService.go2rtcFrameUrl(
+            'http://cam.local:1984/stream.html?src='),
+        isNull,
+      );
+    });
+
+    test('rejects garbage and relative input', () {
+      expect(PrinterStatusService.go2rtcFrameUrl('stream.html?src=x'), isNull);
+      expect(PrinterStatusService.go2rtcFrameUrl(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
# What will this PR change?

go2rtc webcams stop being black in the app. A user running go2rtc (instead of Crowsnest) has his camera configured in Mainsail as a player-page URL like `https://host/stream.html?src=chamber&mode=webrtc`, and today that shows nothing anywhere in Moongate: not on the dashboard tile, not in the full-screen camera, and not even inside the embedded Mainsail page, while the same camera works fine in a desktop browser.

In plain English: the app's camera views only understand pictures (snapshots and MJPEG), but go2rtc hands out a web page containing a video player. And even the app's built-in Mainsail browser was silently forbidding that player from starting, because mobile WebViews block auto-playing video by default. This PR teaches the app to ask go2rtc for plain pictures where pictures are needed, and lets the video player actually play where the real Mainsail page is shown.

# The three stacked failures and their fixes

1. **Dashboard tile + full-screen camera fetched HTML.** The snapshot loop pulled the `stream.html` page and handed the bytes to the image decoder. Fix: the status service recognises a go2rtc player URL (whether auto-detected from Mainsail's webcam config or pasted as a custom tile URL) and rewrites it to go2rtc's single-frame endpoint, `.../api/frame.jpeg?src=NAME`, which the existing snapshot loop renders like any other camera. Reverse-proxy subpaths (`/go2rtc/stream.html`) and explicit ports survive the rewrite. Unit-tested (7 cases).

2. **Embedded Mainsail blocked the WebRTC player.** Mainsail's go2rtc card is a muted auto-playing `<video>` element. Android WebView refuses any scripted playback without a user gesture by default, and iOS additionally forces fullscreen-only playback, so the card stayed black. Fix: a shared `createWebViewController()` factory (used by both the printer screen and the prewarm cache) relaxes both: `setMediaPlaybackRequiresUserGesture(false)` on Android, `allowsInlineMediaPlayback` + empty `mediaTypesRequiringUserAction` on iOS. Both platforms covered, same codebase.

3. **Broken-image hardening.** Any camera URL that answers 200 with something undecodable used to replace the placeholder (or the last good frame) with a broken-image error box. WebcamView now sniffs magic bytes (JPEG/PNG/GIF/WebP/BMP) before storing a body, so bad responses degrade to the placeholder instead.

# Dependency note

`webview_flutter_android` and `webview_flutter_wkwebview` become direct dependencies, pinned to the exact versions the lock file already resolved (4.12.0 / 3.25.1). No native version changes, so no AGP/Gradle risk.

# Known limitation (by design)

A camera on a public hostname can't ride the cloud tunnel remotely: the Pi's `/mg-extcam` proxy deliberately forwards only to literal private IPv4 addresses (SSRF guard). On home WiFi, in Direct (LAN/VPN) mode, and over the user's own VPN it all works, which is where go2rtc setups live anyway.

# Testing

- `flutter analyze` clean; full test suite passes (18 tests, 7 new).
- Owed before merge: on-device pass. The reporting user's setup is the real test; our own printers run Crowsnest, so at minimum verify no regression on a normal camera tile plus the embedded Mainsail page, and ask the reporter to confirm on the release.

App-only, no plugin change, no version bump (rides the next release PR as usual).

PEEKYPAUL 15/07/2026
