### PR TITLE
Keep content clear of the Android system bars (dashboard tile clipping + app-wide sweep)

### DIFF
--- a/mobile/lib/features/auth/pairing_screen.dart
+++ b/mobile/lib/features/auth/pairing_screen.dart
@@ -652,7 +652,11 @@ class _PairingScreenState extends State<PairingScreen> {
         thumbVisibility: true,
         child: SingleChildScrollView(
           controller: _scrollController,
-          padding: const EdgeInsets.all(24),
+          // + the system bar inset: a SingleChildScrollView never applies the
+          // safe area itself, so without this the Pair/Add button at the form's
+          // bottom could scroll to a stop under the Android button/gesture bar.
+          padding: EdgeInsets.fromLTRB(
+              24, 24, 24, 24 + MediaQuery.of(context).padding.bottom),
           child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/mobile/lib/features/dashboard/dashboard_screen.dart
+++ b/mobile/lib/features/dashboard/dashboard_screen.dart
@@ -2192,7 +2192,14 @@ class _PrinterGrid extends StatelessWidget {
           ? (columns + 1).clamp(2, 4)
           : columns;
 
-      const padding = EdgeInsets.all(12);
+      // Explicit padding switches OFF a scroll view's automatic safe-area
+      // handling, so fold the obscured edges back in ourselves: the Android
+      // button/gesture bar overlapped the last row's name + temps (Centauri
+      // tester report, 2026-07-18). Bottom in portrait, sides in landscape;
+      // top stays bare 12 - the AppBar already absorbs that inset.
+      final insets  = MediaQuery.of(context).padding;
+      final padding = EdgeInsets.fromLTRB(
+          12 + insets.left, 12, 12 + insets.right, 12 + insets.bottom);
       const spacing = 10.0;
 
       // Keyed by id so a reorder (or a status re-sort) moves a tile and its

--- a/mobile/lib/features/printer/printer_screen.dart
+++ b/mobile/lib/features/printer/printer_screen.dart
@@ -526,113 +526,121 @@ class _PrinterScreenState extends State<PrinterScreen>
           ),
         ],
       ),
