### PR TITLE
Docs: channel-aware sweep for the store launch (the rest of #243)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,7 +81,7 @@ Debug builds are unsigned, slower, and have hot-reload. Press `r` in the termina
 
 ### Release build (production-equivalent)
 
-The app builds in two **distribution flavors** (added in #178 for the Play Store): `github` (the sideloaded APK for GitHub Releases + KIAUH, which keeps the in-app self-updater) and `play` (the App Bundle for Google Play, which ships **without** the self-updater or `REQUEST_INSTALL_PACKAGES`). Because flavors now exist, `--flavor` is **required** - a bare `flutter build apk` errors with "this app has flavors". Details in [`docs/design/play-flavor-plan.md`](docs/design/play-flavor-plan.md).
+The app builds in two **distribution flavors** (added in #178 for the Play Store): `github` (the sideloaded APK for GitHub Releases + KIAUH - the **early-access channel** - which keeps the in-app self-updater) and `play` (the App Bundle for Google Play - the **stable channel**, live in production since v0.9.57 - which ships **without** the self-updater or `REQUEST_INSTALL_PACKAGES`). Because flavors now exist, `--flavor` is **required** - a bare `flutter build apk` errors with "this app has flavors". Details in [`docs/design/play-flavor-plan.md`](docs/design/play-flavor-plan.md).
 
 ```bash
 cd mobile

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -233,7 +233,7 @@ The auth proxy is even more constrained - it doesn't talk to Klipper at all, it 
 
 ## In-app updater (v0.9.17)
 
-> Applies to the **GitHub / KIAUH sideload build** only. As of #178 the Google Play build is a separate flavor that ships **without** the self-updater and **without** `REQUEST_INSTALL_PACKAGES` - Google Play delivers its updates instead.
+> Applies to the **GitHub / KIAUH early-access (sideload) build** only. As of #178 the Google Play build is a separate flavor that ships **without** the self-updater and **without** `REQUEST_INSTALL_PACKAGES` - Google Play delivers its updates instead, and the App Store does the same for the iPhone build.
 
 The update banner can download and install a new version **without leaving the app** (Android only, sideload build). That adds the `REQUEST_INSTALL_PACKAGES` permission and a `FileProvider`, so it's worth stating what it can and can't do:
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -302,6 +302,8 @@ After an emergency stop the machine is **shut down**, not just idle - so the tri
 
 ## In-app update didn't install, or asks for a permission
 
+> **Early-access APK build only.** The App Store and Google Play builds update through their store and never show this flow.
+
 Tapping **Update** downloads the new version inside the app, then hands it to Android's package installer. The **first** time, Android asks you to allow Moongate to **install unknown apps** - expected for an app installed outside the Play Store. Grant it (the system jumps you straight to the toggle), come back, and tap **Update** again; after that it's a single tap plus the standard install confirmation.
 
 If the download or install fails for any reason, Moongate **falls back to opening the APK in your browser** - finish there and open it to install. Either route installs **in place** over your existing app (same signing key), so your printers and settings are kept.

--- a/docs/managing-moongate.md
+++ b/docs/managing-moongate.md
@@ -6,11 +6,15 @@ Moongate has two parts - the **app** on your phone and the **plugin** on your Pi
 
 ## Updating the app
 
-When a new version is out, the app shows an **update banner** on launch. Tap **Update** and Moongate downloads the new version **inside the app** (with a progress bar), then hands it to Android's installer - just confirm the install. It installs **in place** (same signing key, so it's an upgrade, not a fresh install) and your printers and settings are kept. The first time, Android may ask you to let Moongate **install unknown apps** - allow it once, and after that an update is a single tap plus the install confirmation.
+How the app updates depends on where you installed it:
+
+**App Store (iPhone) and Google Play (Android)** - the store delivers updates like any other app; there's nothing to do inside Moongate. Store releases carry the stable channel, so a version can land there a little after the same release appears on GitHub (store review takes time).
+
+**Early-access APK (Android - GitHub Releases / KIAUH)** - the app updates itself. When a new version is out, it shows an **update banner** on launch. Tap **Update** and Moongate downloads the new version **inside the app** (with a progress bar), then hands it to Android's installer - just confirm the install. It installs **in place** (same signing key, so it's an upgrade, not a fresh install) and your printers and settings are kept. The first time, Android may ask you to let Moongate **install unknown apps** - allow it once, and after that an update is a single tap plus the install confirmation.
 
 Prefer to do it by hand? Tap **What's new** on the banner to read the changes first, or **[download the latest APK](https://github.com/PEEKYPAUL/Moongate/releases/latest)** from the Releases page and install over your existing copy. (If an in-app update ever fails - no network, or the permission declined - the app falls back to opening the download in your browser, so you're never stuck.)
 
-> As long as you **install over** the existing app (rather than uninstalling first), your identity is kept and nothing needs re-pairing.
+> As long as you **install over** the existing app (rather than uninstalling first), your identity is kept and nothing needs re-pairing. That includes **switching channels**: the Play build and the APK share a signing key, so moving between them installs in place too.
 
 ---
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -111,10 +111,11 @@ and none of these are advertising or data-broker services:
 - **Apple Push Notification service** - delivers print notifications to your
   iPhone (only if you enable notifications). The notification content is limited
   to your printer's name and print status.
-- **GitHub** - on **Android only**, the app fetches a small file to check
-  whether a newer version is available; this reveals your device's IP address to
-  GitHub as part of an ordinary web request. (On iOS, updates come from the App
-  Store and this check is not performed.)
+- **GitHub** - on the **Android early-access (APK) build only**, the app fetches
+  a small file to check whether a newer version is available; this reveals your
+  device's IP address to GitHub as part of an ordinary web request. (The Google
+  Play and App Store builds update through their store and never perform this
+  check.)
 
 These providers may process and store data on servers located in other
 countries, including outside your own. Where this involves transferring personal

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,5 +1,7 @@
 # Moongate - Setup Guide
 
+> **This is the original v0.4-era guide, kept for reference.** The current, always-up-to-date setup lives in the **[README Quick start](../README.md#quick-start)** - and the app is now on the **[App Store](https://apps.apple.com/gb/app/moongate-klipper-control/id6785038887)** and **[Google Play](https://play.google.com/store/apps/details?id=com.moongate.app.moongate)** as well as the [early-access APK](https://github.com/PEEKYPAUL/Moongate/releases/latest).
+
 ## Requirements
 
 ### On your Raspberry Pi
@@ -9,7 +11,7 @@
 
 ### On your Android phone
 - Android 8.0 (Oreo) or later
-- "Install from unknown sources" enabled for the app you'll use to install the APK (browser or file manager)
+- Installing from [Google Play](https://play.google.com/store/apps/details?id=com.moongate.app.moongate) needs nothing extra; for the early-access APK, enable "Install from unknown sources" for the app you'll use to install it (browser or file manager)
 - The phone needs to be on the same WiFi as the Pi for pairing - both sides of the QR exchange are LAN-only by design
 
 ### To build from source (optional)
@@ -49,9 +51,9 @@ At the end you'll see:
 
 ## Step 2 - Install the app
 
-Download the latest APK from the [APK folder](https://github.com/PEEKYPAUL/Moongate/tree/master/APK) and install it on your phone.
+Get Moongate on the [App Store](https://apps.apple.com/gb/app/moongate-klipper-control/id6785038887) (iPhone) or [Google Play](https://play.google.com/store/apps/details?id=com.moongate.app.moongate) (Android). Want each release the day it ships? Grab the Android **early-access APK** from the [Releases page](https://github.com/PEEKYPAUL/Moongate/releases/latest) instead - it updates itself in-app.
 
-> Latest public release: **v0.4.2** - the version this guide describes.
+> This guide was written for **v0.4.2**; the flow it describes is unchanged, but see the [README Quick start](../README.md#quick-start) for the current version.
 
 ---
 


### PR DESCRIPTION
## What will this PR change?

The second half of #243, which was merged before this commit reached it: every user-facing doc beyond the README made channel-aware now the app is on both stores.

- **docs/managing-moongate.md** - "Updating the app" split by channel (stores update via the store; the early-access APK keeps the in-app banner), plus a note that switching channels installs in place thanks to the shared signing key.
- **docs/setup-guide.md** - the old v0.4-era guide marked kept-for-reference, its install step no longer points at the dead APK folder and now offers App Store / Google Play / early-access APK.
- **TROUBLESHOOTING.md** - the "In-app update didn't install" entry scoped to the early-access APK build.
- **SECURITY.md** - the in-app updater scope note uses the early-access naming and mentions the App Store build.
- **docs/privacy-policy.md** - accuracy fix: the GitHub update-check disclosure now applies only to the early-access APK build; the Play build never makes that call.
- **DEVELOPMENT.md** - the flavor explainer names the channels (github = early access, play = stable).

## Testing

Docs-only, no code paths.

PEEKYPAUL 27/07/2026