### PR TITLE
Plugin 0.6.19: stay awake while pairing + pair console reorder + tap-to-pair button [skip ci]

### DIFF
--- a/klipper-plugin/moongate-pair.html
+++ b/klipper-plugin/moongate-pair.html
@@ -47,6 +47,9 @@
       margin-top: 16px; font-size: 0.7rem; color: #555;
       word-break: break-all; line-height: 1.4;
     }
+    .tap-hint {
+      margin-top: 8px; font-size: 0.75rem; color: #777; line-height: 1.4;
+    }
     .badge {
       display: inline-block; margin-bottom: 20px; padding: 4px 10px;
       border-radius: 20px; font-size: 0.75rem; font-weight: 600;
@@ -62,6 +65,7 @@
   <div id="badges"></div>
   <div id="qr-wrap"><div class="spinner"></div></div>
   <div id="msg"></div>
+  <div id="tap"></div>
 
   <div class="step"><span>1</span>Run <code>MOONGATE_PAIR</code> in your Klipper console</div>
   <div class="step"><span>2</span>Open the Moongate app &rarr; tap <strong>Add Printer</strong></div>
@@ -102,9 +106,11 @@ async function load() {
   const wrap = document.getElementById('qr-wrap');
   const msg  = document.getElementById('msg');
   const bdg  = document.getElementById('badges');
+  const tap  = document.getElementById('tap');
   wrap.innerHTML = '<div class="spinner"></div>';
   msg.innerHTML  = '';
   bdg.innerHTML  = '';
+  tap.innerHTML  = '';
 
   // 1. Fetch QR URL from Moonraker
   let qr_url, tunnel_url;
@@ -128,6 +134,16 @@ async function load() {
   bdg.innerHTML =
     '<span class="badge local">Local</span>' +
     (hasRemote ? ' <span class="badge remote">Remote ✓</span>' : '');
+
+  // 2b. Tap-to-pair: the QR payload is a moongate:// link, so on the phone
+  // that has the app installed the QR never needs a second screen - tapping
+  // hands the same payload straight to the app. Apps older than the deep-link
+  // support ignore the tap, hence the honest hint underneath.
+  tap.innerHTML = `
+    <a class="btn" href="${qr_url}">Pairing with this phone? Tap here</a>
+    <p class="tap-hint">Nothing happened? Your Moongate app doesn't support
+    tap-pairing yet - scan the QR from another screen, or add the printer
+    manually in the app instead.</p>`;
 
   // 3. Load QR library and render
   const loaded = await loadQRLib();

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -82,7 +82,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.18"
+MOONGATE_PLUGIN_VERSION = "0.6.19"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -615,12 +615,20 @@ class HeartbeatLoop:
         interval: int,
         on_unpaired_cb=None,
         on_dormant_cb=None,
+        pending_pair_cb=None,
     ) -> None:
         self.device      = device
         self.sb          = sb
         self.interval    = interval
         self.on_unpaired = on_unpaired_cb
         self.on_dormant  = on_dormant_cb
+        # Answers "is a pairing session open right now?" (an un-redeemed,
+        # un-expired GATE code). Consulted by the 404/410 handlers: while a
+        # user is mid-pair the row's absence is EXPECTED (reset-owner released
+        # it; the replacement only appears when the code is redeemed), so it
+        # must not put the loop to sleep - that stranded a re-pair with no
+        # heartbeat for up to 6 h (Lucas, 2026-07-28).
+        self.pending_pair = pending_pair_cb
         self._task: Optional[asyncio.Task] = None
         self._last_url_reported: Optional[str] = None
         # Orphan dormancy (v0.6.15). A Pi whose cloud row is gone for good
@@ -789,7 +797,13 @@ class HeartbeatLoop:
             # no new row is coming, so we must NOT keep re-arming or it would
             # spin at 5 s forever (~720 calls/hour). Left alone the window lapses
             # and the loop falls back to the steady cadence (~12 calls/hour).
-            if self._last_url_reported is not None:
+            #
+            # Exception: an OPEN pairing session keeps re-arming. The row
+            # appears the instant the user redeems the GATE code, and the fast
+            # cadence is what turns that into a live tile within ~5 s. Bounded
+            # by the code's TTL (the callback answers False once it expires),
+            # so the worst case is one TTL of fast polling per MOONGATE_PAIR.
+            if self._pair_in_flight() or self._last_url_reported is not None:
                 self._fast_deadline = time.time() + self._FAST_WINDOW_SECONDS
             self._last_url_reported = None
             if self.on_unpaired:
@@ -815,7 +829,21 @@ class HeartbeatLoop:
                 except Exception as exc:
                     logger.warning("on_unpaired callback failed: %s", exc)
             if body.get("error") == "printer_released":
-                self._enter_dormant("released by its owner")
+                if self._pair_in_flight():
+                    # The reset-owner → re-pair race (0.6.15 regression): the
+                    # poke MOONGATE_PAIR sends lands here BEFORE the user has
+                    # redeemed the new GATE code, so the only row is the
+                    # tombstone. Dorming now would leave the freshly-claimed
+                    # row with no tunnel URL for up to 6 h ("app can't
+                    # connect"). Stay awake on the fast cadence instead; once
+                    # the code is redeemed the next beat lands 200, and once
+                    # it expires un-redeemed the next 410 dorms as designed.
+                    logger.info(
+                        "Heartbeat 410 during an open pairing session - "
+                        "staying awake until the code is redeemed or expires")
+                    self._fast_deadline = time.time() + self._FAST_WINDOW_SECONDS
+                else:
+                    self._enter_dormant("released by its owner")
             return
         if status == 401:
             skew = self.sb.clock_skew_seconds()
@@ -837,6 +865,14 @@ class HeartbeatLoop:
     @property
     def dormant(self) -> bool:
         return self._dormant
+
+    def _pair_in_flight(self) -> bool:
+        """True while an un-redeemed, un-expired GATE code is outstanding."""
+        try:
+            return bool(self.pending_pair and self.pending_pair())
+        except Exception as exc:
+            logger.warning("pending_pair callback failed: %s", exc)
+            return False
 
     def _note_confirmed_notfound(self) -> None:
         """Advance the orphan evidence: one more confirmed "no such printer"
@@ -1083,6 +1119,10 @@ class MoongatePlugin:
                 int(self._config["heartbeat_interval_seconds"]),
                 on_unpaired_cb=self._on_unpaired,
                 on_dormant_cb=self._on_dormant,
+                pending_pair_cb=lambda: (
+                    self._pending is not None
+                    and time.time() < self._pending.expires_at
+                ),
             )
             self.watcher   = PrintEventWatcher(
                 self.device, self.sb,
@@ -1319,19 +1359,20 @@ class MoongatePlugin:
             ttl_min = int(self._config["enrollment_ttl_seconds"]) // 60
             lines = [
                 "M118 ==========================================",
-                f"M118 MOONGATE CODE: {pending.raw_token}",
+                "M118 Moongate pairing",
                 "M118 ==========================================",
-                "M118 DO NOT SHARE the code above.",
-                "M118 If shared by accident: MOONGATE_RESET_OWNER",
-                "M118 ==========================================",
-                "M118 Option A - Scan the QR. Open this URL on a",
-                "M118 PC, tablet, or other phone:",
+                "M118 RECOMMENDED - Scan the QR code.",
+                "M118 Open this URL on a PC, tablet, or",
+                "M118 another phone:",
                 f"M118   {local_page}",
-                "M118 then scan the QR with the Moongate app",
+                "M118 then scan it with the Moongate app",
                 "M118 (Add Printer > Scan QR code).",
                 "M118 ==========================================",
-                "M118 Option B - Type the code in the app:",
-                "M118 Add Printer > GATE code field.",
+                "M118 ALTERNATIVE - GATE code. Type it in the",
+                "M118 app: Add Printer > GATE code field.",
+                f"M118   {pending.raw_token}",
+                "M118 DO NOT SHARE this code.",
+                "M118 If shared by accident: MOONGATE_RESET_OWNER",
                 "M118 ==========================================",
                 f"M118 Code expires in {ttl_min} minutes.",
             ]
@@ -1363,14 +1404,15 @@ class MoongatePlugin:
                 "M118 ==========================================",
                 "M118 Moongate LAN-only (no tunnel, no cloud)",
                 "M118 ==========================================",
-                "M118 Option A - Scan the QR. Open this URL on a",
-                "M118 PC, tablet, or other phone:",
+                "M118 RECOMMENDED - Scan the QR code.",
+                "M118 Open this URL on a PC, tablet, or",
+                "M118 another phone:",
                 f"M118   {local_page}",
                 "M118 then scan it with the Moongate app",
                 "M118 (Add Printer > Scan QR code).",
                 "M118 ==========================================",
-                "M118 Option B - Add Printer > Direct (LAN/VPN),",
-                "M118 enter this address:",
+                "M118 ALTERNATIVE - Add Printer > Direct",
+                "M118 (LAN/VPN), enter this address:",
                 f"M118   {lan_addr}",
                 "M118 ==========================================",
                 "M118 Your phone must be on this LAN / your VPN.",

--- a/klipper-plugin/tests/test_heartbeat_pair_window.py
+++ b/klipper-plugin/tests/test_heartbeat_pair_window.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""v0.6.19 regression test: an OPEN pairing session must keep the heartbeat
+awake. The 0.6.15 orphan dormancy had a race: MOONGATE_PAIR's poke lands
+before the user has redeemed the new GATE code, the server still answers with
+the reset-owner tombstone (410 printer_released), and the loop went dormant
+for 6 h right as the freshly-claimed row appeared - so the row never got a
+tunnel URL and the app showed the printer offline (field report 2026-07-28).
+
+Stdlib-only on purpose, same loader as test_lan_only_no_deps.py:
+
+    python3 klipper-plugin/tests/test_heartbeat_pair_window.py
+"""
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "moongate_standalone.py"
+BLOCKED     = ("jwt", "cryptography")
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_PATH)
+    mod  = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass looks its module up in sys.modules.
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+def _load_blocked(name):
+    """Load the plugin with the cloud deps blocked, like an embedded host.
+    HeartbeatLoop itself never touches them, so the tests stay deterministic
+    whether or not this machine has PyJWT/cryptography installed."""
+    for dep in BLOCKED:
+        assert dep not in sys.modules or sys.modules[dep] is None, (
+            f"{dep} already imported - run this test in its own process")
+        sys.modules[dep] = None
+    try:
+        mod = _load(name)
+    finally:
+        for dep in BLOCKED:
+            del sys.modules[dep]
+    # The loop reads the tunnel URL from a module-level helper; give it one so
+    # _send_one() always reaches the fake Supabase client below.
+    mod._get_tunnel_url = lambda: "https://test.trycloudflare.com"
+    return mod
+
+
+class FakeDevice:
+    public_key_b64 = "cGtfdGVzdA=="
+
+    @staticmethod
+    def sign_b64(data):
+        return "c2lnX3Rlc3Q="
+
+
+class FakeSb:
+    """Duck-typed SupabaseClient: one canned heartbeat answer at a time."""
+    def __init__(self):
+        self.reply = (204, {})
+        self.calls = 0
+
+    def heartbeat(self, pk_b64, tunnel, ts, sig_b64):
+        self.calls += 1
+        return self.reply
+
+
+def _make_loop(mod, pending):
+    sb    = FakeSb()
+    state = {"pending": pending}
+    hb    = mod.HeartbeatLoop(
+        FakeDevice(), sb, 300,
+        pending_pair_cb=lambda: state["pending"],
+    )
+    return hb, sb, state
+
+
+def test_410_during_open_pair_stays_awake(mod):
+    hb, sb, state = _make_loop(mod, pending=True)
+    sb.reply = (410, {"error": "printer_released"})
+    hb._send_one()
+    assert hb.dormant is False, "410 mid-pair must not dorm"
+    assert hb._fast_deadline > time.time(), "fast cadence must stay armed"
+    # Code redeemed -> the new live row answers 200 and the loop settles.
+    state["pending"] = False
+    sb.reply = (204, {})
+    hb._send_one()
+    assert hb.dormant is False
+    assert hb._fast_deadline == 0.0, "accepted heartbeat must end the window"
+
+
+def test_410_with_no_open_pair_dorms(mod):
+    hb, sb, _ = _make_loop(mod, pending=False)
+    sb.reply = (410, {"error": "printer_released"})
+    hb._send_one()
+    assert hb.dormant is True, "410 with no pairing session must still dorm"
+
+
+def test_410_after_code_expiry_dorms(mod):
+    hb, sb, state = _make_loop(mod, pending=True)
+    sb.reply = (410, {"error": "printer_released"})
+    hb._send_one()
+    assert hb.dormant is False
+    state["pending"] = False   # the 10-min TTL lapsed, code never redeemed
+    hb._send_one()
+    assert hb.dormant is True, "expiry must restore the dormancy answer"
+
+
+def test_404_during_open_pair_rearms_fast(mod):
+    hb, sb, _ = _make_loop(mod, pending=True)
+    hb._fast_deadline = 0.0    # bootstrap window already lapsed
+    sb.reply = (404, {"error": "not_found"})
+    hb._send_one()
+    assert hb._fast_deadline > time.time(), (
+        "404 mid-pair must re-arm the fast window even on a never-healthy Pi")
+
+
+def test_no_callback_keeps_old_behaviour(mod):
+    hb = mod.HeartbeatLoop(FakeDevice(), FakeSb(), 300)
+    assert hb._pair_in_flight() is False
+    hb2, sb2, _ = _make_loop(mod, pending=False)
+    sb2.reply = (410, {"error": "printer_released"})
+    hb2._send_one()
+    assert hb2.dormant is True
+
+
+if __name__ == "__main__":
+    mod = _load_blocked("moongate_hb_test")
+    test_410_during_open_pair_stays_awake(mod)
+    print("PASS 410 during an open pairing session stays awake")
+    test_410_with_no_open_pair_dorms(mod)
+    print("PASS 410 with no pairing session dorms")
+    test_410_after_code_expiry_dorms(mod)
+    print("PASS 410 after code expiry dorms")
+    test_404_during_open_pair_rearms_fast(mod)
+    print("PASS 404 during an open pairing session re-arms the fast window")
+    test_no_callback_keeps_old_behaviour(mod)
+    print("PASS no callback keeps the old behaviour")
+    print("All good.")


### PR DESCRIPTION
## What will this PR change?

Three things, all on the Pi side (plugin 0.6.19, no app release needed):

1. **A re-paired printer no longer plays dead.** Running `MOONGATE_RESET_OWNER` then `MOONGATE_PAIR` could leave the printer permanently "offline" in the app. The plugin now stays awake while a pairing code is outstanding, so the tile goes live within a few seconds of typing the code.
2. **`MOONGATE_PAIR` console output reordered.** The pair-page URL now leads as RECOMMENDED and the GATE code (or the direct address in LAN-only mode) follows as ALTERNATIVE, with the do-not-share warning kept right next to the code.
3. **Tap-to-pair button on moongate-pair.html.** If you open the pair page on the phone that has the app, you can tap instead of scanning your own screen.

## Why

A user hit no. 1 today (the "cloud contact is paused" console block right after running MOONGATE_PAIR, then the app could not connect). The race shipped in 0.6.15's orphan dormancy: MOONGATE_PAIR pokes a heartbeat that lands before the user has redeemed the new GATE code, the server still answers with the reset-owner tombstone (410 `printer_released`), and the loop went dormant for 6 hours at exactly the wrong moment. The freshly-claimed row then never received a tunnel URL, so unless LAN mDNS happened to rescue it, the app saw the printer as offline. Workaround for anyone on 0.6.18 or older: after the printer appears in the app, run `MOONGATE_PAIR` once more (or restart Moonraker) to wake the heartbeat.

Nos. 2 and 3 are pair-flow UX: the QR route is what we want people to try first, and the "I only have my phone" pairing case (e.g. over Tailscale) had no good answer, since a phone cannot scan a QR displayed on its own screen.

## How

- `HeartbeatLoop` gains `pending_pair_cb` ("is an un-expired pairing session open?"). While True, a 410 stays awake and re-arms the fast cadence, and a 404 re-arms it too, so the row goes live within ~5 s of redemption. Once the code expires un-redeemed, the old answers return and the orphan dorms as designed. Worst-case cost is one code TTL (10 min) of 5 s polling per MOONGATE_PAIR, only on the tombstone/orphan path.
- The owner-bind path already clears `_pending` and pokes the heartbeat, so every recovery route stays consistent.
- The tap-to-pair button just links the same `moongate://` payload the QR encodes. Today's apps do not register the scheme at the OS level (the QR scanner is the only consumer), so the button carries an honest "nothing happened?" hint; the app-side deep-link registration is planned for the next app release, and the button starts working retroactively on every already-updated plugin the moment the app ships.
- `kCurrentPluginVersion` stays held at 0.6.16 (no fleet update nag for this).

## Testing

- New stdlib-only regression test `klipper-plugin/tests/test_heartbeat_pair_window.py` (same loader pattern as the 0.6.17 test): 410 mid-pair stays awake then settles on 200; 410 with no session dorms; 410 after expiry dorms; 404 mid-pair re-arms the fast window; no-callback construction keeps the old behaviour. All pass, and `test_lan_only_no_deps.py` still passes.
- `ruff check klipper-plugin/` clean at the pinned 0.15.22.
- Not yet exercised on a real Pi; the reset -> re-pair -> tile-goes-live loop is worth one run on a test rig before the fleet picks it up.

No version bump in this PR, so please squash-merge with `[skip ci]` in the title to avoid the harmless duplicate re-publish.

PEEKYPAUL 28/07/2026
