### PR TITLE
Fix: the webcam wake spinner no longer spins forever for an unreachable camera

### DIFF
--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "Webcam lädt hier aus der Ferne nicht - Moongate-Kamera öffnen.",
   "cameraHintOpen": "Öffnen",
   "webcamWakingUp": "Kamera wacht auf…",
+  "webcamUnreachable": "Kamera nicht erreichbar, Adresse prüfen",
   "printerUnreachable": "Drucker nicht erreichbar",
   "printerUseTunnel": "Tunnel verwenden",
   "printerAddressInvalid": "Versuche z. B. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -811,6 +811,8 @@
   "@cameraHintOpen": {"description": "Button on the camera-discoverability hint that opens the full-screen Moongate camera view."},
   "webcamWakingUp": "Camera waking up…",
   "@webcamWakingUp": {"description": "Shown with a spinner in the webcam box while the first frame is still being fetched - on-demand cameras (go2rtc) take a moment to start."},
+  "webcamUnreachable": "Camera unreachable, check its address",
+  "@webcamUnreachable": {"description": "Shown in the webcam box when every fetch failed and the wake window gave up - the camera is off or its address is wrong."},
   "printerUnreachable": "Printer unreachable",
   "@printerUnreachable": {"description": "Heading on the full-screen error overlay when the printer cannot be loaded."},
   "printerUseTunnel": "Use tunnel",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "La cámara no se carga aquí en remoto - abre la cámara de Moongate.",
   "cameraHintOpen": "Abrir",
   "webcamWakingUp": "La cámara se está activando…",
+  "webcamUnreachable": "Cámara inaccesible, comprueba su dirección",
   "printerUnreachable": "Impresora inaccesible",
   "printerUseTunnel": "Usar túnel",
   "printerAddressInvalid": "Prueba p. ej. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "La webcam ne se charge pas ici à distance - ouvrez la caméra Moongate.",
   "cameraHintOpen": "Ouvrir",
   "webcamWakingUp": "La caméra se réveille…",
+  "webcamUnreachable": "Caméra injoignable, vérifiez son adresse",
   "printerUnreachable": "Imprimante injoignable",
   "printerUseTunnel": "Utiliser le tunnel",
   "printerAddressInvalid": "Essayez par ex. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "La webcam non si carica qui da remoto - apri la telecamera Moongate.",
   "cameraHintOpen": "Apri",
   "webcamWakingUp": "La telecamera si sta attivando…",
+  "webcamUnreachable": "Telecamera irraggiungibile, controlla l'indirizzo",
   "printerUnreachable": "Stampante irraggiungibile",
   "printerUseTunnel": "Usa il tunnel",
   "printerAddressInvalid": "Prova ad es. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -2500,6 +2500,12 @@ abstract class AppLocalizations {
   /// **'Camera waking up…'**
   String get webcamWakingUp;
 
+  /// Shown in the webcam box when every fetch failed and the wake window gave up - the camera is off or its address is wrong.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera unreachable, check its address'**
+  String get webcamUnreachable;
+
   /// Heading on the full-screen error overlay when the printer cannot be loaded.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/app_localizations_de.dart
+++ b/mobile/lib/l10n/app_localizations_de.dart
@@ -1368,6 +1368,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get webcamWakingUp => 'Kamera wacht auf…';
 
   @override
+  String get webcamUnreachable => 'Kamera nicht erreichbar, Adresse prüfen';
+
+  @override
   String get printerUnreachable => 'Drucker nicht erreichbar';
 
   @override

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -1349,6 +1349,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get webcamWakingUp => 'Camera waking up…';
 
   @override
+  String get webcamUnreachable => 'Camera unreachable, check its address';
+
+  @override
   String get printerUnreachable => 'Printer unreachable';
 
   @override

--- a/mobile/lib/l10n/app_localizations_es.dart
+++ b/mobile/lib/l10n/app_localizations_es.dart
@@ -1378,6 +1378,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get webcamWakingUp => 'La cámara se está activando…';
 
   @override
+  String get webcamUnreachable => 'Cámara inaccesible, comprueba su dirección';
+
+  @override
   String get printerUnreachable => 'Impresora inaccesible';
 
   @override

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -1380,6 +1380,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get webcamWakingUp => 'La caméra se réveille…';
 
   @override
+  String get webcamUnreachable => 'Caméra injoignable, vérifiez son adresse';
+
+  @override
   String get printerUnreachable => 'Imprimante injoignable';
 
   @override

