### PR TITLE
Plugin 0.6.21: auth proxy probes the lazy cloud deps - fixes remote 500 on 0.6.20 [skip ci]

### DIFF
--- a/klipper-plugin/moongate_authproxy.py
+++ b/klipper-plugin/moongate_authproxy.py
@@ -62,6 +62,7 @@ from moongate_standalone import (  # noqa: E402  (import after path manipulation
     AccessTokenVerifier,
     JwksCache,
     OwnerState,
+    _import_cloud_deps,
 )
 
 # ─── Config ─────────────────────────────────────────────────────────────────
@@ -629,6 +630,27 @@ async def _proxy_websocket(
 
 # ─── Unified handler ────────────────────────────────────────────────────────
 
+@web.middleware
+async def _unhandled_error_middleware(request, handler):
+    """Last-resort catch: journal the traceback and answer a terse 500.
+    Without this, an unhandled exception renders aiohttp's stock HTML error
+    page ("Server got itself in trouble") and the journal shows NOTHING - the
+    0.6.20 pyjwt=None regression served that page to every tunnel request
+    with zero log lines to find it by. request.path deliberately, not
+    path_qs: the query string can carry mg_token."""
+    try:
+        return await handler(request)
+    except asyncio.CancelledError:
+        raise
+    except web.HTTPException:
+        raise
+    except Exception:
+        logger.exception("unhandled error serving %s %s",
+                         request.method, request.path)
+        return web.Response(status=500, text="internal error\n",
+                            headers={"Cache-Control": "no-store"})
+
+
 async def handle(request: web.Request) -> web.StreamResponse:
     deny = await _authorize(request)
     if deny is not None:
@@ -677,7 +699,7 @@ async def _on_cleanup(app: web.Application) -> None:
 
 
 def make_app() -> web.Application:
-    app = web.Application()
+    app = web.Application(middlewares=[_unhandled_error_middleware])
     app.on_startup.append(_on_startup)
     app.on_cleanup.append(_on_cleanup)
     # One catch-all that handles every HTTP method on every path, including
@@ -691,6 +713,18 @@ def main() -> None:
         level=getattr(logging, LOG_LEVEL, logging.INFO),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+    # v0.6.21: moongate_standalone imports PyJWT/cryptography lazily (0.6.20,
+    # so LAN-only never pays their RAM) and the probe only runs when the
+    # Moonraker component constructs in cloud mode - in ITS process. This
+    # process reuses that module's verifier classes and must run the probe
+    # itself, or pyjwt stays None and every tunnel request dies as an
+    # unhandled 500. The proxy only exists on cloud-mode installs, so the
+    # deps are a hard requirement: exit loud and let systemd surface it
+    # rather than serve a broken tunnel.
+    deps_err = _import_cloud_deps()
+    if deps_err is not None:
+        logger.critical("cannot start: %s", deps_err)
+        sys.exit(1)
     # access_log=None: aiohttp's default access logger writes one INFO line
     # per proxied request, and at the app's poll cadence that is ~13 MB/day
     # into a log nothing rotates (it filled a Pi's /run tmpfs in ~2 weeks).

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -66,6 +66,13 @@ from typing import Any, Dict, Optional
 # _CLOUD_DEPS_ERROR doubles as the "why" surfaced in the log, the
 # MOONGATE_PAIR console output and error responses when a CLOUD-mode box is
 # missing them; it stays None until cloud construction first probes.
+#
+# v0.6.21: the auth proxy is a SEPARATE process that imports this module's
+# verifier classes without ever constructing MoongatePlugin (the one place
+# the probe ran), so it must call _import_cloud_deps() itself at startup.
+# 0.6.20 shipped without that: pyjwt stayed None there and every tunnel
+# request died as an unhandled 500 while LAN and heartbeats stayed healthy
+# (first field report 2026-08-03).
 pyjwt             = None  # type: ignore[assignment]
 serialization     = None  # type: ignore[assignment]
 Ed25519PrivateKey = None  # type: ignore[assignment]
@@ -108,7 +115,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.20"
+MOONGATE_PLUGIN_VERSION = "0.6.21"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/klipper-plugin/tests/test_lan_only_no_deps.py
+++ b/klipper-plugin/tests/test_lan_only_no_deps.py
@@ -140,6 +140,44 @@ def test_lan_only_with_real_deps_does_not_import_them():
         "lan_only construction imported PyJWT as a side effect"
 
 
+AUTHPROXY_PATH = Path(__file__).resolve().parents[1] / "moongate_authproxy.py"
+
+
+def test_authproxy_startup_contract():
+    """v0.6.21 regression (the 0.6.20 field failure): the auth proxy is a
+    SEPARATE process that imports JwksCache/AccessTokenVerifier from this
+    module and never constructs MoongatePlugin - the only place the lazy
+    cloud-deps probe ran. Without its own probe, pyjwt stays None and every
+    tunnel request raises AttributeError -> aiohttp's stock 500 page, while
+    LAN (which bypasses the proxy) and heartbeats (the component's process,
+    where the probe DID run) look healthy. Two guards:
+      a) the proxy source probes + exits loud at startup;
+      b) after a successful probe, verify() on garbage tokens returns None
+         (the constant-401 path) instead of raising.
+
+    NOTE this test must stay LAST: on a deps-present box it really imports
+    PyJWT into the process, which would trip test_lan_only_with_real_deps's
+    "jwt not in sys.modules" assert if it ran before it."""
+    src = AUTHPROXY_PATH.read_text(encoding="utf-8")
+    assert "_import_cloud_deps" in src, \
+        "auth proxy no longer probes the lazy cloud deps at startup"
+
+    mod = _load("moongate_authproxy_pattern")
+    err = mod._import_cloud_deps()
+    if err is not None:
+        print("  (PyJWT/cryptography absent on this box - probe reported the "
+              "gap; the verify half needs a deps-present run)")
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        jwks     = mod.JwksCache("https://unused.invalid", "anon-key",
+                                 Path(tmp) / "jwks.json", 3600)
+        verifier = mod.AccessTokenVerifier(jwks)
+        # Garbage tokens fail the header parse long before any JWKS/network
+        # touch - the contract is they 401 (None), never raise.
+        assert verifier.verify("not-a-jwt", None) is None
+        assert verifier.verify("aaaa.bbbb.cccc", None) is None
+
+
 if __name__ == "__main__":
     mod = test_import_without_deps()
     print("PASS import with jwt/cryptography blocked (no probe, no error)")
@@ -149,4 +187,6 @@ if __name__ == "__main__":
     print("PASS cloud construction without deps fails loud but keeps running")
     test_lan_only_with_real_deps_does_not_import_them()
     print("PASS lan_only never imports the cloud deps even when installed")
+    test_authproxy_startup_contract()
+    print("PASS auth proxy probes the lazy deps; verify never raises on garbage")
     print("All good.")


### PR DESCRIPTION
## What will this PR change?

Since plugin 0.6.20 (on master since 29 Jul), remote access through the tunnel answers "500 Internal Server Error / Server got itself in trouble" on every request, while LAN access, heartbeats and the tunnel indicator all stay healthy. This PR fixes that: the auth proxy now loads the crypto libraries it needs at startup, and the plugin version goes to 0.6.21. Anyone already on 0.6.20 gets fixed by a normal plugin update from Mainsail's update manager.

## Why it broke

0.6.20 deliberately stopped importing PyJWT + cryptography at module level so LAN-only installs never pay their ~6.5 MB RAM cost. The import now happens in `_import_cloud_deps()`, called when the Moonraker component constructs in cloud mode, in the component's process.

The auth proxy is a separate process. It imports the same module for its verifier classes but never constructs the component, so nothing ran the probe: `pyjwt` stayed `None`, and the first thing token verification does (`pyjwt.get_unverified_header`) raised AttributeError on every tunnel request. aiohttp turned that into its stock 500 page with nothing in the journal. LAN does not go through the proxy, and heartbeat signing happens in the component's process where the probe DID run, which is why the printer looked fine everywhere except remote.

Field report 2026-08-03 from the farm-Mainsail Discord thread: remote screenshots show the aiohttp 500 page, local works, tunnel checkmark green. Exactly this signature.

## The fix

- `moongate_authproxy.py` `main()` now calls `_import_cloud_deps()` and exits loud (`logger.critical` + exit 1) if the deps are missing. The proxy only exists on cloud-mode installs, so they are a hard requirement there; systemd surfaces the failure instead of the proxy serving a broken tunnel.
- New last-resort middleware: any future unhandled exception is journaled with a traceback and answered as a terse "internal error" 500 instead of aiohttp's default page. This bug would have been one journalctl away with it.
- `MOONGATE_PLUGIN_VERSION` 0.6.20 -> 0.6.21. `kCurrentPluginVersion` stays 0.6.16 (same as 0.6.20: no fleet badge).

## Testing

- `klipper-plugin/tests/test_lan_only_no_deps.py` gains `test_authproxy_startup_contract`: after a successful probe, `verify()` on garbage tokens returns None (the constant-401 path) and never raises; plus a source-level assert that the proxy probes at startup.
- Ran the suite twice locally: bare Python (no deps installed: blocked branches + probe-reports-gap path) and a venv with real PyJWT + cryptography (the verify half runs for real). All green both times.
- The unprobed pattern reproduces the exact field error: AttributeError "'NoneType' object has no attribute 'PyJWTError'".
- Live e2e on the V-Minion after merge: a real cloud-mode installer run bringing the rig to 0.6.21, riding the owed MOONGATE_KEEP_BIND e2e.

## Rollout

Pis already on 0.6.20: refresh + update moongate in Mainsail's update manager. The update restarts Moonraker and PartOf= propagates the restart to the auth proxy, so remote access comes back without touching anything else.

PEEKYPAUL 03/08/2026
