### PR TITLE
Fix: print time remaining now matches Mainsail (slicer + filament blend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install ruff
-        run: pip install ruff
+        # Pinned: 0.16.0 (released ~2026-07-23) turned on stricter defaults
+        # that flag 92 pre-existing lines in the (unchanged, shipped) plugin.
+        # Lift the pin only together with a deliberate cleanup to its rules.
+        run: pip install "ruff==0.15.22"
 
       - name: Lint klipper-plugin
         run: ruff check klipper-plugin/

--- a/mobile/lib/features/dashboard/printer_tile.dart
+++ b/mobile/lib/features/dashboard/printer_tile.dart
@@ -450,16 +450,20 @@ class _PrinterTileState extends ConsumerState<PrinterTile>
   }
 
   /// Seconds left on the running print for the tile's time chip, or null when
-  /// the chip is hidden: the setting is off, nothing is printing, or it's too
-  /// early for the shared elapsed ÷ progress estimate ([printRemainingSeconds],
-  /// the notification card's maths) to be meaningful. Watched providers make
-  /// the chip appear/disappear live when the drawer setting changes.
+  /// the chip is hidden: the setting is off, nothing is printing, or no
+  /// estimate source has usable inputs yet ([printRemainingSeconds], the
+  /// notification card's maths - a Mainsail-style blend of file, filament and
+  /// slicer estimates). Watched providers make the chip appear/disappear live
+  /// when the drawer setting changes.
   double? get _etaRemaining {
     if (!ref.watch(tileEtaProvider)) return null;
     return printRemainingSeconds(
-      state:            _status.state,
-      progress:         _status.progress,
-      printDurationSec: _status.printDurationSec,
+      state:             _status.state,
+      progress:          _status.progress,
+      printDurationSec:  _status.printDurationSec,
+      filamentUsedMm:    _status.filamentUsedMm,
+      filamentTotalMm:   _status.filamentTotalMm,
+      slicerEstimateSec: _status.slicerEstimateSec,
     );
   }
 

