### PR TITLE
Authproxy: log every non-frame mg-extcam outcome (plugin 0.6.18)

### DIFF
--- a/klipper-plugin/moongate_authproxy.py
+++ b/klipper-plugin/moongate_authproxy.py
@@ -365,14 +365,38 @@ def _extcam_target_ok(raw: str) -> Optional[str]:
     return raw
 
 
+def _extcam_log_target(raw: str) -> str:
+    """Loggable form of a client-supplied camera URL: scheme + host + path,
+    query dropped (a camera URL can carry credentials, and our own request
+    URL carries mg_token - neither belongs in the journal)."""
+    if not raw:
+        return "(empty)"
+    try:
+        p = urlsplit(raw)
+    except ValueError:
+        return "(unparseable)"
+    return f"{p.scheme or '?'}://{p.netloc or '?'}{p.path or ''}"
+
+
 async def _proxy_extcam(request: web.Request) -> web.StreamResponse:
     """Relay a snapshot / MJPEG frame from a LAN camera the client points us
     at. Auth was already enforced by _authorize. The app reads one frame then
     disconnects; the byte cap is a backstop against a target that streams
     forever, and the content-type gate stops us relaying arbitrary content
-    from whatever happens to answer on that host:port."""
-    target = _extcam_target_ok(request.query.get("u", ""))
+    from whatever happens to answer on that host:port.
+
+    Every NON-frame outcome logs one terse line (the happy path stays
+    silent - the /run-log lesson). The app swallows relay failures by design,
+    so without these lines a remote camera that never frames is invisible at
+    every layer; with them, `journalctl -u moongate-authproxy` names the
+    failing hop: gate reject (a https/hostname URL in the tile gear), an
+    upstream error, or a 200 that carried no image (the cold-camera-that-
+    couldn't-start signature)."""
+    raw = request.query.get("u", "")
+    target = _extcam_target_ok(raw)
     if target is None:
+        logger.info("extcam reject (not plain-http private-IPv4): %s",
+                    _extcam_log_target(raw))
         return web.Response(status=400, text="bad target\n",
                             headers={"Cache-Control": "no-store"})
 
@@ -386,12 +410,18 @@ async def _proxy_extcam(request: web.Request) -> web.StreamResponse:
             "GET", target, headers=headers, allow_redirects=False,
         ) as upstream:
             if upstream.status != 200:
+                logger.info("extcam %s -> upstream %s",
+                            _extcam_log_target(target), upstream.status)
                 return web.Response(status=502, text="camera error\n")
             ctype = upstream.headers.get("Content-Type", "")
             low = ctype.lower()
             if not (low.startswith("image/")
                     or "multipart/x-mixed-replace" in low
                     or low.startswith("application/octet-stream")):
+                # A 200 with an empty/none content-type is how a camera
+                # backend that failed to start its producer answers.
+                logger.info("extcam %s -> 200 but content-type %r",
+                            _extcam_log_target(target), ctype[:60])
                 return web.Response(status=415, text="unsupported\n")
 
             response = web.StreamResponse(
@@ -408,6 +438,11 @@ async def _proxy_extcam(request: web.Request) -> web.StreamResponse:
                 sent += len(chunk)
                 if sent >= EXTCAM_MAX_BYTES:
                     break
+            if sent == 0:
+                # Image content-type but not one byte of body - the upstream
+                # accepted the request and produced nothing.
+                logger.info("extcam %s -> 200 with 0 bytes",
+                            _extcam_log_target(target))
             await response.write_eof()
             return response
     except asyncio.CancelledError:
@@ -416,7 +451,8 @@ async def _proxy_extcam(request: web.Request) -> web.StreamResponse:
         # App got its frame and closed the connection - normal.
         return web.Response(status=499, text="")
     except Exception as exc:
-        logger.warning("extcam %s failed: %s", target, exc)
+        logger.warning("extcam %s failed: %s",
+                       _extcam_log_target(target), exc)
         return web.Response(status=502, text="camera unreachable\n")
 
 

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -82,7 +82,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.17"
+MOONGATE_PLUGIN_VERSION = "0.6.18"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What will this PR change?

The Pi's auth proxy now writes one short journal line whenever the external-camera relay fails to deliver a frame: the target was rejected by the safety gate (for example an https or hostname URL set in the tile's gear override), the camera answered with an error, the camera answered 200 but with a non-image content type, or the camera answered 200 with an empty body. Successful frames stay silent.

## Why?

The app deliberately swallows camera relay failures (a broken frame must never break the tile), which means a remote camera that never produces a frame is invisible at every layer. The recent field case needed tcpdump on the Pi to see what was happening. After this, one journalctl -u moongate-authproxy command names the failing hop. The empty-200 line in particular is the exact signature of a camera backend that could not start its device.

## How?

- Four logger.info lines in the /mg-extcam handler, one per non-frame outcome, plus the existing exception warning now redacts its URL.
- Logged URLs are stripped to scheme, host and path. No query strings, so neither mg_token nor any camera credentials can land in the journal (the 0.6.14 lesson).
- The happy path logs nothing, steady-state journal volume stays zero.
- Plugin version 0.6.18. The app's kCurrentPluginVersion stays at 0.6.16 on purpose: this is observability only, no fleet update badge warranted. Fleets pick it up on their normal update.

## Testing

- python syntax check on both files, klipper-plugin/tests/test_lan_only_no_deps.py passes.
- Will deliver to the V-Minion via the normal Moonraker update after merge and verify the lines appear (its go2rtc camera plus real tunnel makes a live test rig).

No app change, no version bump. Suggest merging with the CI skip token.

PEEKYPAUL 22/07/2026