-      body: Column(
-        children: [
-          // Camera-discoverability hint - a full-width strip directly under the
-          // app bar (Moongate's own chrome), so it never overlaps the embedded
-          // Mainsail page or the system nav bar. Gated to tunnel + external
-          // camera (see _maybeShowCameraHint). Dismissible, one-time.
-          if (_showCameraHint)
-            Material(
-              color: cs.secondaryContainer,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(14, 4, 4, 4),
-                child: Row(
-                  children: [
-                    Icon(Icons.videocam_outlined,
-                        size: 20, color: cs.onSecondaryContainer),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        l.cameraHintBody,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(color: cs.onSecondaryContainer),
-                      ),
-                    ),
-                    TextButton(
-                      onPressed: _openCamera,
-                      child: Text(l.cameraHintOpen),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.close, size: 18),
-                      color: cs.onSecondaryContainer,
-                      onPressed: _dismissCameraHint,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          Expanded(
-            child: Stack(
-              children: [
-                if (_webController != null)
-                  WebViewWidget(
-                    key: ValueKey(_webController),
-                    controller: _webController!,
-                  ),
-
-                if (_loading && _errorMsg == null)
-                  const Center(child: CircularProgressIndicator()),
-
-                if (_errorMsg != null && !_loading)
-                  Container(
-                    width: double.infinity,
-                    height: double.infinity,
-                    color: cs.surface,
-                    padding: const EdgeInsets.all(32),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(Icons.cloud_off_outlined,
-                            size: 64, color: cs.error),
-                        const SizedBox(height: 20),
-                        Text(
-                          l.printerUnreachable,
+      // SafeArea keeps the embedded web UI clear of the Android button/gesture
+      // bar (and the side bar in landscape) - Mainsail/Fluidd put interactive
+      // rows right at their page bottom, which the system bar was overlapping.
+      // Browsers keep web content above the nav bar too, so this matches what
+      // the same page looks like in Chrome. Top stays with the AppBar.
+      body: SafeArea(
+        top: false,
+        child: Column(
+          children: [
+            // Camera-discoverability hint - a full-width strip directly under the
+            // app bar (Moongate's own chrome), so it never overlaps the embedded
+            // Mainsail page or the system nav bar. Gated to tunnel + external
+            // camera (see _maybeShowCameraHint). Dismissible, one-time.
+            if (_showCameraHint)
+              Material(
+                color: cs.secondaryContainer,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(14, 4, 4, 4),
+                  child: Row(
+                    children: [
+                      Icon(Icons.videocam_outlined,
+                          size: 20, color: cs.onSecondaryContainer),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Text(
+                          l.cameraHintBody,
                           style: Theme.of(context)
                               .textTheme
-                              .headlineSmall
-                              ?.copyWith(color: cs.error),
-                          textAlign: TextAlign.center,
+                              .bodySmall
+                              ?.copyWith(color: cs.onSecondaryContainer),
                         ),
-                        const SizedBox(height: 16),
-                        Text(
-                          _errorMsg!,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                  color: cs.onSurface.withValues(alpha: 0.7)),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 32),
-                        FilledButton.icon(
-                          onPressed: () {
-                            PrinterWebViewCache.instance
-                                .invalidate(widget.printer.id);
-                            PrinterAccessCache.instance
-                                .invalidate(widget.printer.id);
-                            _start();
-                          },
-                          icon: const Icon(Icons.refresh),
-                          label: Text(l.commonRetry),
-                        ),
-                        // No tunnel escape hatch in Local-only mode - the
-                        // whole point of the toggle is that remote stays off.
-                        if (_usingLan && _tunnelUrl != null && !_localOnly) ...[
-                          const SizedBox(height: 12),
-                          OutlinedButton.icon(
-                            onPressed: _retryViaTunnel,
-                            icon: const Icon(Icons.cloud_outlined),
-                            label: Text(l.printerUseTunnel),
-                          ),
-                        ],
-                      ],
-                    ),
+                      ),
+                      TextButton(
+                        onPressed: _openCamera,
+                        child: Text(l.cameraHintOpen),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.close, size: 18),
+                        color: cs.onSecondaryContainer,
+                        onPressed: _dismissCameraHint,
+                      ),
+                    ],
                   ),
-              ],
+                ),
+              ),
+            Expanded(
+              child: Stack(
+                children: [
+                  if (_webController != null)
+                    WebViewWidget(
+                      key: ValueKey(_webController),
+                      controller: _webController!,
+                    ),
+
+                  if (_loading && _errorMsg == null)
+                    const Center(child: CircularProgressIndicator()),
+
+                  if (_errorMsg != null && !_loading)
+                    Container(
+                      width: double.infinity,
+                      height: double.infinity,
+                      color: cs.surface,
+                      padding: const EdgeInsets.all(32),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.cloud_off_outlined,
+                              size: 64, color: cs.error),
+                          const SizedBox(height: 20),
+                          Text(
+                            l.printerUnreachable,
+                            style: Theme.of(context)
+                                .textTheme
+                                .headlineSmall
+                                ?.copyWith(color: cs.error),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            _errorMsg!,
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                    color: cs.onSurface.withValues(alpha: 0.7)),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 32),
+                          FilledButton.icon(
+                            onPressed: () {
+                              PrinterWebViewCache.instance
+                                  .invalidate(widget.printer.id);
+                              PrinterAccessCache.instance
+                                  .invalidate(widget.printer.id);
+                              _start();
+                            },
+                            icon: const Icon(Icons.refresh),
+                            label: Text(l.commonRetry),
+                          ),
+                          // No tunnel escape hatch in Local-only mode - the
+                          // whole point of the toggle is that remote stays off.
+                          if (_usingLan && _tunnelUrl != null && !_localOnly) ...[
+                            const SizedBox(height: 12),
+                            OutlinedButton.icon(
+                              onPressed: _retryViaTunnel,
+                              icon: const Icon(Icons.cloud_outlined),
+                              label: Text(l.printerUseTunnel),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/features/settings/notification_content_screen.dart
+++ b/mobile/lib/features/settings/notification_content_screen.dart
@@ -45,7 +45,11 @@ class NotificationContentScreen extends ConsumerWidget {
             child: ReorderableListView(
               // Drag only from the handle so the row's switch stays tappable.
               buildDefaultDragHandles: false,
-              padding: const EdgeInsets.only(bottom: 24),
+              // + the system bar inset: explicit padding switches off the
+              // list's automatic safe-area handling, and the last row's drag
+              // handle was sitting under the Android button/gesture bar.
+              padding: EdgeInsets.only(
+                  bottom: 24 + MediaQuery.of(context).padding.bottom),
               // onReorder is current on stable Flutter; only this box's
               // pre-release SDK flags it (the onReorderItem replacement doesn't
               // exist on stable, so switching would break the CI build).


### PR DESCRIPTION
## What will this PR change?

Content will stop hiding under the phone's system bars. The bug report (from the Centauri tester, with a screenshot): the dashboard's last tile had its name, temperatures and update badge sitting underneath the Android navigation buttons. This PR fixes that and sweeps the whole app for the same class of problem.

**The gist in plain English:** the app draws edge-to-edge, and Flutter only pads scrolling content away from the system bars automatically when a screen doesn't set its own padding. Several screens do set their own, which silently turns that protection off. Each one now folds the system-bar size into its padding, so the last row always scrolls fully clear of the phone's buttons.

## What was fixed

- **Dashboard** (both normal display mode and reorder mode): the grid now pads for the bottom bar in portrait and the side bar in landscape. This is the reported bug.
- **Printer page**: the embedded Mainsail/Fluidd view now stops above the system bar instead of running underneath it. Mainsail puts interactive controls right at its page bottom (visible in the tester's second screenshot, the extrusion row under the nav buttons), and a browser showing the same page keeps it above the bar too, so this matches expectations.
- **Pairing screen**: the form can no longer scroll to a stop with the Pair/Add button under the bar.
- **Notification content settings**: the last row's drag handle was under the bar.

## Checked and already safe

Settings and custom-theme lists (no explicit padding, so Flutter pads them automatically), every dashboard sheet and overlay (they all carry SafeArea), dialogs (inset by the dialog frame), the custom-theme editor sheet (already handles both the nav bar and the keyboard, with a comment explaining why), and the dashboard FABs (the framework positions those).

## Testing

- `flutter analyze` clean.
- Not yet device-tested: this box has no release keystore, so installing here would wipe the dev phone. The visual check (dashboard bottom tile fully visible above the nav buttons, Mainsail page bottom reachable, pairing form bottom reachable) rides the next release build or a work-box session. The Centauri tester who reported it will see the dashboard fix in the next release too.
- No version bump here; this rides the next release PR with its changelog.

PEEKYPAUL 18/07/2026