--- a/mobile/lib/l10n/app_localizations_it.dart
+++ b/mobile/lib/l10n/app_localizations_it.dart
@@ -1372,6 +1372,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get webcamWakingUp => 'La telecamera si sta attivando…';
 
   @override
+  String get webcamUnreachable =>
+      'Telecamera irraggiungibile, controlla l\'indirizzo';
+
+  @override
   String get printerUnreachable => 'Stampante irraggiungibile';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pl.dart
+++ b/mobile/lib/l10n/app_localizations_pl.dart
@@ -1366,6 +1366,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get webcamWakingUp => 'Kamera się budzi…';
 
   @override
+  String get webcamUnreachable => 'Kamera nieosiągalna, sprawdź jej adres';
+
+  @override
   String get printerUnreachable => 'Drukarka nieosiągalna';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pt.dart
+++ b/mobile/lib/l10n/app_localizations_pt.dart
@@ -1371,6 +1371,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get webcamWakingUp => 'A câmera está acordando…';
 
   @override
+  String get webcamUnreachable => 'Câmera inacessível, verifique o endereço';
+
+  @override
   String get printerUnreachable => 'Impressora inacessível';
 
   @override

--- a/mobile/lib/l10n/app_localizations_ru.dart
+++ b/mobile/lib/l10n/app_localizations_ru.dart
@@ -1366,6 +1366,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get webcamWakingUp => 'Камера просыпается…';
 
   @override
+  String get webcamUnreachable => 'Камера недоступна, проверьте её адрес';
+
+  @override
   String get printerUnreachable => 'Принтер недоступен';
 
   @override

--- a/mobile/lib/l10n/app_localizations_zh.dart
+++ b/mobile/lib/l10n/app_localizations_zh.dart
@@ -1293,6 +1293,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get webcamWakingUp => '摄像头唤醒中…';
 
   @override
+  String get webcamUnreachable => '无法连接摄像头，请检查其地址';
+
+  @override
   String get printerUnreachable => '无法连接打印机';
 
   @override

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "Kamera nie ładuje się tutaj zdalnie - otwórz kamerę Moongate.",
   "cameraHintOpen": "Otwórz",
   "webcamWakingUp": "Kamera się budzi…",
+  "webcamUnreachable": "Kamera nieosiągalna, sprawdź jej adres",
   "printerUnreachable": "Drukarka nieosiągalna",
   "printerUseTunnel": "Użyj tunelu",
   "printerAddressInvalid": "Spróbuj np. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -413,6 +413,7 @@
   "cameraHintBody": "A webcam não carregará remotamente aqui - abra a câmera do Moongate.",
   "cameraHintOpen": "Abrir",
   "webcamWakingUp": "A câmera está acordando…",
+  "webcamUnreachable": "Câmera inacessível, verifique o endereço",
   "printerUnreachable": "Impressora inacessível",
   "printerUseTunnel": "Usar túnel",
   "printerAddressInvalid": "Tente p. ex., 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_ru.arb
+++ b/mobile/lib/l10n/app_ru.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "Веб-камера не загружается здесь удалённо - откройте камеру Moongate.",
   "cameraHintOpen": "Открыть",
   "webcamWakingUp": "Камера просыпается…",
+  "webcamUnreachable": "Камера недоступна, проверьте её адрес",
   "printerUnreachable": "Принтер недоступен",
   "printerUseTunnel": "Использовать туннель",
   "printerAddressInvalid": "Попробуйте, например, 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -425,6 +425,7 @@
   "cameraHintBody": "网络摄像头在此处无法远程加载 - 打开 Moongate 摄像头。",
   "cameraHintOpen": "打开",
   "webcamWakingUp": "摄像头唤醒中…",
+  "webcamUnreachable": "无法连接摄像头，请检查其地址",
   "printerUnreachable": "无法连接打印机",
   "printerUseTunnel": "使用隧道",
   "printerAddressInvalid": "请尝试例如 192.168.1.50:7125",

