### PR TITLE
fix: Direct-mode printers no longer mint cloud access tokens (the printer-access 500s)

### DIFF
--- a/mobile/lib/services/printer_access_cache.dart
+++ b/mobile/lib/services/printer_access_cache.dart
@@ -37,6 +37,13 @@ class PrinterAccessCache {
   /// this hold every 4s dashboard poll minted-and-404'd forever. One such
   /// install was ~⅔ of ALL Edge Function invocations (July 2026 quota blow).
   Future<PrinterAccess> get(String printerId) async {
+    // A Direct-added printer's synthetic id ('lan-…', see
+    // PrinterConfig.cloudPaired) never has a cloud row - it isn't even a
+    // UUID, so the mint can only fail (observed in prod as a 500 every
+    // 4 min from the webview cookie refresh). Fail locally, zero Edge cost,
+    // whatever call site asks.
+    if (printerId.startsWith('lan-')) throw PrinterNotFoundException();
+
     final cached = _cached[printerId];
     if (cached != null && !cached.isStale()) return cached;
 

--- a/mobile/lib/services/printer_webview_cache.dart
+++ b/mobile/lib/services/printer_webview_cache.dart
@@ -10,6 +10,7 @@ import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 import '../models/printer_config.dart';
 import 'lan_discovery_service.dart';
 import 'printer_access_cache.dart';
+import 'printer_registry.dart';
 import 'supabase_service.dart';
 
 /// Build a [WebViewController] with media autoplay enabled - the one factory
@@ -155,22 +156,49 @@ class PrinterWebViewCache with WidgetsBindingObserver {
     }
   }
 
+  /// True when [printerId] must not touch the cloud: a Direct (LAN/VPN)
+  /// printer, whether Direct-added (synthetic 'lan-…' id, no cloud row ever)
+  /// or a cloud-paired one the user switched to Direct. Registry-live so a
+  /// mode toggle takes effect without recreating anything.
+  bool _isDirectMode(String printerId) {
+    if (printerId.startsWith('lan-')) return true;
+    for (final p in PrinterRegistry.instance.printers) {
+      if (p.id == printerId) return p.lanOnly;
+    }
+    return false;
+  }
+
   Future<void> _prewarmOne(PrinterConfig printer) async {
     try {
-      final access = await PrinterAccessCache.instance.get(printer.id);
-      await setMgTokenCookie(access);
-
-      // Prefer LAN when reachable (Mainsail loads far faster direct), else the
-      // tunnel - the same resolution the printer screen uses on a cold open.
-      final lanUrl =
-          LanDiscoveryService.instance.lookup(printer.id) ?? printer.lanUrl;
       String? useUrl;
       var usingLan = false;
-      if (lanUrl != null && await _isLanReachable(lanUrl)) {
-        useUrl = lanUrl;
+      String? tunnelUrl;
+      if (_isDirectMode(printer.id)) {
+        // Direct (LAN/VPN): no Supabase mint, no mg_token cookie - mirror the
+        // printer screen's Direct branch. LAN only; there is no tunnel to
+        // fall back to. (Minting for a Direct-added id would just 500 the
+        // Edge Function - its synthetic id isn't a cloud row.)
+        final lanUrl =
+            LanDiscoveryService.instance.lookup(printer.id) ?? printer.lanUrl;
+        if (lanUrl == null || !await _isLanReachable(lanUrl)) return;
+        useUrl   = lanUrl;
         usingLan = true;
-      } else if (access.tunnelUrl != null) {
-        useUrl = access.tunnelUrl;
+      } else {
+        final access = await PrinterAccessCache.instance.get(printer.id);
+        await setMgTokenCookie(access);
+        tunnelUrl = access.tunnelUrl;
+
+        // Prefer LAN when reachable (Mainsail loads far faster direct), else
+        // the tunnel - the same resolution the printer screen uses on a cold
+        // open.
+        final lanUrl =
+            LanDiscoveryService.instance.lookup(printer.id) ?? printer.lanUrl;
+        if (lanUrl != null && await _isLanReachable(lanUrl)) {
+          useUrl = lanUrl;
+          usingLan = true;
+        } else if (tunnelUrl != null) {
+          useUrl = tunnelUrl;
+        }
       }
       if (useUrl == null) return; // not reachable yet - the screen cold-loads it
 
@@ -210,7 +238,7 @@ class PrinterWebViewCache with WidgetsBindingObserver {
           controller: controller,
           baseUrl:    useUrl,
           usingLan:   usingLan,
-          tunnelUrl:  access.tunnelUrl,
+          tunnelUrl:  tunnelUrl,
         ),
       );
       _log('prewarmed ${printer.id} (${usingLan ? 'LAN' : 'tunnel'})');
@@ -229,6 +257,12 @@ class PrinterWebViewCache with WidgetsBindingObserver {
     session.cookieRefresh =
         Timer.periodic(const Duration(minutes: 4), (_) async {
       try {
+        // Direct (LAN/VPN) mode has no cloud row and no mg_token cookie to
+        // keep fresh - minting from here only 500s the Edge Function (this
+        // exact timer was one real install's 15 calls/hr, July 2026).
+        // Checked per tick so a mode toggle takes effect while the session
+        // stays warm, in either direction.
+        if (_isDirectMode(printerId)) return;
         final access = await PrinterAccessCache.instance.get(printerId);
         await setMgTokenCookie(access);
         final host = session.tunnelHost;

--- a/mobile/test/printer_access_cache_test.dart
+++ b/mobile/test/printer_access_cache_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:moongate/services/printer_access_cache.dart';
+import 'package:moongate/services/supabase_service.dart';
+
+/// A Direct-added printer's synthetic id ('lan-…') has no cloud row by
+/// construction, so PrinterAccessCache must refuse it locally - before any
+/// Supabase call. In this test environment Supabase is never initialized:
+/// if the guard were missing, the lookup would blow up on the uninitialized
+/// client instead of throwing the typed not-found, so a pass here proves no
+/// network path was reached. (The prod symptom this locks out: the webview
+/// cookie refresh minting for 'lan-http---192-168-1-84' every 4 minutes,
+/// a 500 per attempt, July 2026.)
+void main() {
+  test('Direct-mode synthetic id fails locally with PrinterNotFound', () {
+    expect(
+      () => PrinterAccessCache.instance.get('lan-http---192-168-1-84'),
+      throwsA(isA<PrinterNotFoundException>()),
+    );
+  });
+
+  test('the guard is prefix-anchored, not a substring match', () {
+    // A UUID id containing 'lan-' elsewhere must NOT trip the guard; it
+    // should fall through toward a real lookup (which here fails on the
+    // uninitialized Supabase client - anything but PrinterNotFound).
+    expect(
+      () => PrinterAccessCache.instance.get('0b5dlan-fake-uuid'),
+      throwsA(isNot(isA<PrinterNotFoundException>())),
+    );
+  });
+}

--- a/supabase/functions/printer-access/index.ts
+++ b/supabase/functions/printer-access/index.ts
@@ -31,7 +31,13 @@
 // Errors:
 //   400 - malformed body
 //   401 - no/invalid JWT
-//   404 - printer doesn't exist OR not owned by caller (constant shape)
+//   404 - printer doesn't exist OR not owned by caller (constant shape).
+//         Also any non-UUID printer_id: a Direct-mode app bug (fixed
+//         app-side alongside this) sent synthetic 'lan-…' ids here, which
+//         threw 22P02 through the RPC as a 500 - and the app only
+//         negative-caches 404 verdicts, so fielded clients retried the
+//         "transient" 500 forever. Answering 404 puts any such client on
+//         the existing back-off.
 //   503 - printer exists but Pi has not sent a heartbeat yet AND the caller
 //         did not set accept_no_tunnel; retry_after seconds
 
@@ -65,6 +71,14 @@ Deno.serve(async (req) => {
   if (typeof printerId !== "string" || printerId.length === 0) {
     return badRequest("printer_id required");
   }
+
+  // printers.id is a uuid column - any other shape (e.g. a Direct-mode
+  // synthetic 'lan-…' id) can never match a row. Answer with the constant
+  // 404 instead of letting Postgres throw 22P02 through the RPC as a 500,
+  // so clients land on their not-found back-off path.
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(printerId)) return notFound();
 
   // v0.5.0+ apps set this to opt into LAN-first: get the token even when the
   // tunnel URL isn't known yet (tunnel_url comes back null). Older apps omit


### PR DESCRIPTION
## What will this PR change?

Direct (LAN/VPN) printers will stop calling the cloud entirely. Today, two background paths quietly send a Direct printer's made-up local id (like `lan-http---192-168-1-84`) to the `printer-access` function, and every one of those calls fails with a 500 because the database expects a UUID.

**The gist:** open the printer page on a Direct printer and the app starts asking the cloud, every 4 minutes, for a token it can never get. Nobody sees an error; it just burns Edge Function invocations and fills the logs. After this PR, Direct mode means what it says: zero cloud calls. The server also learns to answer these malformed ids with its normal "not found" instead of a server error, which matters for apps already in the field (see below).

### Why

Found during the daily Supabase meter watch (21/07): every `printer-access` 500 in the last hour came from ONE Android install, exactly one call every 4 minutes. The function log showed `get_printer_access` throwing `invalid input syntax for type uuid: "lan-http---192-168-1-84"`. These 500s first appeared on 14 July, the day after Direct mode shipped in v0.9.51; at the time they were misread as Supabase platform blips.

The chain: the printer page stores a warm WebView session for a Direct printer, storing any session starts the 4-minute `mg_token` cookie-refresh timer, and that timer minted a cloud token with no Direct-mode check. The failure is swallowed and, because only 404s are negative-cached (the v0.9.48 fix), a 500 is retried forever. The startup pre-warm had the same gap (one wasted call per launch per Direct printer).

### How

- `printer_access_cache.dart`: refuse `lan-` ids locally with the typed not-found before any network call. A Direct-added printer has no cloud row by construction, so no call site can leak an Edge call for one again, now or in future code.
- `printer_webview_cache.dart`: the cookie-refresh tick skips Direct printers (checked per tick against the live registry, so the edit-dialog mode toggle behaves in both directions), and the pre-warm warms Direct printers straight from the LAN with no token or cookie, mirroring the printer screen's Direct branch.
- `supabase/functions/printer-access/index.ts`: validate the id shape before the RPC; non-UUID ids get the constant 404. Fielded apps negative-cache 404 verdicts, so the affected install out there drops from 15 calls/hr to ~4/hr on its own, without an app update.

App changes are pure Dart, so both platforms get them. No version bump; this rides the next release. Code merge without a bump, so quiet-merge it per DEVELOPMENT.md.

### Testing

- `flutter analyze` clean; all 26 unit tests pass, including 2 new ones locking the cache guard. In tests the Supabase client is never initialized, so a passing guard test proves no network path is reached; a second test pins the guard to the `lan-` prefix rather than a substring.
- Not device-tested (this box has no keystore). What to eyeball on a device later: a Direct printer's page still loads and pre-warms, and the Supabase logs show zero `printer-access` calls with `lan-` ids.
- The function change needs a manual deploy after merge:
  `supabase functions deploy printer-access --project-ref wlmmaoupmupbrrkcjglj`

PEEKYPAUL 21/07/2026
