### PR TITLE
Plugin 0.6.20: LAN-only never imports the cloud crypto deps (embedded RAM fix) [skip ci]

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -55,34 +55,60 @@ from typing import Any, Dict, Optional
 # signing, token verification). LAN-only installs never touch them, and the
 # embedded hosts in docs/third-party-printers.md (no pip, no prebuilt wheels)
 # can't install them at all - so their absence must not stop the module from
-# loading. _CLOUD_DEPS_ERROR doubles as the "why" surfaced in the log, the
+# loading.
+#
+# v0.6.20: the import moved from module level into _import_cloud_deps(),
+# called only when CLOUD mode constructs. A module-level try-import still
+# LOADED the pair whenever they happened to be installed, and a
+# present-but-unused cryptography costs ~6.5 MB of RSS inside Moonraker
+# (measured on a 32-bit Pi: module import ~1 MB without the pair, ~7.5 MB
+# with) - real money on the ~112 MB embedded hosts LAN-only exists for.
+# _CLOUD_DEPS_ERROR doubles as the "why" surfaced in the log, the
 # MOONGATE_PAIR console output and error responses when a CLOUD-mode box is
-# missing them.
-try:
-    import jwt as pyjwt  # PyJWT
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-        Ed25519PrivateKey,
-        Ed25519PublicKey,
-    )
-    _CLOUD_DEPS_ERROR: Optional[str] = None
-except ImportError as _deps_exc:
-    pyjwt             = None  # type: ignore[assignment]
-    serialization     = None  # type: ignore[assignment]
-    Ed25519PrivateKey = None  # type: ignore[assignment]
-    Ed25519PublicKey  = None  # type: ignore[assignment]
-    _CLOUD_DEPS_ERROR = (
-        f"cloud dependencies unavailable ({_deps_exc}); cloud pairing and "
-        "heartbeats are disabled. Install PyJWT[crypto] + cryptography into "
-        "Moonraker's Python, or run LAN-only (lan_only: true)."
-    )
+# missing them; it stays None until cloud construction first probes.
+pyjwt             = None  # type: ignore[assignment]
+serialization     = None  # type: ignore[assignment]
+Ed25519PrivateKey = None  # type: ignore[assignment]
+Ed25519PublicKey  = None  # type: ignore[assignment]
+_CLOUD_DEPS_ERROR: Optional[str] = None
+_CLOUD_DEPS_PROBED = False
+
+
+def _import_cloud_deps() -> Optional[str]:
+    """Import PyJWT + cryptography into the module globals, once. Returns
+    None on success, else the human-readable reason (also kept in
+    _CLOUD_DEPS_ERROR). Idempotent - the verdict is cached either way."""
+    global pyjwt, serialization, Ed25519PrivateKey, Ed25519PublicKey
+    global _CLOUD_DEPS_ERROR, _CLOUD_DEPS_PROBED
+    if _CLOUD_DEPS_PROBED:
+        return _CLOUD_DEPS_ERROR
+    _CLOUD_DEPS_PROBED = True
+    try:
+        import jwt as _pyjwt  # PyJWT
+        from cryptography.hazmat.primitives import serialization as _serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey as _priv,
+            Ed25519PublicKey as _pub,
+        )
+    except ImportError as exc:
+        _CLOUD_DEPS_ERROR = (
+            f"cloud dependencies unavailable ({exc}); cloud pairing and "
+            "heartbeats are disabled. Install PyJWT[crypto] + cryptography into "
+            "Moonraker's Python, or run LAN-only (lan_only: true)."
+        )
+        return _CLOUD_DEPS_ERROR
+    pyjwt             = _pyjwt
+    serialization     = _serialization
+    Ed25519PrivateKey = _priv
+    Ed25519PublicKey  = _pub
+    return None
 
 logger = logging.getLogger("moonraker.moongate")
 
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.19"
+MOONGATE_PLUGIN_VERSION = "0.6.20"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1097,8 +1123,11 @@ class MoongatePlugin:
         # still loads (the LAN endpoints keep working) and says exactly what
         # is wrong in the log and its error responses instead of crashing
         # Moonraker.
