### PR TITLE
Webcam wake-up spinner, honest camera states + bug-report camera diagnostics

### DIFF
--- a/mobile/lib/features/dashboard/printer_tile.dart
+++ b/mobile/lib/features/dashboard/printer_tile.dart
@@ -645,6 +645,7 @@ class _PrinterTileState extends ConsumerState<PrinterTile>
                     webcamTargetFps: _status.webcamTargetFps,
                     webcamIsExternal: _status.webcamIsExternal,
                     uiType: _uiType,
+                    printerId: widget.printer.id,
                   ),
                   // Overlay shown while we don't yet have a usable
                   // status (first poll in flight, Pi waiting for its first

--- a/mobile/lib/features/printer/printer_camera_screen.dart
+++ b/mobile/lib/features/printer/printer_camera_screen.dart
@@ -116,6 +116,7 @@ class _PrinterCameraOverlayState extends ConsumerState<_PrinterCameraOverlay> {
           webcamTargetFps: s.webcamTargetFps,
           webcamIsExternal: s.webcamIsExternal,
           uiType: _service.uiType ?? widget.printer.uiType,
+          printerId: widget.printer.id,
           fit: BoxFit.contain,
           respectDashboardThrottle: false,
         ),

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "Für diesen Drucker ist keine Kamera konfiguriert.",
   "cameraHintBody": "Webcam lädt hier aus der Ferne nicht - Moongate-Kamera öffnen.",
   "cameraHintOpen": "Öffnen",
+  "webcamWakingUp": "Kamera wacht auf…",
   "printerUnreachable": "Drucker nicht erreichbar",
   "printerUseTunnel": "Tunnel verwenden",
   "printerAddressInvalid": "Versuche z. B. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -809,6 +809,8 @@
   "@cameraHintBody": {"description": "Dismissible hint on the printer page, shown only over the tunnel for an external camera, pointing the user to the native full-screen camera view."},
   "cameraHintOpen": "Open",
   "@cameraHintOpen": {"description": "Button on the camera-discoverability hint that opens the full-screen Moongate camera view."},
+  "webcamWakingUp": "Camera waking up…",
+  "@webcamWakingUp": {"description": "Shown with a spinner in the webcam box while the first frame is still being fetched - on-demand cameras (go2rtc) take a moment to start."},
   "printerUnreachable": "Printer unreachable",
   "@printerUnreachable": {"description": "Heading on the full-screen error overlay when the printer cannot be loaded."},
   "printerUseTunnel": "Use tunnel",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "No hay ninguna cámara configurada para esta impresora.",
   "cameraHintBody": "La cámara no se carga aquí en remoto - abre la cámara de Moongate.",
   "cameraHintOpen": "Abrir",
+  "webcamWakingUp": "La cámara se está activando…",
   "printerUnreachable": "Impresora inaccesible",
   "printerUseTunnel": "Usar túnel",
   "printerAddressInvalid": "Prueba p. ej. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "Aucune caméra configurée pour cette imprimante.",
   "cameraHintBody": "La webcam ne se charge pas ici à distance - ouvrez la caméra Moongate.",
   "cameraHintOpen": "Ouvrir",
+  "webcamWakingUp": "La caméra se réveille…",
   "printerUnreachable": "Imprimante injoignable",
   "printerUseTunnel": "Utiliser le tunnel",
   "printerAddressInvalid": "Essayez par ex. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "Nessuna telecamera configurata per questa stampante.",
   "cameraHintBody": "La webcam non si carica qui da remoto - apri la telecamera Moongate.",
   "cameraHintOpen": "Apri",
+  "webcamWakingUp": "La telecamera si sta attivando…",
   "printerUnreachable": "Stampante irraggiungibile",
   "printerUseTunnel": "Usa il tunnel",
   "printerAddressInvalid": "Prova ad es. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -2494,6 +2494,12 @@ abstract class AppLocalizations {
   /// **'Open'**
   String get cameraHintOpen;
 
+  /// Shown with a spinner in the webcam box while the first frame is still being fetched - on-demand cameras (go2rtc) take a moment to start.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera waking up…'**
+  String get webcamWakingUp;
+
   /// Heading on the full-screen error overlay when the printer cannot be loaded.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/app_localizations_de.dart
+++ b/mobile/lib/l10n/app_localizations_de.dart
@@ -1365,6 +1365,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cameraHintOpen => 'Öffnen';
 
   @override
