### PR TITLE
Docs: Play uploads are CI-artifact-only + pre-upload verification (rescued from 09 Jul)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,10 +90,12 @@ flutter build apk --release --flavor github --dart-define=MOONGATE_CHANNEL=githu
 # Output: build/app/outputs/flutter-apk/app-github-release.apk
 adb install -r build/app/outputs/flutter-apk/app-github-release.apk
 
-# Play App Bundle (no self-updater) - CI / work-box only, never sideload it
+# Play App Bundle (no self-updater) - for local inspection only, never sideload it
 flutter build appbundle --release --flavor play --dart-define=MOONGATE_CHANNEL=play
 # Output: build/app/outputs/bundle/playRelease/app-play-release.aab
 ```
+
+> **The `.aab` that goes to the Play Console must come from the CI artifact, never a local build.** Run the *Build Android APK* workflow (Actions tab; `workflow_dispatch`) and download the `Moongate-play-aab` artifact. The optional `play_build_number` input stamps a different `versionCode` onto the `.aab` only - needed when Play has already consumed a number and the same code must be re-uploaded (Play accepts each `versionCode` exactly once). Before uploading, verify the bundle: `versionCode` in `base/manifest/AndroidManifest.xml`, a feature string from the release inside `base/lib/arm64-v8a/libapp.so` (search UTF-8 **and** UTF-16-LE - Dart stores non-ASCII strings two-byte), and the signing cert SHA-256. A local build from a stale checkout once shipped old code under a new version number; the version label proves nothing about the code inside.
 
 Release builds are signed with the keystore configured in `mobile/android/key.properties` if present, otherwise they fall back to the debug key. Both flavors share the same key and `applicationId`, so a device moves between the sideload APK and the Play build in place with no wipe. CI uses GitHub Secrets - see [Release signing](#release-signing) below.
 

--- a/docs/design/play-flavor-plan.md
+++ b/docs/design/play-flavor-plan.md
@@ -125,8 +125,8 @@ Play, but is not needed for v1.
 4. **Debug-signing fallback unchanged (deliberate).** A `--release` build with no
    `key.properties` still falls back to debug signing (existing behaviour, for
    local `flutter run --release`). Play refuses debug-signed `.aab` uploads, so
-   the Play path is safe; but only ever build the Play `.aab` in CI or on the
-   work box (CDG-3D-TECH) that holds the keystore - never the psych box.
+   the Play path is safe; but the `.aab` that actually goes to the Play Console
+   comes from CI **only** - see caveat 7 for why local builds are banned outright.
 
 5. **`flutter run` / `flutter build` now require `--flavor github`.** Once
    flavors exist, the bare commands error "this app has flavors". Update local
@@ -135,3 +135,27 @@ Play, but is not needed for v1.
 6. **iOS is unaffected.** Android product flavors do not create iOS schemes;
    `flutter build ipa` needs no `--flavor`. Watch the (non-required) `Build iOS`
    check on the first CI run regardless.
+
+7. **Play uploads: CI artifact ONLY, verify before upload (the 2026-07-09
+   incident).** Build 120 was built locally on the work box from a checkout that
+   had not been pulled since the 118 upload, with `0.9.48`/`120` stamped on via
+   build flags: Play reviewed, published, and served **v0.9.46 code labelled
+   v0.9.48** to every tester. Nothing in the upload flow catches this - the
+   version label proves nothing about the code inside. The fix consumed a
+   versionCode (Play accepts each number exactly once; the real 0.9.48 shipped
+   as 121). Rules since:
+   - The Play `.aab` is always the `Moongate-play-aab` artifact from the *Build
+     Android APK* workflow. The `workflow_dispatch` input `play_build_number`
+     re-stamps the versionCode when a number was burned by a bad upload; the
+     APK/Release/manifest pipeline is untouched by it (those steps are gated on
+     `push`).
+   - **Verify every bundle before upload**: unzip the `.aab`, confirm the
+     versionCode in `base/manifest/AndroidManifest.xml`, grep
+     `base/lib/arm64-v8a/libapp.so` for a user-facing string added by the
+     release (check UTF-8 **and** UTF-16-LE - Dart AOT stores any string with a
+     non-ASCII character two-byte, so a plain grep false-negatives), and check
+     the signer fingerprint (`openssl pkcs7 -inform DER -print_certs` on
+     `META-INF/*.RSA`, expect `8878da71...`).
+   - **Check the app on a real device within a day of any Play publish.** The
+     mislabel was caught only because the dev phone auto-updated the same
+     evening and the new features were missing.


### PR DESCRIPTION
**What will this PR change?**

It writes the Play-upload safety rules into the repo docs. In plain English: the `.aab` we upload to the Play Console must always be the CI-built artifact, never a local build, and every bundle gets verified (versionCode, a release-specific string inside `libapp.so`, signing cert) before upload, plus an on-device check within a day of publishing.

**Why?**

These rules have existed since the 2026-07-09 incident (build 120 shipped v0.9.46 code labelled v0.9.48 to every tester because a local build came from a stale checkout), but they only ever lived in session notes. The docs commit written that night was stranded on a local branch on this machine and never pushed. This PR rescues it, cherry-picked cleanly onto current master.

**How?**

- `DEVELOPMENT.md`: a callout under the Play bundle build snippet - CI artifact only, the `play_build_number` re-stamp input, and the three pre-upload checks (versionCode in the manifest, UTF-8 **and** UTF-16-LE string search in `libapp.so`, signer fingerprint).
- `docs/design/play-flavor-plan.md`: caveat 7 documents the incident itself and the standing rules, and caveat 4 now points at it.

**Testing**

Docs-only, no code path affected. Verified the cherry-pick merged into the current DEVELOPMENT.md section cleanly and reads right in place.

PEEKYPAUL 02/08/2026
