### PR TITLE
Docs: uninstall steps for the Centauri Carbon (COSMOS) section

### DIFF
--- a/docs/third-party-printers.md
+++ b/docs/third-party-printers.md
@@ -171,6 +171,39 @@ wall of JSON including the plugin version.
   come (no tunnel, no timers, no outbound calls), but temper expectations
   accordingly.
 
+### Uninstalling
+
+Everything the install put on the machine lives on `/etc` - the sealed root
+was never touched - so removal is a config trim, a few deletes, and a
+restart. SSH in as root, then:
+
+```sh
+# 1. Trim the [moongate] section off the conf. The install appended it at
+#    the end of the file, so this cuts from that line down; if you've added
+#    other sections below it since, edit the file with vi instead.
+sed -i '/^\[moongate\]/,$d' /etc/klipper/config/moonraker.conf
+
+# 2. Unmount the components copy and remove the boot script + its rc links
+/etc/init.d/moongate-overlay stop
+rm -f /etc/init.d/moongate-overlay /etc/rc?.d/S95moongate-overlay
+
+# 3. Confirm the unmount took - NO output means it did. If a line prints
+#    (the mount was busy), reboot the printer instead: the boot script is
+#    gone, so it comes back up unmounted - then continue with step 4.
+mount | grep ' on /usr/share/moonraker/moonraker/components '
+
+# 4. Delete the plugin file, Moongate's state, and the components copy
+rm -rf /etc/moongate /etc/moongate-components
+
+# 5. Restart Moonraker on the stock components folder
+/etc/init.d/moonraker restart
+```
+
+Then remove the printer's tile in the app: **menu → Remove printer**, tap
+the printer. That's everything - all three pieces Moongate added (the
+plugin file and its state, the components copy, the boot script) lived on
+`/etc` and are gone, so the machine is back to stock.
+
 ## Remote access (VPN)
 
 Direct mode away from home rides your own VPN, and the easy path is a


### PR DESCRIPTION
## What will this PR change?

Adds an "Uninstalling" subsection to the Elegoo Centauri Carbon (OpenCentauri COSMOS) section of docs/third-party-printers.md, so the install recipe now has a matching exit.

In plain English: we tell Centauri Carbon owners how to put everything back the way it was. The install only ever writes to /etc (the sealed root is never modified), so removal is trimming the [moongate] section off moonraker.conf, unmounting the components overlay, deleting the boot script + rc links + plugin files, and restarting Moonraker. The section ends with removing the tile in the app (menu -> Remove printer).

## Why

The COSMOS section documented install and update but not removal. On an appliance-style machine a clean exit matters more than on a Pi: there is no installer with an uninstall flag to fall back on, and users trialling Moongate on beta firmware want confidence they can back out fully.

## How

The steps mirror the validated install exactly: same paths, same rc2-5 links, same mount-check pattern the boot script itself uses. One deliberate safety guard: step 3 verifies the bind unmount actually took before step 4 deletes /etc/moongate-components. If the copy were deleted while still bind-mounted, Moonraker's live components directory would be emptied until reboot, so the doc routes that rare busy case through a reboot instead (safe, because the rc links are already gone by then).

## Testing

Docs-only change, no app or plugin code touched (CI skips the app builds on docs-only PRs). Steps desk-checked against the install block directly above them and the boot script's own variables; BusyBox-compatible commands only (sed -i, glob rm, no bash).

PEEKYPAUL 19/07/2026