+  String get webcamWakingUp => 'Kamera wacht auf…';
+
+  @override
   String get printerUnreachable => 'Drucker nicht erreichbar';
 
   @override

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -1346,6 +1346,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cameraHintOpen => 'Open';
 
   @override
+  String get webcamWakingUp => 'Camera waking up…';
+
+  @override
   String get printerUnreachable => 'Printer unreachable';
 
   @override

--- a/mobile/lib/l10n/app_localizations_es.dart
+++ b/mobile/lib/l10n/app_localizations_es.dart
@@ -1375,6 +1375,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cameraHintOpen => 'Abrir';
 
   @override
+  String get webcamWakingUp => 'La cámara se está activando…';
+
+  @override
   String get printerUnreachable => 'Impresora inaccesible';
 
   @override

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -1377,6 +1377,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cameraHintOpen => 'Ouvrir';
 
   @override
+  String get webcamWakingUp => 'La caméra se réveille…';
+
+  @override
   String get printerUnreachable => 'Imprimante injoignable';
 
   @override

--- a/mobile/lib/l10n/app_localizations_it.dart
+++ b/mobile/lib/l10n/app_localizations_it.dart
@@ -1369,6 +1369,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cameraHintOpen => 'Apri';
 
   @override
+  String get webcamWakingUp => 'La telecamera si sta attivando…';
+
+  @override
   String get printerUnreachable => 'Stampante irraggiungibile';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pl.dart
+++ b/mobile/lib/l10n/app_localizations_pl.dart
@@ -1363,6 +1363,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get cameraHintOpen => 'Otwórz';
 
   @override
+  String get webcamWakingUp => 'Kamera się budzi…';
+
+  @override
   String get printerUnreachable => 'Drukarka nieosiągalna';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pt.dart
+++ b/mobile/lib/l10n/app_localizations_pt.dart
@@ -1368,6 +1368,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cameraHintOpen => 'Abrir';
 
   @override
+  String get webcamWakingUp => 'A câmera está acordando…';
+
+  @override
   String get printerUnreachable => 'Impressora inacessível';
 
   @override

--- a/mobile/lib/l10n/app_localizations_ru.dart
+++ b/mobile/lib/l10n/app_localizations_ru.dart
@@ -1363,6 +1363,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cameraHintOpen => 'Открыть';
 
   @override
+  String get webcamWakingUp => 'Камера просыпается…';
+
+  @override
   String get printerUnreachable => 'Принтер недоступен';
 
   @override

--- a/mobile/lib/l10n/app_localizations_zh.dart
+++ b/mobile/lib/l10n/app_localizations_zh.dart
@@ -1290,6 +1290,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get cameraHintOpen => '打开';
 
   @override
+  String get webcamWakingUp => '摄像头唤醒中…';
+
+  @override
   String get printerUnreachable => '无法连接打印机';
 
   @override

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "Brak skonfigurowanej kamery dla tej drukarki.",
   "cameraHintBody": "Kamera nie ładuje się tutaj zdalnie - otwórz kamerę Moongate.",
   "cameraHintOpen": "Otwórz",
+  "webcamWakingUp": "Kamera się budzi…",
   "printerUnreachable": "Drukarka nieosiągalna",
   "printerUseTunnel": "Użyj tunelu",
   "printerAddressInvalid": "Spróbuj np. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -412,6 +412,7 @@
   "cameraNoCamera": "Nenhuma câmera configurada para esta impressora.",
   "cameraHintBody": "A webcam não carregará remotamente aqui - abra a câmera do Moongate.",
   "cameraHintOpen": "Abrir",
+  "webcamWakingUp": "A câmera está acordando…",
   "printerUnreachable": "Impressora inacessível",
   "printerUseTunnel": "Usar túnel",
   "printerAddressInvalid": "Tente p. ex., 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_ru.arb
+++ b/mobile/lib/l10n/app_ru.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "Для этого принтера камера не настроена.",
   "cameraHintBody": "Веб-камера не загружается здесь удалённо - откройте камеру Moongate.",
   "cameraHintOpen": "Открыть",
+  "webcamWakingUp": "Камера просыпается…",
   "printerUnreachable": "Принтер недоступен",
   "printerUseTunnel": "Использовать туннель",
   "printerAddressInvalid": "Попробуйте, например, 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -424,6 +424,7 @@
   "cameraNoCamera": "未为此打印机配置摄像头。",
   "cameraHintBody": "网络摄像头在此处无法远程加载 - 打开 Moongate 摄像头。",
   "cameraHintOpen": "打开",