--- a/mobile/lib/services/webcam_fetch_diag.dart
+++ b/mobile/lib/services/webcam_fetch_diag.dart
@@ -35,12 +35,32 @@ class WebcamFetchDiag {
     entry['external'] = external;
     entry['last_attempt'] = now;
     entry['last_result']  = result;
+    // The relay form (/mg-extcam?u=...) hides which camera actually failed
+    // once the query is redacted - surface the u= target, itself redacted,
+    // so a bug report names the address that's bouncing.
+    final target = Uri.tryParse(url)?.queryParameters['u'];
+    if (target != null && target.isNotEmpty) {
+      entry['target'] = redactUrl(target);
+    } else {
+      entry.remove('target');
+    }
     if (ok) {
       entry['last_success'] = now;
       entry['consecutive_failures'] = 0;
+      entry['consecutive_hard']     = 0;
     } else {
       entry['consecutive_failures'] =
           ((entry['consecutive_failures'] as int?) ?? 0) + 1;
+      // Hard = something answered "no" (an HTTP status, a refused or
+      // unroutable connection). Timeouts and empty bodies stay soft - that's
+      // what a genuinely waking on-demand camera produces, and the wake
+      // window treats the two classes differently.
+      if (result == 'error' || result.startsWith('http ')) {
+        entry['consecutive_hard'] =
+            ((entry['consecutive_hard'] as int?) ?? 0) + 1;
+      } else {
+        entry['consecutive_hard'] = 0;
+      }
     }
     entry['attempts'] = ((entry['attempts'] as int?) ?? 0) + 1;
   }
@@ -59,4 +79,29 @@ class WebcamFetchDiag {
     final entry = _byPrinter[printerId];
     return entry == null ? null : Map.unmodifiable(entry);
   }
+
+  /// Consecutive failed fetches (any kind) recorded for this printer against
+  /// the same (redacted) URL - zero when the URL changed or nothing is
+  /// recorded yet. The wake window's expired state shows the "unreachable"
+  /// message only when this is non-zero (failures actually on record).
+  static int consecutiveFailures(String? printerId, String url) {
+    final entry = printerId == null ? null : _byPrinter[printerId];
+    if (entry == null || entry['url'] != redactUrl(url)) return 0;
+    return (entry['consecutive_failures'] as int?) ?? 0;
+  }
+
+  /// Consecutive HARD failures (HTTP status / refused connection) for this
+  /// printer against the same (redacted) URL. These counters outlive the
+  /// webcam widget, so the wake window can skip the optimistic spinner for a
+  /// camera this session already knows is dead instead of restarting it on
+  /// every remount (grid scroll, app reopen).
+  static int consecutiveHardFailures(String? printerId, String url) {
+    final entry = printerId == null ? null : _byPrinter[printerId];
+    if (entry == null || entry['url'] != redactUrl(url)) return 0;
+    return (entry['consecutive_hard'] as int?) ?? 0;
+  }
+
+  /// Test hook - the per-printer map is process-global state, so tests clear
+  /// it between cases. Production never calls this.
+  static void reset() => _byPrinter.clear();
 }

--- a/mobile/lib/widgets/webcam_view.dart
+++ b/mobile/lib/widgets/webcam_view.dart
@@ -18,6 +18,15 @@ import '../services/webcam_fetch_diag.dart';
 /// window has to survive several slow attempts before giving up.
 const _kWakeWindow = Duration(seconds: 25);
 
+/// Consecutive HARD failures (HTTP errors, refused connections) in the
+/// session-wide fetch history at which a remounting widget skips the
+/// optimistic spinner and starts in the honest expired state. A genuinely
+/// waking on-demand camera produces timeouts and empty bodies - soft results
+/// that never count toward this - so mid-wake remounts still get a spinner,
+/// while a dead address stops getting a fresh 25 s of pretending on every
+/// grid scroll or app reopen.
+const _kDeadCameraThreshold = 6;
+
 // ── Shared webcam renderer ────────────────────────────────────────────────────
 //
 // Self-paced snapshot-fetch loop, shared between the dashboard tile preview and
@@ -101,7 +110,7 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   bool _appPaused = false;
 
   /// True once the wake window expired without a single frame - build() then
-  /// shows the honest plain placeholder instead of the waking spinner.
+  /// shows the honest unreachable/placeholder state instead of the spinner.
   bool _wakeExpired = false;
   Timer? _wakeTimer;
 
@@ -109,7 +118,7 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _armWakeWindow();
+    _armWakeWindow(duringInit: true);
     _loop();
   }
 
