### PR TITLE
Plugin 0.6.17: dependency-free LAN-only mode for embedded hosts (3rd-party printer support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Moongate gives every printer a choice of two connections - and you can mix them 
 
 Switch an existing printer between modes anytime from its edit dialog - no re-pairing. If you later want a Direct printer on the cloud, re-run the installer normally and pair it; the app absorbs the old tile automatically. Networking notes for Direct mode (Moonraker's `trusted_clients`, give the Pi a fixed address) are in the [LAN-only install section](#quick-start) above.
 
+Direct mode isn't picky about the host, either: from plugin 0.6.17 it needs **zero extra Python packages**, so machines that were never a Raspberry Pi - embedded boards, vendor printers on community firmware - can join the dashboard with a one-file install. See [3rd-party printer support](docs/third-party-printers.md).
+
 ---
 
 ## How it works
@@ -202,6 +204,7 @@ Switch an existing printer between modes anytime from its edit dialog - no re-pa
 | Document | What's inside |
 |---|---|
 | [Updating &amp; removing](docs/managing-moongate.md) | Updating the app &amp; plugin, reinstalling / moving to a new phone, full uninstall |
+| [3rd-party printer support](docs/third-party-printers.md) | Direct (LAN/VPN) mode on non-Pi hosts - the one-file install, supported machines, VPN notes |
 | [DEVELOPMENT.md](DEVELOPMENT.md) | Building from source, repo layout, debugging, release signing, CI |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Code structure, state management, data-flow walkthroughs, design decisions |
 | [SECURITY.md](SECURITY.md) | Threat model, what the tunnel does and doesn't expose, the empirical verification, vulnerability reporting |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-p
 
 The installer asks how your phone will connect: **1) Moongate cloud** (the default - remote access from anywhere) or **2) Direct (LAN/VPN)** (cloud-free; [see how the two compare](#run-it-your-way)). With the default it installs the plugin, the `MOONGATE_PAIR` macro, the QR pairing page, the auth proxy, and the Cloudflare tunnel, then restarts Moonraker. Future updates appear in **Mainsail → Software Updates → Moongate**.
 
+> **Using a 3rd-party printer instead?** (e.g. an Elegoo Centauri Carbon on OpenCentauri COSMOS) - this installer targets Raspberry-Pi-style machines and won't run on embedded vendor firmware. Follow [3rd-party printer support](docs/third-party-printers.md) instead: a one-file install, no installer needed.
+
 <details>
 <summary><b>Requirements &amp; custom HTTP port</b></summary>
 

--- a/docs/third-party-printers.md
+++ b/docs/third-party-printers.md
@@ -1,0 +1,121 @@
+# 3rd-party printer support
+
+Moongate's normal installer targets Raspberry-Pi-style hosts (MainsailOS,
+FluiddPI: bash, systemd, sudo, pip, git). Plenty of interesting machines run a
+real Moonraker without any of that - vendor printers with community firmware,
+appliance-style embedded builds - and from **plugin 0.6.17** Moongate's
+**Direct (LAN/VPN) mode** runs on them too, with zero extra Python
+dependencies and no installer: **copy one file, add one config section,
+restart Moonraker.**
+
+Cloud mode (tunnel, notifications) is out of scope on these machines - they
+rarely have the RAM or the packages for it. Direct mode covers home use out of
+the box, and remote use through your own VPN (see
+[Remote access](#remote-access-vpn) below).
+
+## Supported machines
+
+| Machine | Firmware | Status |
+|---|---|---|
+| Elegoo Centauri Carbon | [OpenCentauri COSMOS](https://github.com/OpenCentauri/cosmos) | 🧪 in validation with a community tester |
+
+Running Moongate on a machine that isn't listed? The
+[generic recipe](#the-generic-recipe) below works on anything with a real
+Moonraker. Please [open an issue](https://github.com/PEEKYPAUL/Moongate/issues)
+with your results either way - working reports are how machines get added to
+this table.
+
+## What the machine needs
+
+- A genuine [Moonraker](https://github.com/Arksine/moonraker) (0.9+) you can
+  drop a component file into - Moonraker forks with the components system
+  stripped out won't work
+- Python 3.9+ (Moonraker's own requirement; no extra packages needed)
+- A writable directory for Moongate's state (a few KB)
+- Moonraker's `[authorization] trusted_clients` covering your phone's network
+  - vendor images usually ship this for all private ranges
+- The app talks to the same host and port Moonraker serves on, so no extra
+  ports, proxies, or firewall holes
+
+## The generic recipe
+
+1. Copy `klipper-plugin/moongate_standalone.py` from this repo into
+   Moonraker's components directory as `moongate.py`.
+2. Add to `moonraker.conf`:
+
+   ```ini
+   [moongate]
+   lan_only: true
+   data_path: /path/to/somewhere/writable
+   ```
+
+   `data_path` holds Moongate's state (defaults to `~/.config/moongate`,
+   which embedded systems often can't write). A third option,
+   `moonraker_port`, exists for the rare setup where Moonraker's port can't
+   be auto-detected.
+3. Restart Moonraker.
+4. Confirm it loaded: `moonraker.log` shows
+   `Moongate LAN-only mode: cloud loops disabled (no tunnel, no Supabase).`
+5. In the app: **Add Printer → Direct (LAN/VPN)**, enter a name and the
+   printer's address (e.g. `http://192.168.1.50`, add `:port` if Moonraker
+   isn't on port 80 there). Give the printer a fixed address on your router -
+   the app stores it.
+
+## Elegoo Centauri Carbon (OpenCentauri COSMOS)
+
+COSMOS ships a real Moonraker on port 80 with `trusted_clients` preconfigured
+for all private networks, which is exactly what Direct mode expects. The OS is
+BusyBox-based (no bash, git, pip, or systemd) - which is fine, nothing below
+needs them. SSH in as root, then:
+
+```sh
+# 1. The plugin file. If wget lacks TLS on your build, scp it from a computer
+#    instead:  scp moongate_standalone.py root@<printer-ip>:/usr/share/moonraker/moonraker/components/moongate.py
+wget -O /usr/share/moonraker/moonraker/components/moongate.py \
+  https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/moongate_standalone.py
+
+# 2. State dir on the writable /etc overlay
+mkdir -p /etc/moongate
+
+# 3. Config - append to the WRITABLE conf (not the moonraker-readonly one)
+printf '\n[moongate]\nlan_only: true\ndata_path: /etc/moongate\n' \
+  >> /etc/klipper/config/moonraker.conf
+
+# 4. Restart
+/etc/init.d/moonraker restart
+```
+
+Then add the printer in the app as above (plain `http://<printer-ip>`, no
+port suffix - COSMOS serves Moonraker on 80).
+
+Known caveats on COSMOS:
+
+- If step 1 fails with a read-only filesystem error, remount first
+  (`mount -o remount,rw /`) and re-run it.
+- A COSMOS firmware update replaces the Moonraker directory, taking
+  `moongate.py` with it - re-run step 1 (and 4) after updating. Your config
+  and state on `/etc` survive.
+- COSMOS is beta firmware on a very RAM-limited board, and its authors warn
+  against piling on plugins. LAN-only Moongate is about as light as they come
+  (no tunnel, no timers, no outbound calls), but temper expectations
+  accordingly.
+
+## Remote access (VPN)
+
+Direct mode away from home rides your own VPN, and the easy path is a
+**subnet router** (Tailscale or WireGuard on any always-on box at home,
+advertising your LAN). Your phone's traffic then arrives at the printer
+looking like home-LAN traffic, which the stock `trusted_clients` ranges
+already cover - no printer-side changes at all.
+
+If instead you address the printer by a Tailscale IP directly, that traffic
+comes from `100.64.0.0/10`, which stock configs do **not** trust - add that
+range to `trusted_clients` in the writable moonraker.conf.
+
+## What you give up vs a Pi install
+
+- **No print notifications** - they're a cloud feature, and this is the
+  cloud-free mode.
+- **No update badge / one-tap update** - these machines have no Moonraker
+  update_manager. Updating Moongate = re-copying the file.
+- **No mDNS discovery** - the app uses the fixed address you gave it.

--- a/docs/third-party-printers.md
+++ b/docs/third-party-printers.md
@@ -17,7 +17,7 @@ the box, and remote use through your own VPN (see
 
 | Machine | Firmware | Status |
 |---|---|---|
-| Elegoo Centauri Carbon | [OpenCentauri COSMOS](https://github.com/OpenCentauri/cosmos) | 🧪 in validation with a community tester |
+| Elegoo Centauri Carbon | [OpenCentauri COSMOS](https://github.com/OpenCentauri/cosmos) | ✅ community-validated (2026-07-18) |
 
 Running Moongate on a machine that isn't listed? The
 [generic recipe](#the-generic-recipe) below works on anything with a real
@@ -40,7 +40,11 @@ this table.
 ## The generic recipe
 
 1. Copy `klipper-plugin/moongate_standalone.py` from this repo into
-   Moonraker's components directory as `moongate.py`.
+   Moonraker's components directory as `moongate.py`. (Download to `/tmp`
+   first and check the file is real before moving it, silent download
+   failures are the top trap. If the copy then fails with a read-only
+   filesystem, your machine seals its root, use the bind-mount pattern
+   from the COSMOS section below.)
 2. Add to `moonraker.conf`:
 
    ```ini
@@ -63,41 +67,95 @@ this table.
 
 ## Elegoo Centauri Carbon (OpenCentauri COSMOS)
 
-COSMOS ships a real Moonraker on port 80 with `trusted_clients` preconfigured
-for all private networks, which is exactly what Direct mode expects. The OS is
-BusyBox-based (no bash, git, pip, or systemd) - which is fine, nothing below
-needs them. SSH in as root, then:
+Community-validated on a real Centauri Carbon (2026-07-18). COSMOS ships a
+genuine Moonraker on port 80 with `trusted_clients` preconfigured, so the
+app side just works. The OS is BusyBox-based (no bash, git, pip, or
+systemd), which is fine, nothing below needs them. The twist is the disk:
+the root filesystem, including Moonraker's components folder, is **sealed
+squashfs** (not even remountable). Only `/etc` persists, as an overlay
+backed by the `/data` partition. So the plugin lives on `/etc`, and a small
+boot script bind-mounts a copy of the components folder, carrying
+`moongate.py`, over the sealed original before Moonraker starts.
+
+Measured on a real board: the plugin rides inside Moonraker's existing
+process, and the printer idled around 80 MB used of its 112 MB with
+Moongate loaded. That headroom is also why cloud/tunnel mode is not
+offered on this machine.
+
+SSH in as root, then:
 
 ```sh
-# 1. The plugin file. If wget lacks TLS on your build, scp it from a computer
-#    instead:  scp moongate_standalone.py root@<printer-ip>:/usr/share/moonraker/moonraker/components/moongate.py
-wget -O /usr/share/moonraker/moonraker/components/moongate.py \
-  https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/moongate_standalone.py
-
-# 2. State dir on the writable /etc overlay
+# 1. Master copy of the plugin (on /etc = survives reboots AND updates).
+#    COSMOS's wget skips TLS validation but downloads fine; alternatively
+#    scp the file from a computer to /etc/moongate/moongate.py
 mkdir -p /etc/moongate
+wget -O /etc/moongate/moongate.py \
+  https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-plugin/moongate_standalone.py
+grep -m1 'MOONGATE_PLUGIN_VERSION = ' /etc/moongate/moongate.py  # sanity check: prints the version
 
-# 3. Config - append to the WRITABLE conf (not the moonraker-readonly one)
+# 2. Config - append to the WRITABLE conf (not the moonraker-readonly one)
 printf '\n[moongate]\nlan_only: true\ndata_path: /etc/moongate\n' \
   >> /etc/klipper/config/moonraker.conf
 
-# 4. Restart
+# 3. Boot script: rebuilds the components copy and bind-mounts it over the
+#    sealed folder on every boot, just before Moonraker starts (S95 < S96)
+cat > /etc/init.d/moongate-overlay << 'EOF'
+#!/bin/sh
+# Moongate on COSMOS: root is sealed squashfs, so Moonraker's components
+# folder can't take the plugin directly. Rebuild a writable copy on /etc
+# from the sealed originals plus moongate.py, and bind-mount it over the
+# top. Rebuilding EVERY boot means a firmware update's own new components
+# are never masked by a stale copy.
+SEALED=/usr/share/moonraker/moonraker/components
+COPY=/etc/moongate-components
+MASTER=/etc/moongate/moongate.py
+case "${1:-start}" in
+  start)
+    [ -f "$MASTER" ] || exit 0
+    mount | grep -q " on $SEALED type " && exit 0
+    rm -rf "$COPY"
+    mkdir -p "$COPY"
+    cp -a "$SEALED"/. "$COPY"/
+    cp "$MASTER" "$COPY/moongate.py"
+    mount -o bind "$COPY" "$SEALED"
+    ;;
+  stop)
+    umount "$SEALED" 2>/dev/null || true
+    ;;
+  restart)
+    "$0" stop
+    "$0" start
+    ;;
+esac
+exit 0
+EOF
+chmod +x /etc/init.d/moongate-overlay
+for d in /etc/rc2.d /etc/rc3.d /etc/rc4.d /etc/rc5.d; do
+  [ -d "$d" ] && ln -sf ../init.d/moongate-overlay "$d/S95moongate-overlay"
+done
+
+# 4. Activate now
+/etc/init.d/moongate-overlay start
 /etc/init.d/moonraker restart
 ```
 
-Then add the printer in the app as above (plain `http://<printer-ip>`, no
-port suffix - COSMOS serves Moonraker on 80).
+Then add the printer in the app: **Add Printer → Direct (LAN/VPN)**, plain
+`http://<printer-ip>` (COSMOS serves Moonraker on port 80).
 
-Known caveats on COSMOS:
+Verify: the log lives at `/board-resource/moonraker.log` and shows
+`Moongate LAN-only mode: cloud loops disabled` on a good start, and from a
+browser on your LAN `http://<printer-ip>/server/moongate/status` returns a
+wall of JSON including the plugin version.
 
-- If step 1 fails with a read-only filesystem error, remount first
-  (`mount -o remount,rw /`) and re-run it.
-- A COSMOS firmware update replaces the Moonraker directory, taking
-  `moongate.py` with it - re-run step 1 (and 4) after updating. Your config
-  and state on `/etc` survive.
+- **Updating the plugin later:** re-run step 1's `wget`, then
+  `/etc/init.d/moongate-overlay restart` and `/etc/init.d/moonraker restart`.
+- **COSMOS firmware updates:** handled automatically, the boot script
+  rebuilds its copy from the new firmware's own components on the next
+  boot. If an update ever moves Moonraker's install dir, re-check the
+  `SEALED` path in the script.
 - COSMOS is beta firmware on a very RAM-limited board, and its authors warn
-  against piling on plugins. LAN-only Moongate is about as light as they come
-  (no tunnel, no timers, no outbound calls), but temper expectations
+  against piling on plugins. LAN-only Moongate is about as light as they
+  come (no tunnel, no timers, no outbound calls), but temper expectations
   accordingly.
 
 ## Remote access (VPN)

--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -111,8 +111,8 @@ MOONRAKER_CONF="$PRINTER_DATA/config/moonraker.conf"
 COMPONENTS_DIR="$MOONRAKER_DIR/moonraker/components"
 KLIPPER_CFG_DIR="$PRINTER_DATA/config"
 
-[[ -d "$MOONRAKER_DIR" ]]  || die "Moonraker not found at $MOONRAKER_DIR. Set MOONRAKER_DIR= if installed elsewhere."
-[[ -f "$MOONRAKER_CONF" ]] || die "moonraker.conf not found at $MOONRAKER_CONF."
+[[ -d "$MOONRAKER_DIR" ]]  || die "Moonraker not found at $MOONRAKER_DIR. Set MOONRAKER_DIR= if installed elsewhere. On a vendor/embedded printer (e.g. OpenCentauri)? This installer targets Pi-style hosts - follow docs/third-party-printers.md instead."
+[[ -f "$MOONRAKER_CONF" ]] || die "moonraker.conf not found at $MOONRAKER_CONF. On a vendor/embedded printer (e.g. OpenCentauri)? This installer targets Pi-style hosts - follow docs/third-party-printers.md instead."
 
 # ── Clock sanity check ────────────────────────────────────────────────────────
 # Moongate's remote access is cryptographically time-bound: the Pi signs every

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -1740,8 +1740,11 @@ class MoongatePlugin:
 
         client = AsyncHTTPClient()
         if not self._chamber_key_checked:
-            await self._discover_objects(client)
-            self._chamber_key_checked = True
+            # Only mark done on success: a poll during Moonraker's own boot
+            # (Klippy routes not registered yet) must not burn the one-shot
+            # scan, or a mid-boot poller loses chamber + multi-toolhead
+            # detection until the next Moonraker restart.
+            self._chamber_key_checked = await self._discover_objects(client)
 
         query = "print_stats&heater_bed&extruder"
         if self._chamber_key:
@@ -1768,7 +1771,14 @@ class MoongatePlugin:
         if resp.code != 200:
             raise self.server.error(f"Moonraker query returned HTTP {resp.code}", 502)
 
-        data   = json.loads(resp.body)
+        try:
+            data = json.loads(resp.body)
+        except (ValueError, TypeError):
+            # Startup race, seen on COSMOS 2026-07-18: a file-serving
+            # Moonraker can answer 200 with the web UI's HTML for a moment
+            # before the Klippy API routes register. Retryable, so a clean
+            # 503 instead of an uncaught-exception 500 in the log.
+            raise self.server.error("Moonraker is still starting up", 503)
         result = data.get("result", data)
         result["tunnel_url"] = _get_tunnel_url()
         # Surface the Pi's LAN address so the app can prefer a direct LAN
@@ -1905,8 +1915,9 @@ class MoongatePlugin:
 
     # ── Webcam + chamber discovery (kept from v0.2.x) ─────────────────────────
 
-    @staticmethod
-    async def _get_webcam_info(client: Any) -> dict:
+    async def _get_webcam_info(self, client: Any) -> dict:
+        # Not a staticmethod since v0.6.17: the fetch below needs the
+        # instance's resolved Moonraker port.
         from tornado.httpclient import HTTPRequest
         _default_path = "/webcam/?action=snapshot"
         _default_fps  = 15
@@ -1986,13 +1997,16 @@ class MoongatePlugin:
         except Exception:
             return _defaults
 
-    async def _discover_objects(self, client: Any) -> None:
-        """One-shot scan of Moonraker's object list (per service lifetime) for
-        the chamber sensor, any extra hotends (extruder1, extruder2, ... on an
-        IDEX / tool changer) and whether this is a klipper-toolchanger. The
-        results are folded into the /status query so a multi-toolhead printer's
-        extra hotends + active tool ride the single authenticated /status call,
-        instead of the app having to make its own (transport-fragile) queries."""
+    async def _discover_objects(self, client: Any) -> bool:
+        """One-shot scan of Moonraker's object list for the chamber sensor,
+        any extra hotends (extruder1, extruder2, ... on an IDEX / tool
+        changer) and whether this is a klipper-toolchanger. The results are
+        folded into the /status query so a multi-toolhead printer's extra
+        hotends + active tool ride the single authenticated /status call,
+        instead of the app having to make its own (transport-fragile) queries.
+
+        Returns True when the scan actually ran (the caller then stops
+        re-trying); False when Moonraker/Klippy wasn't ready to answer."""
         from tornado.httpclient import HTTPRequest
         try:
             req = HTTPRequest(
@@ -2001,7 +2015,7 @@ class MoongatePlugin:
             )
             resp = await client.fetch(req, raise_error=False)
             if resp.code != 200:
-                return
+                return False
             objects = json.loads(resp.body).get("result", {}).get("objects", [])
             for obj in objects:
                 if ("temperature_sensor" in obj or "heater_generic" in obj
@@ -2022,5 +2036,6 @@ class MoongatePlugin:
                 logger.info(
                     "Moongate: multi-toolhead detected (extras=%s toolchanger=%s)",
                     extra, self._has_toolchanger)
+            return True
         except Exception:
-            pass
+            return False

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -51,19 +51,38 @@ from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import jwt as pyjwt  # PyJWT
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-    Ed25519PrivateKey,
-    Ed25519PublicKey,
-)
+# v0.6.17: PyJWT + cryptography only power CLOUD mode (pairing, heartbeat
+# signing, token verification). LAN-only installs never touch them, and the
+# embedded hosts in docs/third-party-printers.md (no pip, no prebuilt wheels)
+# can't install them at all - so their absence must not stop the module from
+# loading. _CLOUD_DEPS_ERROR doubles as the "why" surfaced in the log, the
+# MOONGATE_PAIR console output and error responses when a CLOUD-mode box is
+# missing them.
+try:
+    import jwt as pyjwt  # PyJWT
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+    _CLOUD_DEPS_ERROR: Optional[str] = None
+except ImportError as _deps_exc:
+    pyjwt             = None  # type: ignore[assignment]
+    serialization     = None  # type: ignore[assignment]
+    Ed25519PrivateKey = None  # type: ignore[assignment]
+    Ed25519PublicKey  = None  # type: ignore[assignment]
+    _CLOUD_DEPS_ERROR = (
+        f"cloud dependencies unavailable ({_deps_exc}); cloud pairing and "
+        "heartbeats are disabled. Install PyJWT[crypto] + cryptography into "
+        "Moonraker's Python, or run LAN-only (lan_only: true)."
+    )
 
 logger = logging.getLogger("moonraker.moongate")
 
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.16"
+MOONGATE_PLUGIN_VERSION = "0.6.17"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -991,31 +1010,92 @@ class MoongatePlugin:
     def __init__(self, config: Any) -> None:
         self.server = config.get_server()
 
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        self._config   = self._load_config()
-        self.device    = DeviceKey(DEVICE_KEY)
-        self.owner     = OwnerState.load(OWNER_FILE)
-        self.jwks      = JwksCache(
-            self._config["supabase_url"],
-            self._config["supabase_anon_key"],
-            JWKS_CACHE,
-            int(self._config["jwks_ttl_seconds"]),
-        )
-        self.verifier  = AccessTokenVerifier(self.jwks)
-        self.sb        = SupabaseClient(
-            self._config["supabase_url"],
-            self._config["supabase_anon_key"],
-        )
-        self.heartbeat = HeartbeatLoop(
-            self.device, self.sb,
-            int(self._config["heartbeat_interval_seconds"]),
-            on_unpaired_cb=self._on_unpaired,
-            on_dormant_cb=self._on_dormant,
-        )
-        self.watcher   = PrintEventWatcher(
-            self.device, self.sb,
-            is_dormant=lambda: self.heartbeat.dormant,
-        )
+        # ── v0.6.17: optional [moongate] options in moonraker.conf ───────────
+        # Embedded hosts (docs/third-party-printers.md) often can't run
+        # install.sh or write ~/.config, so the knobs that matter there live in
+        # the one file they CAN edit. Everything defaults to the historic
+        # behaviour: config.json keeps working, moonraker.conf wins when set.
+        conf_lan_only  = None
+        conf_data_path = None
+        conf_mr_port   = None
+        try:
+            conf_lan_only  = config.getboolean("lan_only", None)
+            conf_data_path = config.get("data_path", None)
+            conf_mr_port   = config.getint("moonraker_port", None)
+        except Exception:
+            pass  # duck-typed/legacy config objects: historic defaults
+
+        self._data_dir        = (Path(conf_data_path).expanduser()
+                                 if conf_data_path else CONFIG_DIR)
+        self._device_key_file = self._data_dir / "device_ed25519"
+        self._owner_file      = self._data_dir / "owner.json"
+        self._config_file     = self._data_dir / "config.json"
+        self._jwks_cache_file = self._data_dir / "jwks.json"
+        self._avahi_tmp_file  = self._data_dir / "moongate-avahi.service.tmp"
+        try:
+            self._data_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.error(
+                "Moongate: cannot create data dir %s (%s). Set data_path in "
+                "the [moongate] section to a writable location.",
+                self._data_dir, exc)
+            raise
+
+        self._config            = self._load_config()
+        self._lan_only_override = conf_lan_only
+
+        # Where Moonraker itself listens: an explicit moonraker_port wins,
+        # else ask the server (embedded builds bind :80, not :7125), else the
+        # stock default.
+        mr_port = conf_mr_port
+        if not mr_port:
+            try:
+                mr_port = int(self.server.get_host_info().get("port") or 0)
+            except Exception:
+                mr_port = 0
+        self._moonraker_port = mr_port or 7125
+
+        # Cloud machinery only exists when cloud mode is both wanted and
+        # possible. LAN-only skips it wholesale (no Ed25519 keygen, no key
+        # file, zero extra deps); a CLOUD-mode box missing PyJWT/cryptography
+        # still loads (the LAN endpoints keep working) and says exactly what
+        # is wrong in the log and its error responses instead of crashing
+        # Moonraker.
+        self._plugin_error = None if self.lan_only else _CLOUD_DEPS_ERROR
+        cloud_ready        = not self.lan_only and _CLOUD_DEPS_ERROR is None
+
+        self.owner = OwnerState.load(self._owner_file)
+        if cloud_ready:
+            self.device    = DeviceKey(self._device_key_file)
+            self.jwks      = JwksCache(
+                self._config["supabase_url"],
+                self._config["supabase_anon_key"],
+                self._jwks_cache_file,
+                int(self._config["jwks_ttl_seconds"]),
+            )
+            self.verifier  = AccessTokenVerifier(self.jwks)
+            self.sb        = SupabaseClient(
+                self._config["supabase_url"],
+                self._config["supabase_anon_key"],
+            )
+            self.heartbeat = HeartbeatLoop(
+                self.device, self.sb,
+                int(self._config["heartbeat_interval_seconds"]),
+                on_unpaired_cb=self._on_unpaired,
+                on_dormant_cb=self._on_dormant,
+            )
+            self.watcher   = PrintEventWatcher(
+                self.device, self.sb,
+                moonraker_port=self._moonraker_port,
+                is_dormant=lambda: self.heartbeat.dormant,
+            )
+        else:
+            self.device    = None
+            self.jwks      = None
+            self.verifier  = None
+            self.sb        = None
+            self.heartbeat = None
+            self.watcher   = None
 
         self._pending: Optional[PendingPair]   = None
         self._chamber_key: Optional[str]       = None
@@ -1038,12 +1118,14 @@ class MoongatePlugin:
         # Bootstrap JWKS (best effort) and start the heartbeat + print-watch loops.
         # LAN-only mode has no cloud: skip all of it so the plugin makes zero
         # outbound calls (no Supabase JWKS fetch, no heartbeat, no print-event push).
-        if not self.lan_only:
+        if cloud_ready:
             self.jwks.fetch_now()
             self.heartbeat.start()
             self.watcher.start()
-        else:
+        elif self.lan_only:
             logger.info("Moongate LAN-only mode: cloud loops disabled (no tunnel, no Supabase).")
+        else:
+            logger.error("Moongate: %s", self._plugin_error)
 
         owner_str = (
             f"{self.owner.owner_user_id[:8]}.../{self.owner.printer_id[:8]}..."
@@ -1056,16 +1138,20 @@ class MoongatePlugin:
         # is paired but the file isn't there. Covers (a) upgrade from
         # pre-v0.4.4, (b) manual deletion, (c) the file being lost during
         # a system update that wiped /etc/avahi/services/.
-        if self.owner is not None and not AVAHI_SERVICE_FILE.exists():
+        # Cloud mode only: a LAN-only (or deps-missing) box never advertises -
+        # a stale owner.json from an earlier cloud install must not trigger
+        # sudo attempts on hosts that have neither sudo nor avahi.
+        if (self.device is not None and self.owner is not None
+                and not AVAHI_SERVICE_FILE.exists()):
             self._write_avahi_service()
 
     # ── Config ────────────────────────────────────────────────────────────────
 
     def _load_config(self) -> dict:
         cfg = DEFAULT_CONFIG.copy()
-        if CONFIG_FILE.exists():
+        if self._config_file.exists():
             try:
-                user_cfg = json.loads(CONFIG_FILE.read_text())
+                user_cfg = json.loads(self._config_file.read_text())
                 if isinstance(user_cfg, dict):
                     cfg.update(user_cfg)
             except Exception as exc:
@@ -1081,6 +1167,10 @@ class MoongatePlugin:
 
     @property
     def lan_only(self) -> bool:
+        # moonraker.conf's [moongate] lan_only (when present) beats config.json
+        # - the embedded-host path, where config.json may not even exist.
+        if self._lan_only_override is not None:
+            return bool(self._lan_only_override)
         return bool(self._config.get("lan_only", False))
 
     # ── Pairing ───────────────────────────────────────────────────────────────
@@ -1126,6 +1216,11 @@ class MoongatePlugin:
             self._pending = pending
             return pending
 
+        if self.device is None:
+            # Cloud mode without its deps: _plugin_error says how to fix it.
+            logger.error("Moongate pair unavailable: %s", self._plugin_error)
+            return None
+
         raw  = self._generate_enrollment_token()
         hash_b64 = _b64std(hashlib.sha256(raw.encode()).digest())
 
@@ -1167,6 +1262,25 @@ class MoongatePlugin:
         """MOONGATE_PAIR macro entry point."""
         if self.lan_only:
             await self._klipper_pair_lan()
+            return
+
+        if self.device is None:
+            # Cloud mode but the crypto deps are missing (embedded host or a
+            # broken venv): a generic "Supabase unreachable" would send the
+            # user chasing their network, so say the real cause.
+            script = "\n".join([
+                "M118 ============================================",
+                "M118 Moongate: cloud pairing unavailable.",
+                "M118 Python deps missing (PyJWT + cryptography).",
+                "M118 Install them into Moonraker's Python, or",
+                "M118 reinstall Moongate in LAN-only mode.",
+                "M118 ============================================",
+            ])
+            try:
+                klippy_apis: Any = self.server.lookup_component("klippy_apis")
+                await klippy_apis.run_gcode(script)
+            except Exception as exc:
+                logger.error("run_gcode failed: %s", exc)
             return
 
         pending = self._start_pairing()
@@ -1302,6 +1416,11 @@ class MoongatePlugin:
         error / no answer at all"."""
         had_owner = self.owner is not None
         self._wipe_owner()
+        # No cloud machinery (LAN-only or missing deps) - nothing to release.
+        # Also fixes a lan_only wart: 0.6.16 still fired one outbound release
+        # POST here despite the mode's zero-outbound-calls promise.
+        if self.device is None:
+            return had_owner, 0
         # urllib in SupabaseClient is sync; off-load to a thread so the
         # asyncio loop is free for other work (matters because the macro
         # runs inline on Moonraker's loop).
@@ -1339,10 +1458,10 @@ class MoongatePlugin:
     def _wipe_owner(self) -> None:
         self.owner = None
         try:
-            if OWNER_FILE.exists():
-                OWNER_FILE.unlink()
+            if self._owner_file.exists():
+                self._owner_file.unlink()
         except OSError as exc:
-            logger.warning("Failed to delete %s: %s", OWNER_FILE, exc)
+            logger.warning("Failed to delete %s: %s", self._owner_file, exc)
         # v0.4.4: stop advertising on mDNS when we lose owner state - the Pi
         # is no longer paired so it shouldn't be discoverable.
         self._remove_avahi_service()
@@ -1396,14 +1515,14 @@ class MoongatePlugin:
                 printer_id=self.owner.printer_id,
                 http_port=self.http_port,
             )
-            AVAHI_SERVICE_TMP.write_text(content)
+            self._avahi_tmp_file.write_text(content)
             # `sudo -n` fails fast if the sudoers entry isn't in place
             # (e.g. plugin updated from pre-v0.4.4 without re-running
             # install.sh). 5 s timeout because we never want to block
             # pairing on this.
             result = subprocess.run(
                 ["sudo", "-n", "/bin/cp",
-                 str(AVAHI_SERVICE_TMP), str(AVAHI_SERVICE_FILE)],
+                 str(self._avahi_tmp_file), str(AVAHI_SERVICE_FILE)],
                 check=False, capture_output=True, timeout=5,
             )
             if result.returncode == 0:
@@ -1424,7 +1543,7 @@ class MoongatePlugin:
             logger.warning("Failed to write Avahi service file: %s", exc)
         finally:
             try:
-                AVAHI_SERVICE_TMP.unlink(missing_ok=True)
+                self._avahi_tmp_file.unlink(missing_ok=True)
             except OSError:
                 pass
 
@@ -1461,6 +1580,12 @@ class MoongatePlugin:
         # _handle_reset_owner is already token-free by the same reasoning.)
         if self.lan_only:
             return _LAN_ONLY_CLAIMS
+
+        if self.verifier is None:
+            # Cloud mode configured but PyJWT/cryptography are missing: no
+            # token can ever verify, so say why instead of a bare 401.
+            raise self.server.error(
+                f"Moongate cloud mode unavailable: {self._plugin_error}", 503)
 
         args  = webrequest.get_args()
         token = args.get("mg_token", "")
@@ -1502,7 +1627,7 @@ class MoongatePlugin:
                 paired_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             )
             try:
-                self.owner.save(OWNER_FILE)
+                self.owner.save(self._owner_file)
                 logger.info("Owner %s: user=%s..., printer=%s...",
                             "bound" if first_bind else "re-bound",
                             claims.sub[:8], claims.printer_id[:8])
@@ -1559,8 +1684,12 @@ class MoongatePlugin:
     async def _handle_pair(self, webrequest: Any) -> dict:
         pending = self._start_pairing()
         if pending is None:
-            msg = ("Could not determine the Pi's LAN IP" if self.lan_only
-                   else "Supabase /enroll-prepare unreachable")
+            if self.lan_only:
+                msg = "Could not determine the Pi's LAN IP"
+            elif self._plugin_error:
+                msg = f"Moongate cloud mode unavailable: {self._plugin_error}"
+            else:
+                msg = "Supabase /enroll-prepare unreachable"
             raise self.server.error(msg, 502)
         return {
             "code":               pending.raw_token,
@@ -1629,7 +1758,7 @@ class MoongatePlugin:
             query += "&toolchanger"
 
         req = HTTPRequest(
-            f"http://127.0.0.1:7125/printer/objects/query?{query}",
+            f"http://127.0.0.1:{self._moonraker_port}/printer/objects/query?{query}",
             method="GET", request_timeout=5.0,
         )
         try:
@@ -1695,7 +1824,7 @@ class MoongatePlugin:
 
         client = AsyncHTTPClient()
         req    = HTTPRequest(
-            f"http://127.0.0.1:7125{action_map[action]}",
+            f"http://127.0.0.1:{self._moonraker_port}{action_map[action]}",
             method="POST", body="{}",
             headers={"Content-Type": "application/json"},
             request_timeout=10.0,
@@ -1731,7 +1860,7 @@ class MoongatePlugin:
         try:
             client = AsyncHTTPClient()
             resp = await client.fetch(HTTPRequest(
-                "http://127.0.0.1:7125/printer/objects/query?print_stats",
+                f"http://127.0.0.1:{self._moonraker_port}/printer/objects/query?print_stats",
                 method="GET", request_timeout=3.0,
             ), raise_error=False)
             if resp.code == 200:
@@ -1748,7 +1877,7 @@ class MoongatePlugin:
         async def _fire() -> None:
             try:
                 resp = await AsyncHTTPClient().fetch(HTTPRequest(
-                    "http://127.0.0.1:7125/machine/update/client?name=moongate",
+                    f"http://127.0.0.1:{self._moonraker_port}/machine/update/client?name=moongate",
                     method="POST", body=b"", request_timeout=300.0,
                 ), raise_error=False)
                 logger.info("Plugin self-update finished: HTTP %s", resp.code)
@@ -1809,7 +1938,7 @@ class MoongatePlugin:
 
         try:
             req = HTTPRequest(
-                "http://127.0.0.1:7125/server/webcams/list",
+                f"http://127.0.0.1:{self._moonraker_port}/server/webcams/list",
                 method="GET", request_timeout=2.0,
             )
             resp = await client.fetch(req, raise_error=False)
@@ -1867,7 +1996,7 @@ class MoongatePlugin:
         from tornado.httpclient import HTTPRequest
         try:
             req = HTTPRequest(
-                "http://127.0.0.1:7125/printer/objects/list",
+                f"http://127.0.0.1:{self._moonraker_port}/printer/objects/list",
                 method="GET", request_timeout=2.0,
             )
             resp = await client.fetch(req, raise_error=False)

--- a/klipper-plugin/tests/test_lan_only_no_deps.py
+++ b/klipper-plugin/tests/test_lan_only_no_deps.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""v0.6.17 regression test: the plugin must load and run LAN-only WITHOUT
+PyJWT/cryptography installed (embedded hosts - see docs/third-party-printers.md
+- have no pip and no prebuilt wheels for them).
+
+Stdlib-only on purpose so it runs anywhere Python 3.9+ does:
+
+    python3 klipper-plugin/tests/test_lan_only_no_deps.py
+
+Covers:
+  1. import with jwt + cryptography BLOCKED  -> module loads, error recorded
+  2. MoongatePlugin construction in lan_only -> no cloud objects, no keygen
+  3. import with real deps (when installed)  -> no error recorded (else skip)
+"""
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "moongate_standalone.py"
+BLOCKED     = ("jwt", "cryptography")
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_PATH)
+    mod  = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass looks its module up in sys.modules.
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+class FakeServer:
+    def register_endpoint(self, *a, **k):      pass
+    def register_remote_method(self, *a, **k): pass
+    def lookup_component(self, *a, **k):       raise KeyError("not in test")
+    def get_host_info(self):                   return {"port": 80}
+    def error(self, msg, code=500):            return RuntimeError(f"{code}: {msg}")
+
+
+class FakeConfig:
+    """Duck-typed stand-in for Moonraker's ConfigHelper ([moongate] section)."""
+    def __init__(self, opts):
+        self._opts   = opts
+        self._server = FakeServer()
+
+    def get_server(self):            return self._server
+    def get(self, k, d=None):        return self._opts.get(k, d)
+    def getboolean(self, k, d=None): return self._opts.get(k, d)
+    def getint(self, k, d=None):     return self._opts.get(k, d)
+
+
+def test_import_without_deps():
+    # None in sys.modules makes `import <name>` raise ImportError.
+    for name in BLOCKED:
+        assert name not in sys.modules or sys.modules[name] is None, (
+            f"{name} already imported - run this test in its own process")
+        sys.modules[name] = None
+    try:
+        mod = _load("moongate_nodeps")
+    finally:
+        for name in BLOCKED:
+            del sys.modules[name]
+    assert mod._CLOUD_DEPS_ERROR is not None, "deps error not recorded"
+    assert "PyJWT" in mod._CLOUD_DEPS_ERROR
+    # Class definitions must survive the missing imports (only calls need them)
+    for cls in ("MoongatePlugin", "DeviceKey", "JwksCache",
+                "AccessTokenVerifier", "HeartbeatLoop", "PrintEventWatcher"):
+        assert hasattr(mod, cls), f"{cls} missing from module"
+    return mod
+
+
+def test_lan_only_construction(mod):
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin = mod.MoongatePlugin(FakeConfig({
+            "lan_only":  True,
+            "data_path": tmp,
+        }))
+        assert plugin.lan_only is True
+        assert plugin._plugin_error is None, "lan_only must not report an error"
+        for attr in ("device", "jwks", "verifier", "sb", "heartbeat", "watcher"):
+            assert getattr(plugin, attr) is None, f"{attr} built in lan_only"
+        assert plugin._moonraker_port == 80, "get_host_info port not used"
+        assert not (Path(tmp) / "device_ed25519").exists(), \
+            "lan_only must not generate a device key"
+        # moonraker.conf's lan_only wins over config.json's default (False)
+        assert plugin._lan_only_override is True
+
+
+def test_import_with_deps():
+    try:
+        import jwt          # noqa: F401
+        import cryptography # noqa: F401
+    except ImportError:
+        print("  (real deps not installed here - normal-import check skipped)")
+        return
+    mod = _load("moongate_withdeps")
+    assert mod._CLOUD_DEPS_ERROR is None, mod._CLOUD_DEPS_ERROR
+
+
+if __name__ == "__main__":
+    mod = test_import_without_deps()
+    print("PASS import with jwt/cryptography blocked")
+    test_lan_only_construction(mod)
+    print("PASS lan_only construction without deps (no cloud objects, no keygen)")
+    test_import_with_deps()
+    print("PASS normal import")
+    print("All good.")


### PR DESCRIPTION
## What will this PR change?

Moongate's Direct (LAN/VPN) mode will run on printers that aren't Raspberry-Pi-shaped: embedded boards with a real Moonraker but no pip, no git, no systemd, and no way to install Python crypto packages. First target machine is the Elegoo Centauri Carbon running OpenCentauri COSMOS firmware (a community tester is lined up). Plugin version goes 0.6.16 to 0.6.17. The app is untouched.

**The gist in plain English:** today the plugin refuses to even load without PyJWT and cryptography, although LAN-only mode never uses them. After this PR, LAN-only needs nothing beyond what Moonraker itself ships, so installing on an embedded machine becomes: copy one file, add one config section, restart Moonraker. Cloud mode on a normal Pi is completely unchanged.

## Why

An OpenCentauri user asked for Moongate on his Centauri Carbon. Research showed the box runs genuine Moonraker 0.10 with `trusted_clients` preset for private networks (a perfect Direct-mode fit), but it has no pip and no prebuilt 32-bit ARM wheels for `cryptography`, so the plugin's top-level imports kill it on arrival. The fixes are general, not COSMOS-specific: any minimal Moonraker host benefits.

## How

- The PyJWT/cryptography imports are wrapped in try/except. They only power cloud mode (pairing, heartbeat signing, token verification). When missing in cloud mode the plugin still loads and reports the real cause (log line, 503 with the reason on token endpoints, MOONGATE_PAIR console message) instead of crashing Moonraker's component load or sending users chasing "Supabase unreachable".
- LAN-only now skips constructing all cloud machinery (DeviceKey, JWKS cache, verifier, Supabase client, heartbeat loop, print watcher). Before, it built everything, generated an Ed25519 key on disk, and only skipped starting the loops.
- New optional options in the `[moongate]` section of moonraker.conf: `lan_only` (overrides config.json when present), `data_path` (relocates state off `~/.config` for systems where home is read-only), `moonraker_port`. All optional, all defaulting to today's behaviour, so existing installs are untouched.
- Moonraker's port is discovered via `server.get_host_info()` instead of six hardcoded `127.0.0.1:7125` URLs. Embedded builds bind :80; stock Pis keep resolving to 7125 exactly as before.
- Small honesty fix: factory reset on a LAN-only box no longer fires one outbound cloud-release POST (a 0.6.16 wart against the mode's "zero outbound calls" promise).
- Docs: new `docs/third-party-printers.md` with the generic one-file recipe, COSMOS step-by-step, Tailscale/VPN notes (including the 100.64.0.0/10 `trusted_clients` gap we flagged back in the #201 review), and a supported-machines table. Linked from the README's "Run it your way" section and Documentation table.

**Deliberately NOT bumping `kCurrentPluginVersion`:** this change is a no-op for every normal Pi install, so the fleet should not get the amber update badge over it. The constant catches up whenever the next app release has a reason to nag.

## Testing

- New stdlib-only test `klipper-plugin/tests/test_lan_only_no_deps.py`, run on Python 3.13:
  - import with jwt/cryptography blocked: module loads, error recorded, all classes defined - PASS
  - `MoongatePlugin` constructed in lan_only without deps: no cloud objects, no key file generated, moonraker.conf overrides honoured, port taken from `get_host_info()` - PASS
  - normal import with the real deps installed (venv): no error recorded, import path identical to today - PASS
- `python -m py_compile` clean.
- Owed after merge: the usual RatRig remote regression (one-tap update to 0.6.17, confirm cloud heartbeats/status unchanged). I'll run it as soon as this lands.
- The COSMOS field test runs from this branch (raw file URL) before merge, so the first real-device validation happens without touching master.

PEEKYPAUL 18/07/2026
