### PR TITLE
docs: installer connection-mode chooser sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,7 +152,7 @@ LAN traffic doesn't go through the proxy - nginx still listens on the LAN interf
 
 `cloudflared` Quick Tunnel runs as `moongate-tunnel.service`. It makes an outbound connection to the Cloudflare edge - no inbound ports opened on your router. The URL rotates each time the Pi reboots; the Moongate plugin heartbeats the current one to the cloud middleman so the app always knows where to reach the Pi.
 
-On a **LAN-only install** (`install.sh --lan-only`, v0.9.51) neither the tunnel nor the auth proxy exists: the installer skips cloudflared entirely (including its architecture check), never creates the two systemd units, skips the clock check and its htpdate timer, and leaves Moonraker bound to the LAN. Run on a box that already has the tunnel stack, the same flag **retires** it - units disabled, the stale tunnel-URL logs removed so the plugin can't heartbeat a dead URL.
+On a **LAN-only install** (answer **2) Direct (LAN/VPN)** at the installer's connection-mode question, or `install.sh --lan-only`; v0.9.51) neither the tunnel nor the auth proxy exists: the installer skips cloudflared entirely (including its architecture check), never creates the two systemd units, skips the clock check and its htpdate timer, and leaves Moonraker bound to the LAN. Run on a box that already has the tunnel stack, the same choice **retires** it - units disabled, the stale tunnel-URL logs removed so the plugin can't heartbeat a dead URL. The question only appears on interactive runs and defaults to the box's current mode; headless runs and explicit `MOONGATE_LAN_ONLY=` values never prompt.
 
 ### Where state lives on the Pi
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,14 +183,14 @@ cd Moongate/klipper-plugin
 ./install.sh
 ```
 
-To develop against the cloud-free path (v0.9.51's Direct mode), install the box in **LAN-only mode** instead - no cloudflared, no auth proxy, no clock check, and the plugin's `lan_only` config flag set so `/status` + `/control` are token-free on the LAN:
+To develop against the cloud-free path (v0.9.51's Direct mode), install the box in **LAN-only mode** instead - no cloudflared, no auth proxy, no clock check, and the plugin's `lan_only` config flag set so `/status` + `/control` are token-free on the LAN. Run interactively with no flag, the installer asks which mode you want (the default keeps an already-installed box's current mode, so an idle Enter never converts anything); to preselect and skip the question:
 
 ```bash
 ./install.sh --lan-only          # or: MOONGATE_LAN_ONLY=1 ./install.sh
-./install.sh                     # re-run without the flag to convert back to tunnel mode
+MOONGATE_LAN_ONLY=0 ./install.sh # preselect cloud - converts a LAN-only box back to tunnel mode
 ```
 
-Converging an existing tunnel-mode box with `--lan-only` also retires the running tunnel + proxy units and clears the stale tunnel-URL logs.
+Converging an existing tunnel-mode box to LAN-only also retires the running tunnel + proxy units and clears the stale tunnel-URL logs.
 
 Iteration loop:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ SSH into your Pi and run:
 curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/install.sh | bash
 ```
 