+  "webcamWakingUp": "摄像头唤醒中…",
   "printerUnreachable": "无法连接打印机",
   "printerUseTunnel": "使用隧道",
   "printerAddressInvalid": "请尝试例如 192.168.1.50:7125",

--- a/mobile/lib/services/diagnostics_service.dart
+++ b/mobile/lib/services/diagnostics_service.dart
@@ -7,6 +7,7 @@ import '../models/printer_config.dart';
 import 'lan_discovery_service.dart';
 import 'printer_status_registry.dart';
 import 'supabase_service.dart';
+import 'webcam_fetch_diag.dart';
 
 /// Assembles as much debug context as we can for a bug report - built to make
 /// LAN / pairing failures self-explanatory so we can fix users' issues without
@@ -121,6 +122,9 @@ class DiagnosticsService {
           'tunnel_ready': live.tunnelReady,
           'has_webcam': live.webcamSnapshotUrl != null,
         },
+      // How the webcam fetch loop is doing for this printer - catches the
+      // "everything online but the tile never shows frames" class of report.
+      if (WebcamFetchDiag.report(p.id) case final webcam?) 'webcam': webcam,
       if (poll != null) 'last_poll': poll,
     };
   }

--- a/mobile/lib/services/webcam_fetch_diag.dart
+++ b/mobile/lib/services/webcam_fetch_diag.dart
@@ -1,0 +1,62 @@
+/// In-memory per-printer record of how the webcam fetch loop is doing, for
+/// the in-app bug report. A camera that silently never produces a frame (the
+/// "eternal logo" class of report) is invisible in every other diagnostic -
+/// the poll succeeds, the printer is online, only the frames are missing.
+/// WebcamView records every fetch outcome here; DiagnosticsService reads it
+/// when composing a report. Pure Dart, no Flutter imports, session-only.
+class WebcamFetchDiag {
+  WebcamFetchDiag._();
+
+  static final Map<String, Map<String, Object?>> _byPrinter = {};
+
+  /// Strip the query string - the tunnel snapshot URL carries mg_token, and
+  /// a custom camera URL could carry credentials. Host + path is all a bug
+  /// report needs to tell LAN-direct from relay from a stale gear override.
+  static String redactUrl(String url) {
+    final u = Uri.tryParse(url);
+    if (u == null) return 'unparseable';
+    final port = u.hasPort ? ':${u.port}' : '';
+    return '${u.scheme}://${u.host}$port${u.path}';
+  }
+
+  /// Record the outcome of one fetch attempt. [result] is a short token:
+  /// 'ok', 'empty', 'not-image', 'http 502', 'timeout', 'error'.
+  static void record(
+    String? printerId, {
+    required String url,
+    required bool external,
+    required String result,
+  }) {
+    if (printerId == null) return;
+    final now = DateTime.now().toIso8601String();
+    final entry = _byPrinter.putIfAbsent(printerId, () => {});
+    final ok = result == 'ok';
+    entry['url']      = redactUrl(url);
+    entry['external'] = external;
+    entry['last_attempt'] = now;
+    entry['last_result']  = result;
+    if (ok) {
+      entry['last_success'] = now;
+      entry['consecutive_failures'] = 0;
+    } else {
+      entry['consecutive_failures'] =
+          ((entry['consecutive_failures'] as int?) ?? 0) + 1;
+    }
+    entry['attempts'] = ((entry['attempts'] as int?) ?? 0) + 1;
+  }
+
+  /// Record what the widget is currently showing ('frames' | 'waking' |
+  /// 'placeholder') so the report pairs fetch outcomes with what the user
+  /// actually sees.
+  static void recordShowing(String? printerId, String showing) {
+    if (printerId == null) return;
+    _byPrinter.putIfAbsent(printerId, () => {})['showing'] = showing;
+  }
+
+  /// Snapshot for the bug report, or null if this printer's webcam never
+  /// attempted a fetch this session (e.g. webcam hidden / none configured).
+  static Map<String, Object?>? report(String printerId) {
+    final entry = _byPrinter[printerId];
+    return entry == null ? null : Map.unmodifiable(entry);
+  }
+}

--- a/mobile/lib/widgets/webcam_view.dart
+++ b/mobile/lib/widgets/webcam_view.dart
@@ -7,7 +7,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 
+import '../l10n/app_localizations.dart';
 import '../providers/settings_provider.dart';