--- a/mobile/lib/models/printer_config.dart
+++ b/mobile/lib/models/printer_config.dart
@@ -386,8 +386,18 @@ class PrinterStatus {
   /// Klipper's `print_stats.print_duration` - seconds of actual printing on
   /// the current job (excludes heat-up/pause time). 0 when idle or unknown.
   /// Feeds the tile's time-remaining chip via [printRemainingSeconds], the
-  /// same elapsed ÷ progress estimate the notification card shows.
+  /// same Mainsail-style estimate the notification card shows.
   final double printDurationSec;
+
+  /// Klipper's `print_stats.filament_used` (mm) plus the printing file's
+  /// `filament_total` / `estimated_time` from Moonraker metadata - the extra
+  /// inputs [printRemainingSeconds] blends, Mainsail-style, so the time chip
+  /// stops drifting an hour from Mainsail early in a print. Null when the
+  /// metadata isn't known (yet); the estimate then falls back to elapsed ÷
+  /// progress alone, exactly the pre-v0.9.56 behaviour.
+  final double? filamentUsedMm;
+  final double? filamentTotalMm;
+  final double? slicerEstimateSec;
 
   final double hotendTemp;
   final double hotendTarget;
@@ -457,6 +467,9 @@ class PrinterStatus {
     required this.state,
     required this.progress,
     this.printDurationSec = 0,
+    this.filamentUsedMm,
+    this.filamentTotalMm,
+    this.slicerEstimateSec,
     required this.hotendTemp,
     required this.hotendTarget,
     required this.bedTemp,
@@ -489,6 +502,9 @@ class PrinterStatus {
     String? state,
     double? progress,
     double? printDurationSec,
+    double? filamentUsedMm,
+    double? filamentTotalMm,
+    double? slicerEstimateSec,
     double? hotendTemp,
     double? hotendTarget,
     double? bedTemp,
@@ -514,6 +530,9 @@ class PrinterStatus {
       state:            state ?? this.state,
       progress:         progress ?? this.progress,
       printDurationSec: printDurationSec ?? this.printDurationSec,
+      filamentUsedMm:   filamentUsedMm ?? this.filamentUsedMm,
+      filamentTotalMm:  filamentTotalMm ?? this.filamentTotalMm,
+      slicerEstimateSec: slicerEstimateSec ?? this.slicerEstimateSec,
       hotendTemp:       hotendTemp ?? this.hotendTemp,
       hotendTarget:     hotendTarget ?? this.hotendTarget,
       bedTemp:          bedTemp ?? this.bedTemp,

--- a/mobile/lib/services/print_notification_service.dart
+++ b/mobile/lib/services/print_notification_service.dart
@@ -744,6 +744,9 @@ class _PrintTaskHandler extends TaskHandler {
         state:            state,
         progress:         progress,
         printDurationSec: (printStats['print_duration'] as num?)?.toDouble() ?? 0,
+        filamentUsedMm:   (printStats['filament_used']  as num?)?.toDouble(),
+        filamentTotalMm:  offsets?.filamentTotalMm,
+        slicerEstimateSec: offsets?.estimatedTimeSec,
         hotend:           (extruder['temperature'] as num?)?.toDouble() ?? 0,
         hotendTarget:     (extruder['target']      as num?)?.toDouble() ?? 0,
         bed:              (bed['temperature']      as num?)?.toDouble() ?? 0,
@@ -798,6 +801,8 @@ class _PrintTaskHandler extends TaskHandler {
         filename,
         (result?['gcode_start_byte'] as num?)?.toInt(),
         (result?['gcode_end_byte']   as num?)?.toInt(),
+        (result?['estimated_time']   as num?)?.toDouble(),
+        (result?['filament_total']   as num?)?.toDouble(),
       );
       _meta[printerId] = m;
       return m;
@@ -974,9 +979,12 @@ class _PrintTaskHandler extends TaskHandler {
   /// [printRemainingSeconds], which the dashboard tile's ETA chip uses too so
   /// the two surfaces always agree.
   double? _remainingSeconds(_Poll s) => printRemainingSeconds(
-        state:            s.state,
-        progress:         s.progress,
-        printDurationSec: s.printDurationSec,
+        state:             s.state,
+        progress:          s.progress,
+        printDurationSec:  s.printDurationSec,
+        filamentUsedMm:    s.filamentUsedMm,
+        filamentTotalMm:   s.filamentTotalMm,
+        slicerEstimateSec: s.slicerEstimateSec,
       );
 
   /// "1h05m" / "14m" - how much longer the print has to run.
@@ -1266,13 +1274,18 @@ class _PrintTaskHandler extends TaskHandler {
 /// Lifecycle of a printer's "Print jobs" card.
 enum _CardPhase { none, active, done }
 
-/// The gcode body byte offsets for one printer's current file (from Moonraker
-/// metadata), used to compute Mainsail-style file-relative progress.
+/// One printer's current-file metadata (from Moonraker): the gcode body byte
+/// offsets for Mainsail-style file-relative progress, plus the slicer's
+/// estimated_time / filament_total for the Mainsail-style remaining-time blend
+/// ([printRemainingSeconds]).
 class _MetaOffsets {
-  final String filename;
-  final int? startByte;
-  final int? endByte;
-  const _MetaOffsets(this.filename, this.startByte, this.endByte);
+  final String  filename;
+  final int?    startByte;
+  final int?    endByte;
+  final double? estimatedTimeSec;
+  final double? filamentTotalMm;
+  const _MetaOffsets(this.filename, this.startByte, this.endByte,
+      this.estimatedTimeSec, this.filamentTotalMm);
 }
 
 /// A single printer's parsed status - just what the notification needs.
@@ -1280,6 +1293,15 @@ class _Poll {
   final String state;
   final double progress;        // 0..1
   final double printDurationSec;
+
+  /// Extra inputs for the Mainsail-style remaining-time blend - filament used
+  /// (print_stats) against the file's filament_total, and the slicer's own
+  /// estimated_time (both file metadata). Null when unknown; the estimate
+  /// falls back to elapsed ÷ progress alone.
+  final double? filamentUsedMm;
+  final double? filamentTotalMm;
+  final double? slicerEstimateSec;
+
   final double hotend;
   final double hotendTarget;
   final double bed;
@@ -1300,6 +1322,9 @@ class _Poll {
     required this.state,
     required this.progress,
     required this.printDurationSec,
+    this.filamentUsedMm,
+    this.filamentTotalMm,
+    this.slicerEstimateSec,
     required this.hotend,
     required this.hotendTarget,
     required this.bed,

--- a/mobile/lib/services/print_progress.dart
+++ b/mobile/lib/services/print_progress.dart
@@ -49,24 +49,72 @@ double computePrintProgress({
   return 0.0;
 }
 
-/// Print time remaining (seconds), estimated from elapsed ÷ progress with no
-/// extra metadata call - the estimate the notification card has always shown,
-/// now shared with the dashboard tile's ETA chip.
+/// Print time remaining (seconds), following Mainsail's ETA recipe so the chip
+/// lands on the numbers users compare it against: the average of every
+/// estimate source with usable inputs -
+///   file     - elapsed ÷ file-relative progress (the classic extrapolation,
+///              and still the sole source when no metadata is known)
+///   filament - elapsed ÷ filament fraction (print_stats.filament_used over
+///              the file metadata's filament_total)
+///   slicer   - the slicer's own total (file metadata estimated_time) minus
+///              elapsed
+/// (mainsail-crew/mainsail src/store/printer/getters.ts getEstimatedTimeETA,
+/// whose default averages exactly these three.)
+///
+/// The two extrapolating sources only join once they have enough signal to
+/// mean anything (fraction ≥ 2%, ≥ 30s elapsed - below that the division
+/// produces garbage like "~43h"); the slicer total is trustworthy from the
+/// first second. The blend is what keeps the early-print number sane: pure
+/// file extrapolation read ~4h against Mainsail's ~3h at 5% of an ABS print
+/// whose opening minutes are brim + solid bottom layers (2026-07-25 user
+/// report - both screenshots are fixtures in print_progress_test.dart).
 ///
 /// Null when there's nothing meaningful to show:
 ///   - not actively printing (a paused print's elapsed clock is frozen, so its
 ///     estimate silently goes stale - hide rather than mislead);
-///   - too early to extrapolate (progress < 2% or < 30s elapsed - the maths
-///     divides by a near-zero progress and produces garbage like "~43h");
+///   - no source has usable inputs yet;
 ///   - implausibly long (> 100h - a corrupt duration/progress pair).
 double? printRemainingSeconds({
   required String state,
   required double progress,
   required double printDurationSec,
+  double? filamentUsedMm,
+  double? filamentTotalMm,
+  double? slicerEstimateSec,
 }) {
   if (state != 'printing') return null;
-  if (progress < 0.02 || printDurationSec < 30) return null;
-  final remaining = printDurationSec * (1 - progress) / progress;
+
+  final estimates = <double>[];
+
+  // file: elapsed ÷ byte-position progress.
+  if (progress >= 0.02 && printDurationSec >= 30) {
+    estimates.add(printDurationSec * (1 - progress) / progress);
+  }
+
+  // filament: elapsed ÷ consumed-filament fraction. A bottom-heavy part
+  // (solid base, brim) has this fraction running well ahead of the byte
+  // position early in the print, which is precisely the correction that
+  // pulls Mainsail's average down to a realistic figure.
+  if (filamentUsedMm != null &&
+      filamentTotalMm != null &&
+      filamentTotalMm > 0 &&
+      printDurationSec >= 30) {
+    final fraction = filamentUsedMm / filamentTotalMm;
+    if (fraction >= 0.02 && fraction <= 1) {
+      estimates.add(printDurationSec * (1 - fraction) / fraction);
+    }
+  }
+
+  // slicer: its own total minus elapsed. Goes negative once a print overruns
+  // the slicer's guess - drop it then, as Mainsail's average does.
+  if (slicerEstimateSec != null && slicerEstimateSec > 0) {
+    final slicerRemaining = slicerEstimateSec - printDurationSec;
+    if (slicerRemaining > 0) estimates.add(slicerRemaining);
+  }
+
+  if (estimates.isEmpty) return null;
+  final remaining =
+      estimates.reduce((a, b) => a + b) / estimates.length;
   if (remaining <= 0 || remaining > 100 * 3600) return null;
   return remaining;
 }

--- a/mobile/lib/services/printer_status_service.dart
+++ b/mobile/lib/services/printer_status_service.dart
@@ -90,12 +90,17 @@ class PrinterStatusService {
   /// bare `extruder` (T0) is handled separately.
   static final _extruderNumRe = RegExp(r'^extruder\d+$');
 
-  // ── File-metadata cache for accurate progress ────────────────────────────
+  // ── File-metadata cache for accurate progress + ETA ──────────────────────
   // The slicer's gcode body byte offsets, cached per filename. They drive the
   // Mainsail-matching "file position (relative)" progress in _parseStatus -
   // (file_position − start) / (end − start) - via [computePrintProgress].
+  // The same metadata reply carries the slicer's estimated_time and
+  // filament_total, which feed the Mainsail-style blend in
+  // [printRemainingSeconds] (the tile's time chip).
   int?    _gcodeStartByte;
   int?    _gcodeEndByte;
+  double? _slicerEstimateSec;
+  double? _filamentTotalMm;
   String? _metadataFilename;
 
   // ── LAN-first state ──────────────────────────────────────────────────────
@@ -728,9 +733,11 @@ class PrinterStatusService {
       {required bool isLan}) async {
     if (filename == null || filename.isEmpty) return;
     if (filename == _metadataFilename) return;
-    _gcodeStartByte   = null;
-    _gcodeEndByte     = null;
-    _metadataFilename = null;
+    _gcodeStartByte    = null;
+    _gcodeEndByte      = null;
+    _slicerEstimateSec = null;
+    _filamentTotalMm   = null;
+    _metadataFilename  = null;
     try {
       final encoded  = Uri.encodeComponent(filename);
       final uri      = Uri.parse(
@@ -744,6 +751,11 @@ class PrinterStatusService {
             jsonDecode(response.body)['result'] as Map<String, dynamic>?;
         final start = (result?['gcode_start_byte'] as num?)?.toInt();
         final end   = (result?['gcode_end_byte']   as num?)?.toInt();
+        // The slicer's own numbers for the ETA blend - kept even when the
+        // offsets are missing (progress just falls back, the chip still gains
+        // the slicer estimate).
+        _slicerEstimateSec = (result?['estimated_time'] as num?)?.toDouble();
+        _filamentTotalMm   = (result?['filament_total'] as num?)?.toDouble();
         // Only cache (and stop re-fetching) once we have a usable range; a file
         // Moonraker is still analysing may omit the offsets for a moment.
         if (start != null && end != null && end > start) {
@@ -1211,6 +1223,9 @@ class PrinterStatusService {
       state:              state,
       progress:           progress,
       printDurationSec:   (printStats['print_duration']  as num?)?.toDouble() ?? 0,
+      filamentUsedMm:     (printStats['filament_used']   as num?)?.toDouble(),
+      filamentTotalMm:    _filamentTotalMm,
+      slicerEstimateSec:  _slicerEstimateSec,
       hotendTemp:         (extruder['temperature']       as num?)?.toDouble() ?? 0,
       hotendTarget:       (extruder['target']            as num?)?.toDouble() ?? 0,
       bedTemp:            (heaterBed['temperature']      as num?)?.toDouble() ?? 0,

--- a/mobile/test/print_progress_test.dart
+++ b/mobile/test/print_progress_test.dart
@@ -83,13 +83,14 @@ void main() {
     });
   });
 
-  // The elapsed ÷ progress estimate behind the notification card's remaining/
-  // ETA line and (v0.9.53) the dashboard tile's time chip. Locking the gates
-  // here keeps the two surfaces in agreement forever.
+  // The Mainsail-style remaining-time blend behind the notification card's
+  // remaining/ETA line and (v0.9.53) the dashboard tile's time chip. Locking
+  // the gates here keeps the two surfaces in agreement forever.
   group('printRemainingSeconds', () {
-    test('38% into a print, 26 min elapsed → ~42 min left', () {
-      // The user-report screenshot: Mainsail showed total 0:26:11 elapsed at
-      // 38%; elapsed × (1-p)/p = 1571 × 0.62/0.38 ≈ 2563s ≈ 42.7 min.
+    test('38% into a print, 26 min elapsed → ~42 min left (no metadata)', () {
+      // The v0.9.53 user-report screenshot: Mainsail showed total 0:26:11
+      // elapsed at 38%; with no metadata the estimate stays the classic
+      // elapsed × (1-p)/p = 1571 × 0.62/0.38 ≈ 2563s ≈ 42.7 min.
       final r = printRemainingSeconds(
         state: 'printing',
         progress: 0.38,
@@ -97,6 +98,84 @@ void main() {
       );
       expect(r, isNotNull);
       expect(r!, closeTo(2563, 1));
+    });
+
+    // The 2026-07-25 user report: a bottom-heavy ABS-CF box (solid base +
+    // brim), slicer total 3:02:53 (10973s). Early on, byte-position progress
+    // trails the filament fraction badly, so the old file-only extrapolation
+    // read ~4h07m while Mainsail showed ~2h58m. Inputs below are solved from
+    // the two screenshots against Mainsail's default ETA (the average of the
+    // file / filament / slicer estimates) - the blend must land on Mainsail's
+    // displayed ETA, minute-close.
+    test('Mainsail parity: 11:37 snapshot → ~2h57m, not the old ~4h07m', () {
+      final r = printRemainingSeconds(
+        state:             'printing',
+        progress:          0.045,   // file-relative, layer 11/325
+        printDurationSec:  888,     // Total 0:14:48
+        filamentUsedMm:    2750,    // Filament 2.75 m
+        filamentTotalMm:   12050,
+        slicerEstimateSec: 10973,
+      );
+      expect(r, isNotNull);
+      // file 18845 + filament 3003 + slicer 10085, averaged. Mainsail's
+      // displayed ETA 14:35 ⇒ 10680s remaining - within a minute.
+      expect(r!, closeTo(10644, 60));
+    });
+
+    test('Mainsail parity: 11:40 snapshot → finish 14:30 on the dot', () {
+      final r = printRemainingSeconds(
+        state:             'printing',
+        progress:          0.0549,
+        printDurationSec:  1039,    // Total 0:17:19
+        filamentUsedMm:    3260,    // Filament 3.26 m
+        filamentTotalMm:   12050,
+        slicerEstimateSec: 10973,
+      );
+      expect(r, isNotNull);
+      // 10207s ≈ 2h50m from 11:40 ⇒ 14:30, exactly Mainsail's displayed ETA.
+      expect(r!, closeTo(10207, 60));
+    });
+
+    test('slicer estimate alone carries the first seconds of a print', () {
+      // Too early for either extrapolation (progress 0.5%, 10s elapsed), but
+      // the slicer total is valid from the first second - the chip no longer
+      // hides for the opening minutes when metadata is known.
+      final r = printRemainingSeconds(
+        state:             'printing',
+        progress:          0.005,
+        printDurationSec:  10,
+        slicerEstimateSec: 10973,
+      );
+      expect(r, isNotNull);
+      expect(r!, closeTo(10963, 1));
+    });
+
+    test('an overrun print drops the (negative) slicer estimate', () {
+      // 90% done but already past the slicer's total: slicer remaining would
+      // be negative, so only the file extrapolation counts.
+      final r = printRemainingSeconds(
+        state:             'printing',
+        progress:          0.9,
+        printDurationSec:  20000,
+        slicerEstimateSec: 10973,
+      );
+      expect(r, isNotNull);
+      expect(r!, closeTo(2222, 1));
+    });
+
+    test('garbage filament inputs are ignored, not averaged', () {
+      // total of 0 and used > total must both fall out of the blend.
+      for (final (used, total) in [(100.0, 0.0), (1200.0, 1000.0)]) {
+        final r = printRemainingSeconds(
+          state:            'printing',
+          progress:         0.5,
+          printDurationSec: 1000,
+          filamentUsedMm:   used,
+          filamentTotalMm:  total,
+        );
+        expect(r, isNotNull);
+        expect(r!, closeTo(1000, 1)); // file-only
+      }
     });
 
     test('null unless actively printing (paused estimate is frozen)', () {


### PR DESCRIPTION
## What will this PR change?

The dashboard time chip (and the notification card's remaining/ETA line) will stop reading an hour or more longer than Mainsail early in a print. It now computes remaining time the same way Mainsail does, so the number on the tile lands within a minute or two of the one users see in Mainsail itself.

## Why

A user compared the two side by side (Russian-locale screenshots, 2026-07-25): 15 minutes into a ~3h ABS-CF print, Mainsail said ~2h58m remaining (ETA 14:35) while our chip said ~4h07m; three minutes later Mainsail's ETA was 14:30 and our finish clock said 15:29.

Our estimate was pure extrapolation: elapsed time divided by progress. Early in a print that is at its worst, because the opening minutes are brim and slow solid bottom layers, and the byte-position progress badly trails how much work is actually done on a bottom-heavy part. The maths assumed the whole print runs at that crawl.

Mainsail instead averages three estimates: the same extrapolation, a filament-based one (filament used over the file's total), and the slicer's own time estimate for the file. The filament and slicer sources do not inherit the slow-start bias, which is what keeps its number sane.

## How

Every input Mainsail uses was already in our hands:

- `filament_used` is in the `print_stats` we poll every tick.
- `estimated_time` and `filament_total` are in the `/server/files/metadata` reply both the dashboard service and the notification isolate already fetch (once per print) for the gcode byte offsets. We were parsing the two offsets and discarding the rest.

`printRemainingSeconds` (the single shared maths for tile + notification, so they can never disagree) now averages whichever sources have usable inputs, mirroring `getEstimatedTimeETA` in mainsail-crew/mainsail:

- file: elapsed / progress, still gated at 2% progress + 30s elapsed (below that the division produces garbage)
- filament: elapsed / filament fraction, same gates
- slicer: the slicer's total minus elapsed; dropped once it goes negative on an overrunning print, as Mainsail does

Two behaviour notes:
- With metadata known, the chip now shows from the first seconds of a print (slicer estimate alone) instead of hiding below 2% progress.
- With no metadata at all (older setups, failed fetch, file with no slicer estimate) the estimate is exactly the old one - nothing regresses.

App-only and pure Dart, so Android and iPhone get it together; no plugin change, no extra network calls.

## Testing

- The user's two screenshots are unit-test fixtures now: the blend reproduces Mainsail's displayed ETA within a minute at 11:37 and to the minute at 14:30 for the 11:40 snapshot, where the old formula was ~65 minutes off.
- Six new tests (parity x2, slicer-only early print, overrun drop, garbage filament guards); all pre-existing tests untouched and passing - 34/34, `flutter analyze` clean.
- Worth a real-device glance on the next live print: chip appears early with a sane number and tracks Mainsail.

No version bump - rides the next release (0.9.56) with the other four merged-unreleased PRs; merge with the CI-skip token in the merge message like those. Changelog for all five comes in the release PR.

## Rides along: CI ruff pin

The plugin-lint check went red on this PR for reasons nothing to do with it: the job installs ruff unpinned, and ruff 0.16.0 (released this week) tightened its defaults and now flags 92 pre-existing lines in the unchanged plugin. The same job passed on Tuesday with 0.15.22. One line in ci.yml pins ruff to 0.15.22, same medicine as the device_info_plus pin in #173. Unpin whenever we feel like doing a deliberate lint cleanup, no urgency.

PEEKYPAUL 25/07/2026

