### PR TITLE
Docs: 0.6.20 remote-500 troubleshooting entry + authproxy startup-probe notes (end sweep 03 Aug)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -330,7 +330,7 @@ It costs N parallel HTTP loops where N is the number of printers, but that's fin
 
 The Moongate plugin runs inside Moonraker's process and has access to anything Moonraker depends on. Staying within that surface (stdlib + Moonraker's existing deps) reduces installation to "copy one file and restart Moonraker". No virtualenvs, no `pip install`, no breakage when Moonraker updates.
 
-The auth proxy is the one exception - it pulls in `aiohttp` (`pip install` inside Moonraker's venv) because there's no Moonraker-native way to intercept everything *before* Moonraker. The verifier classes (token-signature checks, owner state) are imported from the plugin file rather than duplicated, so signature semantics stay single-source.
+The auth proxy is the one exception - it pulls in `aiohttp` (`pip install` inside Moonraker's venv) because there's no Moonraker-native way to intercept everything *before* Moonraker. The verifier classes (token-signature checks, owner state) are imported from the plugin file rather than duplicated, so signature semantics stay single-source. One consequence of that sharing: the plugin file loads its signing/verification libraries lazily (v0.6.20, so LAN-only installs never pay their memory cost), and the proxy - a separate process - therefore runs that load itself at startup and refuses to start if the libraries are missing (v0.6.21). A proxy that can't verify tokens must fail loudly at boot, not crash on every request.
 
 ### Cloud middleman, not a Moongate-operated print server
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -263,7 +263,7 @@ The plugin logs under the `moonraker.moongate` logger - its messages are prefixe
 journalctl -u moongate-authproxy -f
 ```
 
-The proxy logs every request at INFO with the verdict (forwarded / 401), the path, and the cause when 401. Useful for distinguishing "the token is bad" from "the path doesn't match anything".
+The proxy is quiet on the happy path (the per-request access lines were removed in plugin 0.6.14 - they were filling `/run`). Token rejections log at DEBUG - set `MG_LOG_LEVEL=DEBUG` in the unit to see per-request verdicts and distinguish "the token is bad" from "the path doesn't match anything". Since 0.6.21 any unexpected internal error writes a full traceback to the journal before answering a terse 500, so an empty journal means healthy and a traceback names the failing hop.
 
 ### Tunnel-side: cloudflared logs
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -252,6 +252,12 @@ curl -fsSL https://raw.githubusercontent.com/PEEKYPAUL/Moongate/master/klipper-p
 
 A bug report (see above) now shows the **Pi's plugin version**, so you can confirm the Pi is on v0.6.4+ afterwards.
 
+## Remote shows "500 Internal Server Error" but LAN works (plugin 0.6.20)
+
+If every **remote (tunnel)** request answers a plain "500 Internal Server Error / Server got itself in trouble" page while home-WiFi access, pairing and the tunnel indicator all look healthy, the Pi is on **plugin 0.6.20** (installed or updated between 29 Jul and 3 Aug 2026). A memory-saving change in 0.6.20 left the tunnel gatekeeper without the signature-checking library it needs, so it crashed on every remote request instead of answering. Nothing was lost or exposed: it failed *closed*, and local access never goes through that gatekeeper, which is why everything else kept working.
+
+**Fix:** update the plugin to **0.6.21 or newer** (*Mainsail → Machine → Update Manager* - refresh, then update **moongate**; or re-run the installer). Remote access returns as soon as the services restart - no re-pairing and no app update needed.
+
 ## Webcam not showing
 
 - The app uses the snapshot path Moonraker reports for your webcam - typically `/webcam/?action=snapshot` for mjpg-streamer setups.


### PR DESCRIPTION
## What will this PR change?

Documentation only, closing out the 0.6.20 remote-500 incident. Users who hit the bug get a findable TROUBLESHOOTING entry with the exact page text they saw and the one-step fix; the architecture and development docs stop being wrong about how the auth proxy loads its libraries and what it logs.

- **TROUBLESHOOTING.md**: new section "Remote shows '500 Internal Server Error' but LAN works (plugin 0.6.20)" beside its v0.6.3 sibling - the signature (remote-only stock 500 page, LAN and tunnel indicator healthy), the affected window (29 Jul to 3 Aug 2026), the reassurance (failed closed, nothing exposed), and the fix (update plugin to 0.6.21 via Mainsail's Update Manager, no re-pair, no app update).
- **ARCHITECTURE.md**: the single-source verifier paragraph now records the 0.6.21 consequence - the proxy runs the lazy dependency load itself at startup and refuses to boot without the libraries, instead of crashing per request.
- **DEVELOPMENT.md**: the auth-proxy logging section stops claiming per-request INFO lines (removed back in 0.6.14) and now documents reality: quiet happy path, DEBUG verdicts via MG_LOG_LEVEL, and the 0.6.21 traceback-then-terse-500 for internal errors.

## Testing

Link audit run across all Markdown: zero broken internal links; key external URLs (installer raw, v0.9.58 APK asset, Play listing, App Store listing) all answer 200. README, SECURITY and CHANGELOG checked against this session's changes and confirmed unaffected (SECURITY's "401 with 13-byte body" verification recipe was re-proven live on the fixed rig).

PEEKYPAUL 03/08/2026