-This installs the plugin, the `MOONGATE_PAIR` macro, the QR pairing page, the auth proxy, and the Cloudflare tunnel, then restarts Moonraker. Future updates appear in **Mainsail → Software Updates → Moongate**.
+The installer asks how your phone will connect: **1) Moongate cloud** (the default - remote access from anywhere) or **2) Direct (LAN/VPN)** (cloud-free; [see how the two compare](#run-it-your-way)). With the default it installs the plugin, the `MOONGATE_PAIR` macro, the QR pairing page, the auth proxy, and the Cloudflare tunnel, then restarts Moonraker. Future updates appear in **Mainsail → Software Updates → Moongate**.
 
 <details>
 <summary><b>Requirements &amp; custom HTTP port</b></summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -182,7 +182,7 @@ If you don't want Cloudflare in the picture, point the cloudflared step at any o
 
 ## Direct (LAN/VPN) mode (v0.9.51)
 
-An opt-in, per-printer alternative to everything above: a Pi installed with `install.sh --lan-only` runs **no tunnel, no auth proxy, and makes zero outbound calls** - and the app, in its **Direct (LAN/VPN)** mode, talks straight to Moonraker on the LAN (or across your own WireGuard / Tailscale VPN) with **no cloud account and no tokens**.
+An opt-in, per-printer alternative to everything above: a Pi installed in LAN-only mode (the installer's **Direct (LAN/VPN)** answer, or `install.sh --lan-only`) runs **no tunnel, no auth proxy, and makes zero outbound calls** - and the app, in its **Direct (LAN/VPN)** mode, talks straight to Moonraker on the LAN (or across your own WireGuard / Tailscale VPN) with **no cloud account and no tokens**.
 
 What that changes, stated plainly:
 
@@ -190,7 +190,7 @@ What that changes, stated plainly:
 - **Remote access is your VPN's perimeter.** There is no tunnel to leak and no token to steal; if your WireGuard/Tailscale subnet is in `trusted_clients`, VPN membership is the credential. Choose that subnet deliberately (Tailscale uses `100.64.0.0/10`).
 - **Nothing is stored in the cloud.** A Direct-added printer has no cloud row, sends no heartbeats, and mints no tokens - the middleman never learns it exists.
 - **The tunnel path is unaffected.** The token bypass applies only when the plugin itself runs `lan_only`. On a half-converged box (flag set but the tunnel stack somehow still running) the auth proxy still does its own independent token verification, so the internet-facing promise above - flat 401s without a valid broker-signed token - holds regardless of the plugin's mode.
-- **Switching modes is explicit.** A cloud-paired printer flipped to Direct in the app simply stops using its cloud identity (and can flip back); converting a box's *install* between modes is a deliberate re-run of the installer with or without `--lan-only`.
+- **Switching modes is explicit.** A cloud-paired printer flipped to Direct in the app simply stops using its cloud identity (and can flip back); converting a box's *install* between modes is a deliberate re-run of the installer, answering the mode question the other way (or forcing it with `--lan-only` / `MOONGATE_LAN_ONLY=`). The interactive default always keeps the box's current mode, so a repair re-run can't silently stand up a tunnel on a LAN-only box.
 
 ## What the plugin can see and do
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -153,11 +153,11 @@ A printer added through **Add Printer → Direct (LAN/VPN)** (v0.9.51+) has exac
        192.168.1.0/24
        100.64.0.0/10   # Tailscale
    ```
-3. **The Pi isn't actually in LAN-only mode.** Direct mode needs the plugin installed with `--lan-only` (see the README's LAN-only install section). Against a normal cloud-mode install the plugin still demands a token and answers `401`, so the tile sits offline. Check from any PC on the LAN:
+3. **The Pi isn't actually in LAN-only mode.** Direct mode needs the plugin installed in LAN-only mode - answer **2) Direct (LAN/VPN)** when the installer asks, or pass `--lan-only` (see the README's LAN-only install section). Against a normal cloud-mode install the plugin still demands a token and answers `401`, so the tile sits offline. Check from any PC on the LAN:
    ```bash
    curl -s -o /dev/null -w "%{http_code}\n" "http://<pi-ip>/server/moongate/status?mg_token="
    ```
-   `200` = LAN-only mode; `401` = cloud mode (re-run the installer with `--lan-only`, or pair the printer through the cloud instead).
+   `200` = LAN-only mode; `401` = cloud mode (re-run the installer and pick **Direct (LAN/VPN)**, or pair the printer through the cloud instead).
 4. **The Pi's address changed** (DHCP handed it a new IP). The app stores the address a Direct printer was added with - fix it in the printer's edit dialog (the pencil on its page), and give the Pi a **DHCP reservation / static IP** so it stops moving.
 
 Also by design: Direct printers have **no print notifications** (there's no cloud to send them), so a quiet notification shade for one isn't a fault.

--- a/docs/managing-moongate.md
+++ b/docs/managing-moongate.md
@@ -26,6 +26,8 @@ Prefer the command line? SSH in and re-run the installer - it pulls the latest a
 curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/install.sh | bash
 ```
 
+> The installer asks how your phone connects (cloud or Direct LAN/VPN). On a re-run the default is the mode the box already uses, so just pressing Enter updates without changing anything.
+
 > Some releases note **"re-run the Pi installer"** in the changelog - that means a plugin-side change shipped (e.g. v0.5.1's instant-pairing QR). Update the plugin to get it.
 
 ---


### PR DESCRIPTION
# What will this PR change?

Documentation only. Now that the installer asks "How will your phone connect?" (#212, live on master), every doc that still described the flag-only install is updated to lead with the question, with the flags kept as the script/preselect path:

- **README** - Quick start step 1 mentions the question right after the one-liner, linking the mode comparison.
- **ARCHITECTURE** - the LAN-only paragraph: chooser first, plus when the question does and doesn't appear (interactive only, defaults to the box's current mode, explicit env values never prompt).
- **DEVELOPMENT** - the dev-install snippet: interactive default explained, `MOONGATE_LAN_ONLY=0` preselect added.
- **TROUBLESHOOTING** - the "Pi isn't actually in LAN-only mode" fix now says answer Direct at the prompt (or `--lan-only`).
- **SECURITY** - Direct-mode section: install choice wording, and the keeps-current-mode default documented as a deliberate property (a repair re-run can't silently stand up a tunnel on a LAN-only box).
- **managing-moongate** - the re-run-to-update note reassures that Enter keeps the current mode.

No code changes. Merge with `[skip ci]` to skip the same-version release re-run.

PEEKYPAUL 15/07/2026