-        self._plugin_error = None if self.lan_only else _CLOUD_DEPS_ERROR
-        cloud_ready        = not self.lan_only and _CLOUD_DEPS_ERROR is None
+        # LAN-only never probes the cloud deps, so a host that happens to have
+        # PyJWT/cryptography installed doesn't pay their ~6.5 MB for machinery
+        # that is never constructed (v0.6.20; the embedded-host RAM complaint).
+        self._plugin_error = None if self.lan_only else _import_cloud_deps()
+        cloud_ready        = not self.lan_only and self._plugin_error is None
 
         self.owner = OwnerState.load(self._owner_file)
         if cloud_ready:

--- a/klipper-plugin/tests/test_lan_only_no_deps.py
+++ b/klipper-plugin/tests/test_lan_only_no_deps.py
@@ -3,14 +3,23 @@
 PyJWT/cryptography installed (embedded hosts - see docs/third-party-printers.md
 - have no pip and no prebuilt wheels for them).
 
+v0.6.20 tightened the contract: the pair imports lazily, only when CLOUD mode
+constructs. LAN-only must never import them EVEN WHEN INSTALLED - a
+present-but-unused cryptography costs ~6.5 MB of RSS inside Moonraker
+(measured on a 32-bit Pi), real money on ~112 MB embedded hosts.
+
 Stdlib-only on purpose so it runs anywhere Python 3.9+ does:
 
     python3 klipper-plugin/tests/test_lan_only_no_deps.py
 
 Covers:
-  1. import with jwt + cryptography BLOCKED  -> module loads, error recorded
-  2. MoongatePlugin construction in lan_only -> no cloud objects, no keygen
-  3. import with real deps (when installed)  -> no error recorded (else skip)
+  1. import with jwt + cryptography BLOCKED  -> module loads, no probe yet
+  2. MoongatePlugin construction in lan_only -> no cloud objects, no keygen,
+     and the cloud deps are never probed/imported
+  3. CLOUD-mode construction with deps BLOCKED -> fail-loud-but-running
+     (plugin_error says what to install, no cloud objects)
+  4. import with real deps (when installed)  -> lan_only still never
+     imports them
 """
 
 import importlib.util
@@ -35,6 +44,21 @@ def _load(name):
     return mod
 
 
+class _BlockDeps:
+    """Context manager: `import jwt` / `import cryptography` raise ImportError
+    inside the with-block (None in sys.modules makes the import fail)."""
+    def __enter__(self):
+        for name in BLOCKED:
+            assert name not in sys.modules or sys.modules[name] is None, (
+                f"{name} already imported - run this test in its own process")
+            sys.modules[name] = None
+
+    def __exit__(self, *exc):
+        for name in BLOCKED:
+            del sys.modules[name]
+        return False
+
+
 class FakeServer:
     def register_endpoint(self, *a, **k):      pass
     def register_remote_method(self, *a, **k): pass
@@ -56,18 +80,11 @@ class FakeConfig:
 
 
 def test_import_without_deps():
-    # None in sys.modules makes `import <name>` raise ImportError.
-    for name in BLOCKED:
-        assert name not in sys.modules or sys.modules[name] is None, (
-            f"{name} already imported - run this test in its own process")
-        sys.modules[name] = None
-    try:
+    with _BlockDeps():
         mod = _load("moongate_nodeps")
-    finally:
-        for name in BLOCKED:
-            del sys.modules[name]
-    assert mod._CLOUD_DEPS_ERROR is not None, "deps error not recorded"
-    assert "PyJWT" in mod._CLOUD_DEPS_ERROR
+    # Lazy since v0.6.20: a bare import must neither probe nor fail.
+    assert mod._CLOUD_DEPS_ERROR is None, "import must not probe cloud deps"
+    assert mod._CLOUD_DEPS_PROBED is False
     # Class definitions must survive the missing imports (only calls need them)
     for cls in ("MoongatePlugin", "DeviceKey", "JwksCache",
                 "AccessTokenVerifier", "HeartbeatLoop", "PrintEventWatcher"):
@@ -90,24 +107,46 @@ def test_lan_only_construction(mod):
             "lan_only must not generate a device key"
         # moonraker.conf's lan_only wins over config.json's default (False)
         assert plugin._lan_only_override is True
+        # The v0.6.20 guarantee: lan_only never even probes the cloud deps.
+        assert mod._CLOUD_DEPS_PROBED is False, \
+            "lan_only construction must not import/probe PyJWT+cryptography"
 
 
-def test_import_with_deps():
-    try:
-        import jwt          # noqa: F401
-        import cryptography # noqa: F401
-    except ImportError:
-        print("  (real deps not installed here - normal-import check skipped)")
-        return
+def test_cloud_construction_without_deps():
+    with _BlockDeps():
+        mod = _load("moongate_nodeps_cloud")
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = mod.MoongatePlugin(FakeConfig({"data_path": tmp}))
+    assert plugin.lan_only is False
+    assert plugin._plugin_error is not None, "cloud mode must surface the gap"
+    assert "PyJWT" in plugin._plugin_error
+    assert mod._CLOUD_DEPS_ERROR == plugin._plugin_error
+    for attr in ("device", "jwks", "verifier", "sb", "heartbeat", "watcher"):
+        assert getattr(plugin, attr) is None, f"{attr} built without deps"
+
+
+def test_lan_only_with_real_deps_does_not_import_them():
     mod = _load("moongate_withdeps")
     assert mod._CLOUD_DEPS_ERROR is None, mod._CLOUD_DEPS_ERROR
+    with tempfile.TemporaryDirectory() as tmp:
+        mod.MoongatePlugin(FakeConfig({
+            "lan_only":  True,
+            "data_path": tmp,
+        }))
+    assert mod._CLOUD_DEPS_PROBED is False
+    # Whether or not this machine has the packages, a lan_only construction
+    # must not be the thing that pulls them into the process.
+    assert "jwt" not in sys.modules, \
+        "lan_only construction imported PyJWT as a side effect"
 
 
 if __name__ == "__main__":
     mod = test_import_without_deps()
-    print("PASS import with jwt/cryptography blocked")
+    print("PASS import with jwt/cryptography blocked (no probe, no error)")
     test_lan_only_construction(mod)
-    print("PASS lan_only construction without deps (no cloud objects, no keygen)")
-    test_import_with_deps()
-    print("PASS normal import")
+    print("PASS lan_only construction without deps (no cloud objects, no keygen, no probe)")
+    test_cloud_construction_without_deps()
+    print("PASS cloud construction without deps fails loud but keeps running")
+    test_lan_only_with_real_deps_does_not_import_them()
+    print("PASS lan_only never imports the cloud deps even when installed")
     print("All good.")


### PR DESCRIPTION
## What will this PR change?

Plugin 0.6.20: a LAN-only install never imports PyJWT + cryptography, even on a host where they happen to be installed. This is the answer to the OpenCentauri memory complaint: measured on a 32-bit Pi, importing the module costs about **1 MB** without the crypto pair and about **7.5 MB** with it, and the old module-level try-import loaded the pair whenever it could, LAN-only or not. On the ~112 MB embedded boards LAN-only exists for, that unused import was most of the claimed footprint.

## Why

Discord users on the Elegoo Centauri Carbon (OpenCentauri COSMOS) measured "the moongate module" at 7-10 MB and reasonably asked why something so simple costs that much. Digging showed the LAN-only plugin itself is genuinely small; the multi-MB item is cryptography, which LAN-only never uses but still imported when present. Cloud mode on normal Pis needs and keeps it, unchanged.

## How

- The module-level try-import became `_import_cloud_deps()`, called only when CLOUD mode constructs. LAN-only construction never probes it.
- Same fail-loud-but-running behaviour when a cloud-mode box lacks the deps: `_plugin_error` carries the same message, MOONGATE_PAIR still explains it, nothing constructs.
- Type annotations referencing the crypto classes are safe: the file uses `from __future__ import annotations`, so they are never evaluated at import time.
- `MOONGATE_PLUGIN_VERSION` bumped to 0.6.20; `kCurrentPluginVersion` in the app stays held at 0.6.16 (no fleet nag).

## Testing

- `tests/test_lan_only_no_deps.py` reworked for the lazy contract and extended: bare import never probes; lan_only construction never probes even with real deps installed (asserts `jwt` absent from `sys.modules` afterwards); cloud construction without deps still fails loud with the install hint; plus the existing no-keygen/no-cloud-object assertions. All pass.
- `tests/test_heartbeat_pair_window.py` still passes; `ruff check klipper-plugin/` clean at the pinned 0.15.22.
- Import-cost measurements were taken on the V-Minion (armv7l, printer standby, read-only).

No app version bump, so please squash-merge with the default title (this PR title carries the skip token; the branch commits deliberately do not, so PR CI runs).

PEEKYPAUL 28/07/2026
