### PR TITLE
Fix: a printer next to your phone no longer shows Tunnel because discovery answered with an unusable address

### DIFF
--- a/mobile/lib/services/lan_discovery_service.dart
+++ b/mobile/lib/services/lan_discovery_service.dart
@@ -136,11 +136,43 @@ class LanDiscoveryService {
       _log('Resolved service has no host, ignoring: ${service.name}');
       return;
     }
-    final url = port == 80 ? 'http://$host' : 'http://$host:$port';
+    final url = urlForHost(host, port);
+    if (url == null) {
+      // Never store it: everything that consults this map treats a hit as
+      // better than the persisted lanUrl, so one bad answer would strand the
+      // printer on the tunnel while it sits on the same subnet (the field
+      // case: Android resolving to fe80::...%wlan0).
+      _log('Unusable resolved host for ${printerId.substring(0, 8)}... '
+          '($host), ignoring');
+      return;
+    }
     if (_discovered[printerId] != url) {
       _log('Discovered ${printerId.substring(0, 8)}... → $url');
       _discovered[printerId] = url;
     }
+  }
+
+  /// LAN URL for a resolved mDNS host, or null when the host can never work
+  /// as one. Android's resolver happily answers with IPv6 link-local
+  /// addresses carrying a zone index (`fe80::...%wlan0`) - meaningless off
+  /// the resolving interface and unusable in a URL, so they are rejected
+  /// rather than stored. A usable plain IPv6 host is bracketed; IPv4 and
+  /// hostnames pass through unchanged. Static and pure for tests.
+  static String? urlForHost(String host, int port) {
+    if (host.contains('%')) return null; // zone index = interface-scoped
+    var h = host;
+    if (h.contains(':')) {
+      // IPv6. Link-local (fe80::/10) is unroutable outside its interface -
+      // covers fe80-febf in the first hextet, any case.
+      final first = h.split(':').first.toLowerCase();
+      if (first.length == 4 &&
+          first.startsWith('fe') &&
+          '89ab'.contains(first[2])) {
+        return null;
+      }
+      h = '[$h]';
+    }
+    return port == 80 ? 'http://$h' : 'http://$h:$port';
   }
 
   /// Forget all discoveries - used on sign-out / user change.

--- a/mobile/test/lan_discovery_host_test.dart
+++ b/mobile/test/lan_discovery_host_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:moongate/services/lan_discovery_service.dart';
+
+// The mDNS host -> LAN URL gate. The field failure (2026-07-27 bug report):
+// Android's resolver answered a browse with `fe80::4684:2651:1a53:50f6%wlan0`,
+// the service stored it verbatim, and because a discovered URL outranks the
+// persisted lanUrl everywhere, a printer sitting on the same subnet as the
+// phone rode the tunnel forever. Unusable hosts must never enter the map -
+// lookup() then answers null and every consumer falls back to the persisted
+// address, which works.
+
+void main() {
+  test('IPv4 hosts pass through, port 80 elided', () {
+    expect(LanDiscoveryService.urlForHost('192.168.1.105', 80),
+        'http://192.168.1.105');
+    expect(LanDiscoveryService.urlForHost('192.168.1.105', 7125),
+        'http://192.168.1.105:7125');
+  });
+
+  test('mDNS hostnames pass through', () {
+    expect(LanDiscoveryService.urlForHost('mainsailos.local', 80),
+        'http://mainsailos.local');
+  });
+
+  test('zone-indexed hosts are rejected whatever the address', () {
+    expect(
+        LanDiscoveryService.urlForHost(
+            'fe80::4684:2651:1a53:50f6%wlan0', 80),
+        isNull);
+    expect(LanDiscoveryService.urlForHost('2001:db8::1%eth0', 80), isNull);
+  });
+
+  test('IPv6 link-local is rejected across the fe80::/10 range, any case', () {
+    expect(LanDiscoveryService.urlForHost('fe80::1', 80), isNull);
+    expect(LanDiscoveryService.urlForHost('FE80::1', 80), isNull);
+    expect(LanDiscoveryService.urlForHost('febf::1', 80), isNull);
+    expect(LanDiscoveryService.urlForHost('fe9a::1', 80), isNull);
+  });
+
+  test('routable IPv6 is kept and bracketed', () {
+    expect(LanDiscoveryService.urlForHost('2001:db8::1', 80),
+        'http://[2001:db8::1]');
+    expect(LanDiscoveryService.urlForHost('2001:db8::1', 7125),
+        'http://[2001:db8::1]:7125');
+    // fd00::/8 unique-local is routable on a site - keep it.
+    expect(LanDiscoveryService.urlForHost('fd12:3456::1', 80),
+        'http://[fd12:3456::1]');
+    // "fe" in the first hextet but outside fe80::/10 is NOT link-local.
+    expect(LanDiscoveryService.urlForHost('fec0::1', 80),
+        'http://[fec0::1]');
+  });
+}


### PR DESCRIPTION
## What will this PR change?

A printer on the same network as your phone will no longer get stuck on the tunnel (orange "Tunnel" badge at home) when Android's local-network discovery answers with an address that can't actually be used.

In plain English: today's bug report showed a phone at 192.168.1.155 and its printer at 192.168.1.105, same subnet, yet the tile said Tunnel. Discovery had answered with an IPv6 link-local address (`fe80::...%wlan0`), the app trusted it over the perfectly good saved address, the connection check failed on it every poll, and the printer paid tunnel latency forever - it also forced the tile's external camera through the remote relay, which is what made the camera bug visible. With this fix the bad answer is discarded and the saved address wins, so the tile goes green Local like it should.

## How

One change at the source, `LanDiscoveryService`: resolved hosts now pass through a small gate before entering the discovery map.

- Zone-indexed hosts (anything with `%`) and IPv6 link-local (`fe80::/10`) are rejected - they are interface-scoped and can never work in a URL, so storing one only ever breaks things.
- A routable IPv6 host is kept and properly bracketed (previously it would have produced an invalid URL too).
- IPv4 and hostnames are untouched - the overwhelmingly common case behaves exactly as before.

Fixing it at the source protects all seven places that consult the map (status polls, control calls, WebView warm-up, pairing) at once: a rejected answer means `lookup()` returns null and every one of them falls back to the persisted address, which is the behaviour that already works today for printers mDNS never finds.

## Who this affects

Any Android phone on an IPv6-enabled home network can be handed a link-local answer, and until now one bad answer silently stranded that printer on the tunnel with no user-visible cause and no workaround (the discovered URL even outranks a manually typed address). This likely explains a slice of the long-running "shows Tunnel while at home" support class.

## Testing

- 5 new unit tests on the gate: the exact field address, the fe80 range upper/lower case, zone indexes on any address, and the kept classes (IPv4, hostnames, routable/unique-local IPv6, fe-prefixed-but-not-link-local).
- flutter analyze clean.
- No version bump - rides the next release.

PEEKYPAUL 27/07/2026