### PR TITLE
Tap-to-pair: register the moongate:// scheme and route tapped links to the pairing screen [skip ci]

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,16 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Tap-to-pair: the Pi's moongate-pair.html offers its QR payload
+                 (moongate://pair / moongate://lan) as a tappable link for the
+                 no-second-screen case. app_links receives it and routes to the
+                 pairing screen; the QR scanner parses the same URIs. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="moongate"/>
+            </intent-filter>
         </activity>
 
         <!-- Don't delete the meta-data below.

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -22,6 +22,19 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.moongate.app.moongate</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>moongate</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -20,6 +20,7 @@ import 'providers/app_lock_provider.dart';
 import 'providers/custom_theme_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/update_provider.dart';
+import 'services/deep_link_service.dart';
 import 'services/lan_discovery_service.dart';
 import 'services/printer_registry.dart';
 
@@ -32,7 +33,12 @@ final _router = GoRouter(
       redirect: (_, __) => '/dashboard',
     ),
     GoRoute(path: '/dashboard', builder: (_, __) => const DashboardScreen()),
-    GoRoute(path: '/pair', builder: (_, __) => const PairingScreen()),
+    GoRoute(
+      path: '/pair',
+      // extra carries a tapped moongate:// link (DeepLinkService) so the
+      // pairing screen can stage it exactly as if its scanner had read it.
+      builder: (_, state) => PairingScreen(initialUri: state.extra as String?),
+    ),
     GoRoute(
       path: '/printer/:id',
       builder: (_, state) {
@@ -82,6 +88,7 @@ class _MoongateAppState extends ConsumerState<MoongateApp>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    DeepLinkService.instance.start(_router);
   }
 
   @override

--- a/mobile/lib/features/auth/pairing_screen.dart
+++ b/mobile/lib/features/auth/pairing_screen.dart
@@ -31,7 +31,11 @@ import '../dashboard/feedback_sheet.dart';
 ///   5. On success, the printer row exists in Supabase owned by this
 ///      anonymous user. Add it to the local cache and navigate back.
 class PairingScreen extends StatefulWidget {
-  const PairingScreen({super.key});
+  const PairingScreen({super.key, this.initialUri});
+
+  /// A tapped moongate:// link (tap-to-pair on the Pi's pair page), staged on
+  /// open exactly as if the QR scanner had read it. Null for normal opens.
+  final String? initialUri;
 
   @override
   State<PairingScreen> createState() => _PairingScreenState();
@@ -107,6 +111,13 @@ class _PairingScreenState extends State<PairingScreen> {
         setState(() => _nameHintIx++);
       }
     });
+    // Tap-to-pair: stage the link the user tapped. Post-frame because the
+    // parser reads AppLocalizations from context for its error strings.
+    if (widget.initialUri != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _applyScannedCode(widget.initialUri!);
+      });
+    }
   }
 
   @override

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:go_router/go_router.dart';
+
+/// Tap-to-pair: routes OS-delivered `moongate://` links into the pairing
+/// screen.
+///
+/// The Pi's moongate-pair.html renders its QR payload as a tappable link for
+/// the no-second-screen case (the phone that should pair is the one showing
+/// the page, e.g. over Tailscale - it can't scan its own screen). The OS hands
+/// the URI here via app_links; we navigate to the pairing screen, which runs
+/// it through the exact parser the QR scanner uses. The app lock is untouched:
+/// its overlay sits above the router, so a link tapped while locked just waits
+/// behind the lock screen like any other navigation.
+class DeepLinkService {
+  DeepLinkService._();
+  static final DeepLinkService instance = DeepLinkService._();
+
+  StreamSubscription<Uri>? _sub;
+
+  // uriLinkStream replays the launching link as well as delivering foreground
+  // taps, but some platforms surface a cold-start link through BOTH that
+  // replay and the initial-link API. Remember the last handled link briefly so
+  // one tap can't stage the pairing form twice.
+  Uri?      _lastUri;
+  DateTime? _lastAt;
+
+  /// True for the two pairing payloads the app understands. Anything else
+  /// carrying our scheme (typo'd host, future payloads from a newer Pi) is
+  /// ignored rather than dumped on the pairing screen as an error.
+  static bool isPairingUri(Uri uri) =>
+      uri.scheme == 'moongate' && (uri.host == 'pair' || uri.host == 'lan');
+
+  /// Idempotent. Wired from the app root, which owns the router.
+  void start(GoRouter router) {
+    _sub ??= AppLinks().uriLinkStream.listen((uri) {
+      if (!isPairingUri(uri)) return;
+      final now = DateTime.now();
+      if (uri == _lastUri &&
+          _lastAt != null &&
+          now.difference(_lastAt!) < const Duration(seconds: 2)) {
+        return;
+      }
+      _lastUri = uri;
+      _lastAt  = now;
+      // Land on the dashboard first so the pairing screen pops back to it
+      // from every entry point (cold start included - this also cancels the
+      // splash's own pending hop, its navigation is mounted-guarded).
+      router.go('/dashboard');
+      router.push('/pair', extra: uri.toString());
+    });
+  }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   app_links:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: app_links
       sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
@@ -1299,5 +1299,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -130,6 +130,12 @@ dependencies:
   # cells (the package needs them) while the masonry above is the normal view.
   reorderable_grid_view: ^2.2.8
 
+  # Tap-to-pair deep links: the Pi's pair page offers its moongate:// QR
+  # payload as a tappable link (DeepLinkService routes it to the pairing
+  # screen). Was already in the graph transitively via supabase_flutter; the
+  # 6.x pin below (dependency_overrides) still governs the resolved version.
+  app_links: ^6.4.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/mobile/test/deep_link_service_test.dart
+++ b/mobile/test/deep_link_service_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:moongate/services/deep_link_service.dart';
+
+void main() {
+  group('DeepLinkService.isPairingUri', () {
+    test('accepts the cloud pairing payload', () {
+      final uri = Uri.parse(
+          'moongate://pair?v=3&pk=abc123&et=GATE-1234-5678&ip=192.168.1.50&port=80');
+      expect(DeepLinkService.isPairingUri(uri), isTrue);
+    });
+
+    test('accepts the LAN-only payload', () {
+      final uri =
+          Uri.parse('moongate://lan?v=1&ip=192.168.1.50&port=80&name=voron');
+      expect(DeepLinkService.isPairingUri(uri), isTrue);
+    });
+
+    test('rejects other schemes carrying our hosts', () {
+      expect(DeepLinkService.isPairingUri(Uri.parse('https://pair/x')), isFalse);
+      expect(DeepLinkService.isPairingUri(Uri.parse('http://lan')), isFalse);
+    });
+
+    test('rejects unknown moongate hosts rather than surfacing errors', () {
+      expect(
+          DeepLinkService.isPairingUri(Uri.parse('moongate://update?v=9')),
+          isFalse);
+      expect(DeepLinkService.isPairingUri(Uri.parse('moongate://')), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What will this PR change?

The tap-to-pair button that plugin 0.6.19's pair page already shows (#249) actually works once this ships: tapping the link on the phone that has Moongate installed opens the app straight onto the pairing screen with everything from the QR pre-filled. This is the "I only have my phone" pairing route - open moongate-pair.html on the phone (LAN or Tailscale), tap, name the printer, done. No scanning your own screen, no typing codes.

## Why

A phone cannot scan a QR it is displaying, so pairing with only the phone in hand (the remote/Tailscale case a user raised) had no first-class path. The QR payload is already a `moongate://` link in both modes; the missing half was the app registering that scheme with the OS. Today the scheme exists only inside QR images that the in-app scanner decodes.

## How

- **Android**: VIEW/BROWSABLE intent-filter for scheme `moongate` on MainActivity.
- **iOS**: `CFBundleURLTypes` entry for the same scheme (Info.plist only).
- **DeepLinkService** (new, `mobile/lib/services/deep_link_service.dart`): listens via `app_links` - already in the dependency graph through supabase_flutter, and the AGP-motivated 6.x pin is untouched; it just becomes a declared direct dependency. Accepts only the two known payloads (`moongate://pair`, `moongate://lan`), ignores anything else on our scheme, dedupes the cold-start replay, then lands on the dashboard and pushes the pairing screen so back always returns somewhere sane.
- **PairingScreen** gains `initialUri` and runs a tapped link through `_applyScannedCode`, the exact parser the QR scanner uses: cloud links pre-fill pk/et, LAN links flip to Direct mode and pre-fill address/name. The user still names the printer and taps Pair, so a malicious link can do no more than a malicious QR.
- **App lock unaffected**: the lock overlay sits above the router, so a link tapped while locked waits behind the lock screen like any other navigation.
- Both platforms from the one Dart change; only the scheme registration is native config.

## Testing

- `flutter analyze` clean; full suite passes (55 tests, 4 new covering the link filter).
- Known pubspec.lock trap handled: local pub get rewrote the `sdks:` floors, reverted; the only lock change is app_links moving from "direct overridden" to "direct main" at the same 6.4.1.
- **Device pass owed** on both platforms before release: a real tap from Brave/Safari on the pair page, cold-start and warm, plus the locked-app case. Not possible from this box today.

No version bump - this rides the next app release (0.9.59) with whatever else collects. No changelog entries yet for the same reason; they land in the release PR. No rush to merge; when it does merge, squash with the default title (it inherits this PR's title, which carries the skip token; the branch commits deliberately do not, so PR CI runs).

PEEKYPAUL 28/07/2026