+import '../services/webcam_fetch_diag.dart';
+
+/// How long a frameless camera shows the "waking up" spinner before falling
+/// back to the honest plain placeholder. Generous on purpose: a go2rtc
+/// producer wakes in under a second, uv4l has been seen taking 3 s+, and a
+/// remote data-saver cadence only attempts a frame every few seconds - the
+/// window has to survive several slow attempts before giving up.
+const _kWakeWindow = Duration(seconds: 25);
 
 // ── Shared webcam renderer ────────────────────────────────────────────────────
 //
@@ -46,6 +55,10 @@ class WebcamView extends ConsumerStatefulWidget {
   /// 'mainsail' | 'fluidd' | null - shown as a logo while there's no frame yet.
   final String? uiType;
 
+  /// Owning printer's id, for the bug-report webcam diagnostics
+  /// ([WebcamFetchDiag]). Null skips recording (nothing else changes).
+  final String? printerId;
+
   /// How a frame fills its box. The dashboard tile crops to fill
   /// ([BoxFit.cover]); the full-screen camera letterboxes the whole frame
   /// ([BoxFit.contain]).
@@ -66,6 +79,7 @@ class WebcamView extends ConsumerStatefulWidget {
     this.webcamTargetFps = 15,
     this.webcamIsExternal = false,
     this.uiType,
+    this.printerId,
     this.fit = BoxFit.cover,
     this.respectDashboardThrottle = true,
   });
@@ -86,22 +100,69 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   /// pulling frames over the network. Resumes on foreground.
   bool _appPaused = false;
 
+  /// True once the wake window expired without a single frame - build() then
+  /// shows the honest plain placeholder instead of the waking spinner.
+  bool _wakeExpired = false;
+  Timer? _wakeTimer;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _armWakeWindow();
     _loop();
   }
 
   @override
   void dispose() {
+    _wakeTimer?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
   @override
+  void didUpdateWidget(WebcamView old) {
+    super.didUpdateWidget(old);
+    // A changed URL (transport flipped LAN<->tunnel, webcam re-detected) is a
+    // fresh chance at a first frame - restart the wake window.
+    if (old.webcamSnapshotUrl != widget.webcamSnapshotUrl &&
+        _currentBytes == null) {
+      _armWakeWindow();
+    }
+  }
+
+  @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    final wasPaused = _appPaused;
     _appPaused = state != AppLifecycleState.resumed;
+    // The camera slept while we idled in the background (no fetches), so a
+    // return to the foreground is a fresh wake - give it a fresh window.
+    if (wasPaused && !_appPaused && _currentBytes == null) _armWakeWindow();
+  }
+
+  /// (Re)start the wake window. Timer-driven rather than wall-clock so the
+  /// window doesn't burn while the loop idles in the background mid-count,
+  /// and so widget tests can advance it with pump(). No-ops without a URL
+  /// (nothing is being fetched, the plain placeholder is already honest).
+  void _armWakeWindow() {
+    if (_currentBytes != null) return;
+    _wakeTimer?.cancel();
+    final url = widget.webcamSnapshotUrl;
+    if (url == null || url.isEmpty) return;
+    if (_wakeExpired) setState(() => _wakeExpired = false);
+    _wakeTimer = Timer(_kWakeWindow, () {
+      if (mounted && _currentBytes == null) {
+        setState(() => _wakeExpired = true);
+      }
+    });
+  }
+
+  /// First (and every) successful frame: store + repaint, and retire the wake
+  /// window for good - once a camera has produced a frame, failures keep the
+  /// last frame on screen, never a spinner.
+  void _storeFrame(Uint8List bytes) {
+    _wakeTimer?.cancel();
+    if (mounted) setState(() => _currentBytes = bytes);
   }
 
   /// Sequential snapshot-fetch loop. One in flight at a time; the next
@@ -157,6 +218,7 @@ class _WebcamViewState extends ConsumerState<WebcamView>
       await _fetchFrameFromStream(url);
       return;
     }