@@ -123,12 +132,28 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   @override
   void didUpdateWidget(WebcamView old) {
     super.didUpdateWidget(old);
-    // A changed URL (transport flipped LAN<->tunnel, webcam re-detected) is a
-    // fresh chance at a first frame - restart the wake window.
-    if (old.webcamSnapshotUrl != widget.webcamSnapshotUrl &&
+    // A changed camera (transport flipped LAN<->tunnel, webcam re-detected,
+    // gear override edited) is a fresh chance at a first frame - restart the
+    // wake window. Compared minus the rotating mg_token: a token refresh is
+    // the same camera and must not resurrect the spinner for a dead one.
+    if (_cameraKey(old.webcamSnapshotUrl) !=
+            _cameraKey(widget.webcamSnapshotUrl) &&
         _currentBytes == null) {
       _armWakeWindow();
     }
+  }
+
+  /// Camera identity for wake-window purposes: the snapshot URL minus the
+  /// short-lived mg_token. Everything else (host, path, the relay's u=
+  /// target) genuinely names a camera; the token just rotates under it.
+  static String? _cameraKey(String? url) {
+    if (url == null || url.isEmpty) return url;
+    final u = Uri.tryParse(url);
+    if (u == null || !u.queryParameters.containsKey('mg_token')) return url;
+    final q  = Map.of(u.queryParameters)..remove('mg_token');
+    final qs = q.entries.map((e) => '${e.key}=${e.value}').join('&');
+    final port = u.hasPort ? ':${u.port}' : '';
+    return '${u.scheme}://${u.host}$port${u.path}?$qs';
   }
 
   @override
@@ -144,12 +169,31 @@ class _WebcamViewState extends ConsumerState<WebcamView>
   /// window doesn't burn while the loop idles in the background mid-count,
   /// and so widget tests can advance it with pump(). No-ops without a URL
   /// (nothing is being fetched, the plain placeholder is already honest).
-  void _armWakeWindow() {
+  /// [duringInit] skips setState - fields are read by the first build anyway.
+  void _armWakeWindow({bool duringInit = false}) {
     if (_currentBytes != null) return;
     _wakeTimer?.cancel();
     final url = widget.webcamSnapshotUrl;
     if (url == null || url.isEmpty) return;
-    if (_wakeExpired) setState(() => _wakeExpired = false);
+    void setExpired(bool v) {
+      if (_wakeExpired == v) return;
+      if (duringInit) {
+        _wakeExpired = v;
+      } else {
+        setState(() => _wakeExpired = v);
+      }
+    }
+
+    // A camera whose session-wide history is a run of hard failures gets no
+    // fresh optimism - the fetch history outlives the widget, so a grid
+    // scroll or app reopen must not restart the spinner for a dead address.
+    // The loop still fetches; a later success lands frames as ever.
+    if (WebcamFetchDiag.consecutiveHardFailures(widget.printerId, url) >=
+        _kDeadCameraThreshold) {
+      setExpired(true);
+      return;
+    }
+    setExpired(false);
     _wakeTimer = Timer(_kWakeWindow, () {
       if (mounted && _currentBytes == null) {
         setState(() => _wakeExpired = true);
@@ -351,8 +395,22 @@ class _WebcamViewState extends ConsumerState<WebcamView>
     // - there's nothing to wake.
     final waking =
         bytes == null && url != null && url.isNotEmpty && !_wakeExpired;
-    WebcamFetchDiag.recordShowing(widget.printerId,
-        bytes != null ? 'frames' : (waking ? 'waking' : 'placeholder'));
+    // Unreachable = the window gave up AND the fetch history holds nothing
+    // but failures for this camera - say so instead of showing a logo that
+    // reads as "still loading". Without recorded failures (no printerId, or
+    // a fetch still in flight at expiry) the plain placeholder stays.
+    final unreachable = bytes == null && url != null && url.isNotEmpty &&
+        _wakeExpired &&
+        WebcamFetchDiag.consecutiveFailures(widget.printerId, url) > 0;
+    WebcamFetchDiag.recordShowing(
+        widget.printerId,
+        bytes != null
+            ? 'frames'
+            : waking
+                ? 'waking'
+                : unreachable
+                    ? 'unreachable'
+                    : 'placeholder');
     Widget image = bytes != null
         ? Image.memory(bytes, fit: widget.fit, gaplessPlayback: true)
         : Container(
@@ -360,7 +418,9 @@ class _WebcamViewState extends ConsumerState<WebcamView>
             child: Center(
                 child: waking
                     ? const _WebcamWaking()
-                    : _WebcamPlaceholder(uiType: widget.uiType)),
+                    : unreachable
+                        ? const _WebcamUnreachable()
+                        : _WebcamPlaceholder(uiType: widget.uiType)),
           );
 
     // Apply the webcam display transforms Mainsail has configured, so the image
@@ -419,6 +479,39 @@ class _WebcamWaking extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Text(
             l.webcamWakingUp,
+            style: const TextStyle(color: Colors.white54, fontSize: 12),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Unreachable camera ────────────────────────────────────────────────────────
+//
+// The wake window gave up with nothing but failures on record: the camera's
+// address is wrong, the camera is off, or the relay can't reach it. Saying so
+// beats both an eternal spinner and a logo that reads as "still loading". The
+// fetch loop keeps trying behind it, so a camera that comes back (or a fixed
+// gear override) replaces this with frames on the next successful fetch.
+
+class _WebcamUnreachable extends StatelessWidget {
+  const _WebcamUnreachable();
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.videocam_off_outlined,
+            size: 30, color: Colors.white38),
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Text(
+            l.webcamUnreachable,
             style: const TextStyle(color: Colors.white54, fontSize: 12),
             textAlign: TextAlign.center,
           ),

--- a/mobile/test/webcam_fetch_diag_test.dart
+++ b/mobile/test/webcam_fetch_diag_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:moongate/services/webcam_fetch_diag.dart';
+
+// The session-wide fetch history behind the wake window's honesty: the relay
+// target surfaced for bug reports, and the hard-vs-soft failure split that
+// decides whether a remounting tile deserves a fresh spinner.
+
+void main() {
+  setUp(WebcamFetchDiag.reset);
+
+  test('mg-extcam target is surfaced, redacted, and cleared on LAN flip', () {
+    const relay =
+        'https://pi.example/mg-extcam?u=http%3A%2F%2F192.168.1.84%2Fwebcam%3Ftoken%3Dsecret&mg_token=xyz';
+    WebcamFetchDiag.record('p1', url: relay, external: true, result: 'http 502');
+    expect(WebcamFetchDiag.report('p1')!['target'], 'http://192.168.1.84/webcam');
+
+    // Back on LAN the URL IS the camera - no stale relay target may linger.
+    WebcamFetchDiag.record('p1',
+        url: 'http://192.168.1.84/webcam', external: true, result: 'ok');
+    expect(WebcamFetchDiag.report('p1')!.containsKey('target'), isFalse);
+  });
+
+  test('hard and soft failures are counted apart, both reset on success', () {
+    const url = 'http://192.0.2.5/snap';
+    WebcamFetchDiag.record('p2', url: url, external: false, result: 'timeout');
+    WebcamFetchDiag.record('p2', url: url, external: false, result: 'http 502');
+    WebcamFetchDiag.record('p2', url: url, external: false, result: 'error');
+    expect(WebcamFetchDiag.consecutiveFailures('p2', url), 3);
+    expect(WebcamFetchDiag.consecutiveHardFailures('p2', url), 2);
+
+    // A soft failure breaks a hard run - a camera that alternates 502s with
+    // timeouts is flaky, not provably dead.
+    WebcamFetchDiag.record('p2', url: url, external: false, result: 'empty');
+    expect(WebcamFetchDiag.consecutiveFailures('p2', url), 4);
+    expect(WebcamFetchDiag.consecutiveHardFailures('p2', url), 0);
+
+    WebcamFetchDiag.record('p2', url: url, external: false, result: 'ok');
+    expect(WebcamFetchDiag.consecutiveFailures('p2', url), 0);
+    expect(WebcamFetchDiag.consecutiveHardFailures('p2', url), 0);
+  });
+
+  test('counters answer zero for a different URL or unknown printer', () {
+    const url = 'http://192.0.2.5/snap';
+    WebcamFetchDiag.record('p3', url: url, external: false, result: 'http 404');
+    expect(WebcamFetchDiag.consecutiveHardFailures('p3', url), 1);
+    expect(
+        WebcamFetchDiag.consecutiveHardFailures('p3', 'http://192.0.2.6/snap'),
+        0);
+    expect(WebcamFetchDiag.consecutiveHardFailures('nobody', url), 0);
+    expect(WebcamFetchDiag.consecutiveHardFailures(null, url), 0);
+  });
+}

--- a/mobile/test/webcam_wake_test.dart
+++ b/mobile/test/webcam_wake_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:moongate/l10n/app_localizations.dart';
+import 'package:moongate/services/webcam_fetch_diag.dart';
 import 'package:moongate/widgets/webcam_view.dart';
 
 // The wake-window state machine: spinner while the first frame is still being
@@ -27,6 +28,8 @@ Future<void> _teardown(WidgetTester tester) async {
 }
 
 void main() {
+  setUp(WebcamFetchDiag.reset);
+
   testWidgets('waking spinner shows, then gives way to the placeholder',
       (tester) async {
     await tester.pumpWidget(_host(const WebcamView(
@@ -73,6 +76,102 @@ void main() {
     )));
     await tester.pump(const Duration(seconds: 1));
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('a token-only URL change does not resurrect an expired spinner',
+      (tester) async {
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl:
+          'https://pi.example/mg-extcam?u=http%3A%2F%2F192.168.1.84%2F&mg_token=aaa',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 30));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    // The mint rotates the token under the same camera - that must not be
+    // treated as a new camera (the field failure mode: the spinner returning
+    // forever for a dead address on every token refresh).
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl:
+          'https://pi.example/mg-extcam?u=http%3A%2F%2F192.168.1.84%2F&mg_token=bbb',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    // A genuinely different relay target IS a new camera - fresh window.
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl:
+          'https://pi.example/mg-extcam?u=http%3A%2F%2F192.168.1.83%2F&mg_token=bbb',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('a run of hard failures on record skips the spinner on remount',
+      (tester) async {
+    const url = 'http://192.0.2.7/snapshot';
+    for (var i = 0; i < 6; i++) {
+      WebcamFetchDiag.record('deadcam',
+          url: url, external: true, result: 'http 502');
+    }
+
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl: url,
+      printerId: 'deadcam',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // No fresh 25 s of pretending - straight to the honest message.
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('Camera unreachable, check its address'), findsOneWidget);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('soft failures (a genuinely waking camera) still get a spinner',
+      (tester) async {
+    const url = 'http://192.0.2.8/snapshot';
+    for (var i = 0; i < 6; i++) {
+      WebcamFetchDiag.record('wakingcam',
+          url: url, external: true, result: 'timeout');
+    }
+
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl: url,
+      printerId: 'wakingcam',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('natural expiry with failures on record shows the message',
+      (tester) async {
+    // With a printerId, the widget's own failing fetches (the test
+    // environment answers every request with 400) land in the diag - after
+    // the window expires the tile must say so, not show a logo that reads
+    // as still loading.
+    await tester.pumpWidget(_host(const WebcamView(
+      webcamSnapshotUrl: 'http://192.0.2.9/snapshot',
+      printerId: 'expiringcam',
+      uiType: 'mainsail',
+    )));
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 30));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('Camera unreachable, check its address'), findsOneWidget);
 
     await _teardown(tester);
   });


### PR DESCRIPTION
## What will this PR change?

A camera whose address can't be reached will now say **"Camera unreachable, check its address"** on the tile instead of showing "Camera waking up…" forever.

In plain English: if you point a tile's camera at an IP that's wrong, off, or gone (the field report that triggered this had 34 straight relay 502s on record while the tile still claimed to be waking up), the tile stops pretending after its 25-second grace window and tells you what's actually wrong. Fix the address in the tile gear and frames come back on the next successful fetch, nothing to restart.

## Why it spun forever

Two re-arm leaks around the 25 s wake window from #234:

1. **Every widget remount got a fresh window.** The fetch-outcome history lives in a session-wide map, but the wake window never consulted it - so scrolling the grid or reopening the app restarted the optimistic spinner for a camera the session already knew was dead. The reporter always looked at the tile shortly after opening the app, so he only ever saw the spinner.
2. **Every URL change got a fresh window, including token rotations.** Over the tunnel the snapshot URL embeds the rotating mg_token, so the same dead camera kept being treated as a brand-new one.

## How

- On arming, the window checks the session's consecutive **hard** failures (HTTP status, refused connection) for the same camera: at 6+ it starts in the expired state. Soft results (timeout, empty body) never count - they're exactly what a genuinely waking go2rtc/uv4l camera produces, so mid-wake remounts keep their spinner and nothing changes for healthy setups.
- URL comparison for re-arming ignores mg_token; a genuinely different camera target or a LAN<->tunnel flip still re-arms as before.
- The expired state shows the new localized message (all 9 languages) only when failures are actually on record; the plain logo placeholder still covers no-camera and never-fetched cases.
- Bug reports now include the relay target host (token-free) plus the hard-failure counter, so the next report names the failing address outright instead of needing it inferred.

## Testing

- 7 widget tests on the wake state machine (3 pre-existing unchanged, 4 new: token-only change doesn't resurrect the spinner, hard-failure history skips it on remount, soft-failure history doesn't, natural expiry shows the message).
- 3 new unit tests on the fetch-history counters and the target redaction.
- flutter analyze clean; full suite 46/46 green.
- No version bump - rides the next release.

PEEKYPAUL 27/07/2026