### PR TITLE
CI: docs-only changes skip the app builds

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,8 +3,20 @@ name: Build Android APK
 on:
   push:
     branches: [master]
+    # Docs-only changes don't need an app build - this also retires the
+    # "[skip ci] on docs merges" discipline (paths-ignore skips the run only
+    # when EVERY changed file matches, so release PRs - which touch pubspec +
+    # changelog.json alongside CHANGELOG.md - still build and release).
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
   workflow_dispatch:
     inputs:
       play_build_number:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,8 +13,17 @@ name: Build iOS
 on:
   push:
     branches: [master]
+    # Docs-only changes don't need an app build (see build-android.yml).
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [master]
+    # Docs-only changes need neither analyze/test nor the plugin lint
+    # (see build-android.yml for the paths-ignore semantics).
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   flutter:


### PR DESCRIPTION
## What will this PR change?

PRs and merges that only touch documentation (docs/**, any .md file, LICENSE) will no longer run the Android APK build, the iOS build, or Flutter analyze/test. Anything touching real code or the version files keeps full CI, paths-ignore only skips a run when every changed file matches the ignore list.

**The gist in plain English:** the question this answers came from PR #224, a pure docs reword that was happily building the whole app. From now on that class of PR shows only the changelog-guard check, and docs merges to master stop re-running the release pipeline, which also retires the manual '[skip ci] in the merge commit' habit and the noisy same-version release re-runs it guarded against.

## Why safe

- Release PRs touch pubspec.yaml and mobile/assets/changelog.json alongside CHANGELOG.md, so they never match the ignore list and always build + release.
- Mixed PRs (code + docs) run everything, one non-matching file is enough.
- The build checks are not merge-gating on this repo, so a docs PR showing fewer checks changes nothing about mergeability.
- changelog-guard still runs on everything: it is 35 seconds and its whole job is watching version bumps.

## Testing

- All workflow YAML parse-validated.
- The natural live test is the next docs PR: it should show only changelog-guard.

PEEKYPAUL 18/07/2026