+    String result = 'error';
     try {
       // Generous 8 s timeout - uv4l-mjpeg has been observed to take 3 s+ per
       // snapshot on first wake. Better to block the loop briefly and get a
@@ -165,10 +227,20 @@ class _WebcamViewState extends ConsumerState<WebcamView>
           await http.get(Uri.parse(url)).timeout(const Duration(seconds: 8));
       if (!mounted) return;
       if (resp.statusCode == 200 && _looksLikeImage(resp.bodyBytes)) {
-        setState(() => _currentBytes = resp.bodyBytes);
+        _storeFrame(resp.bodyBytes);
+        result = 'ok';
+      } else if (resp.statusCode != 200) {
+        result = 'http ${resp.statusCode}';
+      } else {
+        result = resp.bodyBytes.isEmpty ? 'empty' : 'not-image';
       }
+    } on TimeoutException {
+      result = 'timeout';
     } catch (_) {
-      // Network blip / 401 / timeout / parse error - previous frame stays.
+      // Network blip / 401 / parse error - previous frame stays.
+    } finally {
+      WebcamFetchDiag.record(widget.printerId,
+          url: url, external: false, result: result);
     }
   }
 
@@ -179,10 +251,14 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   /// or the Pi's /mg-extcam proxy when remote).
   Future<void> _fetchFrameFromStream(String url) async {
     final client = http.Client();
+    String result = 'error';
     try {
       final req = http.Request('GET', Uri.parse(url));
       final resp = await client.send(req).timeout(const Duration(seconds: 8));
-      if (resp.statusCode != 200) return;
+      if (resp.statusCode != 200) {
+        result = 'http ${resp.statusCode}';
+        return;
+      }
       final ctype = (resp.headers['content-type'] ?? '').toLowerCase();
       final isMultipart = ctype.contains('multipart');
       final buffer = BytesBuilder();
@@ -193,7 +269,8 @@ class _WebcamViewState extends ConsumerState<WebcamView>
         if (isMultipart) {
           final frame = _extractJpeg(buffer.toBytes());
           if (frame != null) {
-            if (mounted) setState(() => _currentBytes = frame);
+            _storeFrame(frame);
+            result = 'ok';
             return; // got a frame - finally closes the still-open stream
           }
         }
@@ -203,14 +280,26 @@ class _WebcamViewState extends ConsumerState<WebcamView>
       // frame): use whatever bytes we collected if they look usable.
       if (!isMultipart) {
         final bytes = buffer.toBytes();
-        if (_looksLikeImage(bytes) && mounted) {
-          setState(() => _currentBytes = bytes);
+        if (_looksLikeImage(bytes)) {
+          _storeFrame(bytes);
+          result = 'ok';
+        } else {
+          // A 200 with zero bytes is the cold-camera-that-couldn't-start
+          // signature (seen in the field on go2rtc with a wedged device) -
+          // keep it distinct from a body that just isn't an image.
+          result = bytes.isEmpty ? 'empty' : 'not-image';
         }
+      } else {
+        result = 'no-frame';
       }
+    } on TimeoutException {
+      result = 'timeout';
     } catch (_) {
-      // Blip / timeout - keep the last frame on screen.
+      // Blip - keep the last frame on screen.
     } finally {
       client.close(); // aborts an MJPEG stream still in flight
+      WebcamFetchDiag.record(widget.printerId,
+          url: url, external: true, result: result);
     }
   }
 
@@ -256,11 +345,22 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   @override
   Widget build(BuildContext context) {
     final bytes = _currentBytes;
+    final url = widget.webcamSnapshotUrl;
+    // Waking = we're actively fetching but nothing has landed yet and the
+    // window hasn't given up. An unset URL skips straight to the placeholder
+    // - there's nothing to wake.
+    final waking =
+        bytes == null && url != null && url.isNotEmpty && !_wakeExpired;
+    WebcamFetchDiag.recordShowing(widget.printerId,
+        bytes != null ? 'frames' : (waking ? 'waking' : 'placeholder'));
     Widget image = bytes != null
         ? Image.memory(bytes, fit: widget.fit, gaplessPlayback: true)
         : Container(
             color: Colors.black54,
-            child: Center(child: _WebcamPlaceholder(uiType: widget.uiType)),
+            child: Center(
+                child: waking
+                    ? const _WebcamWaking()
+                    : _WebcamPlaceholder(uiType: widget.uiType)),
           );
 
     // Apply the webcam display transforms Mainsail has configured, so the image
@@ -287,6 +387,44 @@ class _WebcamViewState extends ConsumerState<WebcamView>
     }
 
     return image;
+  }
+}
+
+// ── Waking spinner ────────────────────────────────────────────────────────────
+//
+// Shown instead of the placeholder while the first frame is still being
+// chased and the wake window hasn't expired. On-demand cameras (go2rtc)
+// genuinely take a moment to start their producer on the first request - an
+// honest "waking up" beats a logo that reads as broken.
+
+class _WebcamWaking extends StatelessWidget {
+  const _WebcamWaking();
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(
+          width: 26,
+          height: 26,
+          child: CircularProgressIndicator(
+            strokeWidth: 2.5,
+            color: Colors.white38,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Text(
+            l.webcamWakingUp,
+            style: const TextStyle(color: Colors.white54, fontSize: 12),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/mobile/test/webcam_wake_test.dart
+++ b/mobile/test/webcam_wake_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:moongate/l10n/app_localizations.dart';
+import 'package:moongate/widgets/webcam_view.dart';
+
+// The wake-window state machine: spinner while the first frame is still being
+// chased, honest placeholder after the window expires, reset on a URL change.
+// In the test environment every HTTP request answers 400 (flutter_test's
+// default HttpOverrides), so no frame ever arrives - exactly the dead-camera
+// scenario the spinner exists for.
+
+Widget _host(Widget child) => ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: SizedBox(width: 200, height: 200, child: child)),
+      ),
+    );
+
+Future<void> _teardown(WidgetTester tester) async {
+  // Dispose the view, then drain the fetch loop's pending delay so the test
+  // ends with no timers outstanding.
+  await tester.pumpWidget(_host(const SizedBox()));
+  await tester.pump(const Duration(seconds: 40));
+}
+
+void main() {
+  testWidgets('waking spinner shows, then gives way to the placeholder',
+      (tester) async {
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl: 'http://192.0.2.1/snapshot',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Camera waking up…'), findsOneWidget);
+
+    // Ride past the wake window - the spinner must yield to the plain logo.
+    await tester.pump(const Duration(seconds: 30));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('Camera waking up…'), findsNothing);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('no URL means no spinner - straight to the placeholder',
+      (tester) async {
+    await tester.pumpWidget(_host(const WebcamView(uiType: 'mainsail')));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('Camera waking up…'), findsNothing);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('a changed URL re-arms the wake window after expiry',
+      (tester) async {
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl: 'http://192.0.2.1/snapshot',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 30));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    // Transport flips (e.g. LAN -> tunnel): a fresh URL is a fresh chance.
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl: 'http://192.0.2.2/snapshot',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await _teardown(tester);
+  });
+}


### PR DESCRIPTION
## What will this PR change?

While a printer's camera has not yet produced a frame, the webcam box now shows a small spinner with "Camera waking up" instead of the silent logo. If a whole 25 second window passes with no frame, the plain logo returns, so a genuinely dead camera still looks honestly dead rather than forever loading. The in-app bug report now also includes, per printer, what the camera fetch loop is actually doing: which URL it is using (with tokens stripped), the last result, how many attempts have failed in a row, and what the tile is currently showing.

## Why?

On-demand cameras (go2rtc) take a moment to start their producer on the first request, and until now that moment looked identical to a broken camera: just the logo. Worse, a camera that never frames was invisible in every diagnostic we collect, the poll succeeds, the printer shows online, only the frames are missing. The recent go2rtc support case took a whole evening of live debugging to see what one bug report field would have told us instantly.

## How?

- New wake window state in WebcamView: spinner while the first frame is chased, plain placeholder after 25 s. The window re-arms when the snapshot URL changes (for example the transport flips between LAN and tunnel) or when the app returns from the background with no frame yet. Once a camera has ever produced a frame the spinner never returns, failures keep the last frame as before.
- New WebcamFetchDiag registry (pure Dart, services layer) records every fetch outcome per printer; DiagnosticsService adds it to the bug report. URLs are stripped to scheme, host and path, no query strings, so no mg_token ever lands in a report.
- New l10n key webcamWakingUp in all 9 languages.

## Testing

- flutter analyze clean, all 29 tests pass (3 new widget tests cover the wake window: spinner shows, expires to placeholder, re-arms on URL change).
- DEVICE PASS DONE on the S24 (release build, marker-verified, cert 8878da71, installed in place): stopped go2rtc on the Micron+ to fake a dead camera, cold-started the app. Tile showed the spinner with "Camera waking up" while the printer itself stayed Idle/Ready/Local; after the window it fell back to the plain logo; restarting go2rtc brought frames back automatically. The V-Minion tile was unaffected throughout.

No version bump here, this rides the next release with #232 and #230. Suggest merging with the CI skip token like #232.

PEEKYPAUL 22/07/2026