### PR TITLE
Plugin 0.6.22: report every enabled webcam in /status [skip ci]

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -115,7 +115,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.21"
+MOONGATE_PLUGIN_VERSION = "0.6.22"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -264,6 +264,104 @@ def _b64std(data: bytes) -> str:
 
 def _b64url_pad(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+# v0.6.22 - every enabled Moonraker webcam rides /status (`webcams: [...]`),
+# not just the first, so the app's dashboard tile can offer a camera switcher.
+# Payload backstop: nobody runs 8 cameras on one printer; a runaway list (a
+# scripted config gone wrong) must not bloat every 4-second poll.
+_WEBCAM_LIST_CAP = 8
+
+
+def _external_cam_url(raw: Any) -> Optional[str]:
+    """An absolute http(s) URL whose host is some OTHER device on the
+    network (not localhost / 127.x) - i.e. a camera Moonraker can't
+    snapshot for us, e.g. an old phone running an IP-webcam app and
+    configured in Mainsail as a stream_url like
+    http://192.168.0.107:8080/video. Returns the URL, else None. The
+    app uses it directly on LAN, or via the /mg-extcam proxy remote."""
+    s = (raw or "").strip()
+    m = re.match(r"^https?://([^/:]+)", s, re.IGNORECASE)
+    if not m:
+        return None
+    host = m.group(1).lower()
+    if host == "localhost" or host.startswith("127."):
+        return None
+    return s
+
+
+def _webcam_entry(cam: dict, index: int = 0) -> dict:
+    """Normalise ONE raw Moonraker webcam entry into the shape /status
+    carries. Defensive on every field - one half-configured camera must
+    never take the whole list (or the poll) down with it."""
+    _default_path = "/webcam/?action=snapshot"
+    _default_fps  = 15
+
+    stream_external   = _external_cam_url(cam.get("stream_url"))
+    snapshot_external = _external_cam_url(cam.get("snapshot_url"))
+
+    # Relative Pi-served snapshot path for the normal (Crowsnest / uv4l)
+    # case. An absolute EXTERNAL snapshot_url must NOT leak into
+    # snapshot_path - the app would build tunnel_base + absolute_url and
+    # get garbage - so fall back to the default and surface the external
+    # URL separately via snapshot_external instead.
+    snap_raw = (cam.get("snapshot_url") or "").strip()
+    if snapshot_external:
+        snap = _default_path
+    elif snap_raw:
+        snap = re.sub(
+            r"^https?://(localhost|127\.0\.0\.1)(:\d+)?", "", snap_raw)
+    else:
+        snap = _default_path
+
+    raw_fps = cam.get("target_fps", _default_fps)
+    try:
+        tgt_fps = int(raw_fps)
+        if tgt_fps < 1 or tgt_fps > 60:
+            tgt_fps = _default_fps
+    except (TypeError, ValueError):
+        tgt_fps = _default_fps
+
+    try:
+        rotation = int(cam.get("rotation", 0) or 0)
+    except (TypeError, ValueError):
+        rotation = 0
+
+    # Moonraker names default to "webcam"; an empty one still needs a label
+    # the app can show in the picker. uid is the stable identity (survives
+    # renames); older Moonraker without uids falls back to name matching.
+    name = str(cam.get("name") or "").strip() or f"Camera {index + 1}"
+    uid  = str(cam.get("uid")  or "").strip() or None
+
+    return {
+        "name":              name,
+        "uid":               uid,
+        "snapshot_path":     snap or _default_path,
+        "flip_horizontal":   bool(cam.get("flip_horizontal", False)),
+        "flip_vertical":     bool(cam.get("flip_vertical",   False)),
+        "rotation":          rotation,
+        "target_fps":        tgt_fps,
+        "stream_external":   stream_external,
+        "snapshot_external": snapshot_external,
+    }
+
+
+def _webcam_entries(webcams: Any) -> list:
+    """The full normalised camera list for /status: enabled entries only,
+    original Moonraker order kept (index feeds the fallback names), capped
+    at _WEBCAM_LIST_CAP."""
+    entries: list = []
+    if not isinstance(webcams, list):
+        return entries
+    for i, cam in enumerate(webcams):
+        if not isinstance(cam, dict):
+            continue
+        if cam.get("enabled", True) is False:
+            continue
+        entries.append(_webcam_entry(cam, i))
+        if len(entries) >= _WEBCAM_LIST_CAP:
+            break
+    return entries
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1883,6 +1981,11 @@ class MoongatePlugin:
         # - directly on LAN, or through the /mg-extcam proxy when remote.
         result["webcam_stream_external"]   = webcam["stream_external"]
         result["webcam_snapshot_external"] = webcam["snapshot_external"]
+        # v0.6.22: the FULL camera list (same normalised shape per entry).
+        # The flat webcam_* fields above stay the first camera so older
+        # apps keep working; a 0.9.59+ app prefers this list and shows its
+        # dashboard camera switcher when there's more than one entry.
+        result["webcams"] = webcam["webcams"]
         return result
 
     async def _handle_control(self, webrequest: Any) -> dict:
@@ -1995,35 +2098,20 @@ class MoongatePlugin:
 
     async def _get_webcam_info(self, client: Any) -> dict:
         # Not a staticmethod since v0.6.17: the fetch below needs the
-        # instance's resolved Moonraker port.
+        # instance's resolved Moonraker port. Per-camera normalisation lives
+        # in the module-level _webcam_entry/_webcam_entries helpers (v0.6.22)
+        # so the stdlib tests can hit it without Moonraker or tornado.
         from tornado.httpclient import HTTPRequest
-        _default_path = "/webcam/?action=snapshot"
-        _default_fps  = 15
         _defaults = {
-            "snapshot_path":     _default_path,
+            "snapshot_path":     "/webcam/?action=snapshot",
             "flip_horizontal":   False,
             "flip_vertical":     False,
             "rotation":          0,
-            "target_fps":        _default_fps,
+            "target_fps":        15,
             "stream_external":   None,
             "snapshot_external": None,
+            "webcams":           [],
         }
-
-        def _ext(raw: Any) -> Optional[str]:
-            # An absolute http(s) URL whose host is some OTHER device on the
-            # network (not localhost / 127.x) - i.e. a camera Moonraker can't
-            # snapshot for us, e.g. an old phone running an IP-webcam app and
-            # configured in Mainsail as a stream_url like
-            # http://192.168.0.107:8080/video. Returns the URL, else None. The
-            # app uses it directly on LAN, or via the /mg-extcam proxy remote.
-            s = (raw or "").strip()
-            m = re.match(r"^https?://([^/:]+)", s, re.IGNORECASE)
-            if not m:
-                return None
-            host = m.group(1).lower()
-            if host == "localhost" or host.startswith("127."):
-                return None
-            return s
 
         try:
             req = HTTPRequest(
@@ -2034,44 +2122,20 @@ class MoongatePlugin:
             if resp.code != 200:
                 return _defaults
             data    = json.loads(resp.body)
-            webcams = data.get("result", {}).get("webcams", [])
-            if not webcams:
+            entries = _webcam_entries(
+                data.get("result", {}).get("webcams", []))
+            if not entries:
                 return _defaults
-            cam = webcams[0]
-
-            stream_external   = _ext(cam.get("stream_url"))
-            snapshot_external = _ext(cam.get("snapshot_url"))
-
-            # Relative Pi-served snapshot path for the normal (Crowsnest /
-            # uv4l) case. An absolute EXTERNAL snapshot_url must NOT leak into
-            # snapshot_path - the app would build tunnel_base + absolute_url
-            # and get garbage - so fall back to the default and surface the
-            # external URL separately via snapshot_external instead.
-            snap_raw = (cam.get("snapshot_url") or "").strip()
-            if snapshot_external:
-                snap = _default_path
-            elif snap_raw:
-                snap = re.sub(
-                    r"^https?://(localhost|127\.0\.0\.1)(:\d+)?", "", snap_raw)
-            else:
-                snap = _default_path
-
-            raw_fps = cam.get("target_fps", _default_fps)
-            try:
-                tgt_fps = int(raw_fps)
-                if tgt_fps < 1 or tgt_fps > 60:
-                    tgt_fps = _default_fps
-            except (TypeError, ValueError):
-                tgt_fps = _default_fps
-            return {
-                "snapshot_path":     snap or _default_path,
-                "flip_horizontal":   bool(cam.get("flip_horizontal", False)),
-                "flip_vertical":     bool(cam.get("flip_vertical",   False)),
-                "rotation":          int(cam.get("rotation", 0)),
-                "target_fps":        tgt_fps,
-                "stream_external":   stream_external,
-                "snapshot_external": snapshot_external,
-            }
+            # The flat single-camera fields mirror the FIRST enabled entry -
+            # the pre-0.6.22 shape, and what pre-multicam apps keep reading.
+            first = entries[0]
+            info  = {k: first[k] for k in (
+                "snapshot_path", "flip_horizontal", "flip_vertical",
+                "rotation", "target_fps", "stream_external",
+                "snapshot_external",
+            )}
+            info["webcams"] = entries
+            return info
         except Exception:
             return _defaults
 

--- a/klipper-plugin/tests/test_webcam_list.py
+++ b/klipper-plugin/tests/test_webcam_list.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""v0.6.22: /status carries EVERY enabled Moonraker webcam (`webcams: [...]`),
+not just the first - the app's dashboard tile shows a camera switcher when
+more than one is present. The flat webcam_* fields stay the first enabled
+camera, which is the whole back-compat story: pre-multicam apps keep reading
+the flat fields, 0.9.59+ apps prefer the list.
+
+Stdlib-only, same harness as test_lan_only_no_deps.py:
+
+    python3 klipper-plugin/tests/test_webcam_list.py
+"""
+
+import asyncio
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "moongate_standalone.py"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_PATH)
+    mod  = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass looks its module up in sys.modules.
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+class FakeServer:
+    def register_endpoint(self, *a, **k):      pass
+    def register_remote_method(self, *a, **k): pass
+    def lookup_component(self, *a, **k):       raise KeyError("not in test")
+    def get_host_info(self):                   return {"port": 80}
+    def error(self, msg, code=500):            return RuntimeError(f"{code}: {msg}")
+
+
+class FakeConfig:
+    """Duck-typed stand-in for Moonraker's ConfigHelper ([moongate] section)."""
+    def __init__(self, opts):
+        self._opts   = opts
+        self._server = FakeServer()
+
+    def get_server(self):            return self._server
+    def get(self, k, d=None):        return self._opts.get(k, d)
+    def getboolean(self, k, d=None): return self._opts.get(k, d)
+    def getint(self, k, d=None):     return self._opts.get(k, d)
+
+
+class FakeResp:
+    def __init__(self, code, body):
+        self.code = code
+        self.body = body
+
+
+class FakeClient:
+    """Stands in for tornado's AsyncHTTPClient: answers /server/webcams/list
+    with a canned payload (or a canned error code)."""
+    def __init__(self, webcams=None, code=200):
+        self._webcams = webcams or []
+        self._code    = code
+
+    async def fetch(self, req, raise_error=False):
+        body = json.dumps({"result": {"webcams": self._webcams}}).encode()
+        return FakeResp(self._code, body)
+
+
+def _stub_tornado():
+    """_get_webcam_info lazily does `from tornado.httpclient import
+    HTTPRequest`; a stdlib box has no tornado, so plant a minimal fake."""
+    if "tornado.httpclient" in sys.modules:
+        return
+    httpclient = types.ModuleType("tornado.httpclient")
+
+    class HTTPRequest:
+        def __init__(self, url, **kw):
+            self.url = url
+
+    httpclient.HTTPRequest = HTTPRequest
+    tornado = types.ModuleType("tornado")
+    tornado.httpclient = httpclient
+    sys.modules.setdefault("tornado", tornado)
+    sys.modules["tornado.httpclient"] = httpclient
+
+
+def test_entry_normalisation(mod):
+    # Normal Pi-served camera: relative snapshot path rides through untouched.
+    e = mod._webcam_entry({
+        "name":         "Nozzle",
+        "uid":          "ec20767d",
+        "snapshot_url": "/webcam/?action=snapshot",
+        "stream_url":   "/webcam/?action=stream",
+        "target_fps":   30,
+        "rotation":     180,
+        "flip_horizontal": True,
+    })
+    assert e["name"] == "Nozzle" and e["uid"] == "ec20767d"
+    assert e["snapshot_path"] == "/webcam/?action=snapshot"
+    assert e["stream_external"] is None and e["snapshot_external"] is None
+    assert e["target_fps"] == 30 and e["rotation"] == 180
+    assert e["flip_horizontal"] is True and e["flip_vertical"] is False
+
+    # localhost absolute URL is stripped to its path (Moonraker often stores
+    # http://127.0.0.1/webcam2/... for the second Crowsnest cam).
+    e = mod._webcam_entry({
+        "name":         "Chamber",
+        "snapshot_url": "http://127.0.0.1/webcam2/?action=snapshot",
+    })
+    assert e["snapshot_path"] == "/webcam2/?action=snapshot"
+    assert e["snapshot_external"] is None
+
+    # External phone-cam: absolute URL surfaces via *_external, and the
+    # snapshot_path falls back to the default instead of leaking the URL.
+    e = mod._webcam_entry({
+        "name":       "Phone",
+        "stream_url": "http://192.168.0.107:8080/video",
+    })
+    assert e["stream_external"] == "http://192.168.0.107:8080/video"
+    assert e["snapshot_path"] == "/webcam/?action=snapshot"
+
+    # Garbage fps / rotation never take the entry down.
+    e = mod._webcam_entry({"target_fps": "abc", "rotation": "sideways"}, 1)
+    assert e["target_fps"] == 15 and e["rotation"] == 0
+    # Unnamed cam gets an indexed fallback label; missing uid stays None.
+    assert e["name"] == "Camera 2" and e["uid"] is None
+    e = mod._webcam_entry({"target_fps": 999})
+    assert e["target_fps"] == 15
+
+
+def test_entries_filter_and_cap(mod):
+    cams = [
+        {"name": "one"},
+        {"name": "off", "enabled": False},
+        "not-a-dict",
+        {"name": "two"},
+    ]
+    entries = mod._webcam_entries(cams)
+    assert [e["name"] for e in entries] == ["one", "two"]
+
+    entries = mod._webcam_entries([{"name": f"c{i}"} for i in range(12)])
+    assert len(entries) == mod._WEBCAM_LIST_CAP
+
+    assert mod._webcam_entries(None) == []
+    assert mod._webcam_entries({"name": "not-a-list"}) == []
+
+
+def test_status_contract(mod):
+    """The async fetch path: flat webcam_* fields mirror the first enabled
+    entry, the full list rides alongside, and a Moonraker error still
+    returns the defaults (with an empty list, never a missing key)."""
+    _stub_tornado()
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin = mod.MoongatePlugin(FakeConfig({
+            "lan_only":  True,
+            "data_path": tmp,
+        }))
+
+    info = asyncio.run(plugin._get_webcam_info(FakeClient([
+        {"name": "off-first", "enabled": False,
+         "snapshot_url": "/webcam9/?action=snapshot"},
+        {"name": "Nozzle",  "uid": "aaa",
+         "snapshot_url": "/webcam/?action=snapshot",  "target_fps": 30},
+        {"name": "Chamber", "uid": "bbb",
+         "snapshot_url": "http://127.0.0.1/webcam2/?action=snapshot"},
+    ])))
+    assert [e["name"] for e in info["webcams"]] == ["Nozzle", "Chamber"]
+    assert info["snapshot_path"] == "/webcam/?action=snapshot"
+    assert info["target_fps"] == 30
+    assert info["webcams"][1]["snapshot_path"] == "/webcam2/?action=snapshot"
+
+    info = asyncio.run(plugin._get_webcam_info(FakeClient(code=500)))
+    assert info["webcams"] == [] and info["target_fps"] == 15
+
+    info = asyncio.run(plugin._get_webcam_info(FakeClient([])))
+    assert info["webcams"] == []
+    assert info["snapshot_path"] == "/webcam/?action=snapshot"
+
+
+if __name__ == "__main__":
+    mod = _load("moongate_webcams")
+    test_entry_normalisation(mod)
+    print("PASS per-camera normalisation (paths, externals, fps, names)")
+    test_entries_filter_and_cap(mod)
+    print("PASS list building (enabled filter, junk tolerance, cap)")
+    test_status_contract(mod)
+    print("PASS /status contract (flat fields = first entry, list alongside)")
+    print("All good.")


### PR DESCRIPTION
## What will this PR change?

The plugin has only ever told the app about the FIRST webcam in Moonraker's list (`webcams[0]`), so a printer with two cameras can never show its second one in the app. That is exactly adamstorm's dual-cam report: switching feeds inside Mainsail is client-side only, it never reorders Moonraker's list, so the app stayed glued to camera 1 forever.

In plain English: after this, `/status` tells the app about ALL the cameras, and the companion app PR #262 grows a switcher on the dashboard tile. On its own this PR is invisible; nothing changes for anyone until both halves are running.

## Why

- One user, one visible report, but multi-cam rigs are common (nozzle + chamber Crowsnest pairs) and every one of them silently loses cameras in the app today.
- Mirroring "whatever Mainsail is showing" is not possible: Mainsail's switch is a per-browser view choice. The app needs its own per-printer pick, which needs the full list first.

## How

- `/status` gains `webcams: [...]`, one normalised entry per ENABLED camera in Moonraker's order, capped at 8: name, uid, snapshot_path, flips, rotation, target_fps, stream/snapshot external URLs. Same normalisation as before, factored into module-level pure helpers (`_webcam_entry` / `_webcam_entries`) so the stdlib tests can hit it without Moonraker or tornado.
- The legacy flat `webcam_*` fields still mirror the FIRST enabled entry, so a pre-multicam app keeps seeing exactly what it saw. One subtle improvement: a DISABLED first camera no longer occupies the single slot; the first enabled one does, matching what Mainsail actually shows.
- Zero new endpoints, zero new dependencies, identical behaviour in LAN-only / Direct mode. Typical payload cost is one or two entries at roughly 200 bytes each, riding the existing authenticated /status.
- `MOONGATE_PLUGIN_VERSION` bumps to 0.6.22. The app-side `kCurrentPluginVersion` badge stays held at 0.6.16 deliberately: single-camera users gain nothing from this, so no fleet-wide amber nag.

## Compatibility (the combo check)

- New plugin + old app: old apps read the flat fields only, unchanged.
- Old plugin + new app: the app synthesises one camera from the flat fields, the switcher stays hidden, behaviour identical to today.
- New + new: the switcher appears on printers reporting 2+ cameras.

## Testing

- [x] `python3 klipper-plugin/tests/test_webcam_list.py` passes (new: per-entry normalisation, enabled filter + cap + junk tolerance, async /status contract with tornado stubbed)
- [x] `python3 klipper-plugin/tests/test_lan_only_no_deps.py` still passes (no new module-level imports, lazy cloud-deps contract untouched)
- [ ] RELEASE GATE, not yet run: real cloud-mode pass on the V-Minion (install this branch, one remote request through the live tunnel with a real token expecting 200, the garbage-token probe answering 401 not 500, journal look at moongate-authproxy + moonraker). The rig is not reachable from the home box tonight, so this PR stays DRAFT until that pass is green.
- [ ] Two-camera e2e on the rig: add a second Mainsail webcam entry on the V-Minion pointing at the Micron+'s go2rtc frame URL, then switch cameras over LAN and over the tunnel with #262's build.

PEEKYPAUL 03/08/2026
