### PR TITLE
A stale webcam entry no longer kills the camera: fall back to the default path

### DIFF
--- a/mobile/lib/features/dashboard/printer_tile.dart
+++ b/mobile/lib/features/dashboard/printer_tile.dart
@@ -677,19 +677,24 @@ class _PrinterTileState extends ConsumerState<PrinterTile>
                         onCleared: _statusService.pollNow,
                       ),
                     ),
-                  // Dead-override notice: the status service has set a
-                  // hard-failing custom camera aside and this feed is the
-                  // printer's own (PrinterStatus.customCameraDown). The swap
+                  // Dead-camera notice: the status service has set a
+                  // hard-failing camera aside - a custom override yielding
+                  // to the printer's own camera (customCameraDown), or the
+                  // printer's own configured camera yielding to the default
+                  // snapshot path (configuredCameraDown, a webcam entry
+                  // left pointing at a dismantled camera service). The swap
                   // must never be silent - on a fleet dashboard a quietly
                   // substituted feed is how someone watches the wrong
                   // camera. Sits under the status badge; a tap opens the
-                  // same gear dialog where the override is fixed or cleared.
-                  if (_status.customCameraDown)
+                  // gear dialog, where an override is fixed or cleared and
+                  // a stale-entry victim can pin a working address.
+                  if (_status.customCameraDown || _status.configuredCameraDown)
                     Positioned(
                       top: 36,
                       left: 8,
-                      child: _CustomCameraDownNotice(
+                      child: _CameraDownNotice(
                         printer: widget.printer,
+                        configured: !_status.customCameraDown,
                         onApplied: _statusService.pollNow,
                       ),
                     ),
@@ -1919,19 +1924,24 @@ class _CameraConfigButton extends ConsumerWidget {
   }
 }
 
-// ── Custom-camera-down notice ─────────────────────────────────────────────────
+// ── Dead-camera notice ────────────────────────────────────────────────────────
 //
-// Shown on the webcam square while the status service has a dead custom
-// override set aside in favour of the printer's own camera
-// ([PrinterStatus.customCameraDown]). Names the swap and opens the gear
-// dialog on tap - the override is the user's to fix or clear, never
-// auto-deleted.
+// Shown on the webcam square while the status service has a dead camera set
+// aside: a custom override yielding to the printer's own camera
+// ([PrinterStatus.customCameraDown]), or the printer's configured camera
+// yielding to the default snapshot path
+// ([PrinterStatus.configuredCameraDown]). Names the swap and opens the gear
+// dialog on tap - the override (or Mainsail's webcam entry) is the user's to
+// fix, never auto-edited.
 
-class _CustomCameraDownNotice extends StatelessWidget {
+class _CameraDownNotice extends StatelessWidget {
   final PrinterConfig printer;
+  final bool configured;
   final VoidCallback onApplied;
-  const _CustomCameraDownNotice(
-      {required this.printer, required this.onApplied});
+  const _CameraDownNotice(
+      {required this.printer,
+      required this.configured,
+      required this.onApplied});
 
   @override
   Widget build(BuildContext context) {
@@ -1956,7 +1966,9 @@ class _CustomCameraDownNotice extends StatelessWidget {
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 110),
                 child: Text(
-                  l.customCameraDownNotice,
+                  configured
+                      ? l.configuredCameraDownNotice
+                      : l.customCameraDownNotice,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "Kamera nicht erreichbar, Adresse prüfen",
   "webcamUnreachableOldPlugin": "Kamera nicht erreichbar. Das Drucker-Plugin ist veraltet, ein Update kann die Kamera reparieren.",
   "customCameraDownNotice": "Eigene Kamera nicht erreichbar",
+  "configuredCameraDownNotice": "Konfigurierte Kamera nicht erreichbar",
   "printerUnreachable": "Drucker nicht erreichbar",
   "printerUseTunnel": "Tunnel verwenden",
   "printerAddressInvalid": "Versuche z. B. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -830,6 +830,8 @@
   "@webcamUnreachableOldPlugin": {"description": "Unreachable-camera message when the printer also reports an outdated Moongate plugin - old plugins have served broken camera info, so the plugin is the first thing to try."},
   "customCameraDownNotice": "Custom camera unreachable",
   "@customCameraDownNotice": {"description": "Tappable notice on the webcam tile while a dead custom camera override has been set aside and the printer's own camera is shown instead - tapping opens the camera dialog."},
+  "configuredCameraDownNotice": "Configured camera unreachable",
+  "@configuredCameraDownNotice": {"description": "Tappable notice on the webcam tile while the camera address from the printer's own webcam config keeps failing and the default camera path is shown instead - tapping opens the camera dialog."},
   "printerUnreachable": "Printer unreachable",
   "@printerUnreachable": {"description": "Heading on the full-screen error overlay when the printer cannot be loaded."},
   "printerUseTunnel": "Use tunnel",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "Cámara inaccesible, comprueba su dirección",
   "webcamUnreachableOldPlugin": "Cámara inaccesible. El plugin de la impresora está desactualizado, actualizarlo puede arreglar la cámara.",
   "customCameraDownNotice": "Cámara personalizada inaccesible",
+  "configuredCameraDownNotice": "Cámara configurada inaccesible",
   "printerUnreachable": "Impresora inaccesible",
   "printerUseTunnel": "Usar túnel",
   "printerAddressInvalid": "Prueba p. ej. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "Caméra injoignable, vérifiez son adresse",
   "webcamUnreachableOldPlugin": "Caméra injoignable. Le plugin de l'imprimante est obsolète, le mettre à jour peut réparer la caméra.",
   "customCameraDownNotice": "Caméra personnalisée injoignable",
+  "configuredCameraDownNotice": "Caméra configurée injoignable",
   "printerUnreachable": "Imprimante injoignable",
   "printerUseTunnel": "Utiliser le tunnel",
   "printerAddressInvalid": "Essayez par ex. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "Telecamera irraggiungibile, controlla l'indirizzo",
   "webcamUnreachableOldPlugin": "Telecamera irraggiungibile. Il plugin della stampante non è aggiornato, aggiornarlo può risolvere il problema.",
   "customCameraDownNotice": "Telecamera personalizzata irraggiungibile",
+  "configuredCameraDownNotice": "Telecamera configurata irraggiungibile",
   "printerUnreachable": "Stampante irraggiungibile",
   "printerUseTunnel": "Usa il tunnel",
   "printerAddressInvalid": "Prova ad es. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -2548,6 +2548,12 @@ abstract class AppLocalizations {
   /// **'Custom camera unreachable'**
   String get customCameraDownNotice;
 
+  /// Tappable notice on the webcam tile while the camera address from the printer's own webcam config keeps failing and the default camera path is shown instead - tapping opens the camera dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Configured camera unreachable'**
+  String get configuredCameraDownNotice;
+
   /// Heading on the full-screen error overlay when the printer cannot be loaded.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/app_localizations_de.dart
+++ b/mobile/lib/l10n/app_localizations_de.dart
@@ -1397,6 +1397,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get customCameraDownNotice => 'Eigene Kamera nicht erreichbar';
 
   @override
+  String get configuredCameraDownNotice =>
+      'Konfigurierte Kamera nicht erreichbar';
+
+  @override
   String get printerUnreachable => 'Drucker nicht erreichbar';
 
   @override

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -1377,6 +1377,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get customCameraDownNotice => 'Custom camera unreachable';
 
   @override
+  String get configuredCameraDownNotice => 'Configured camera unreachable';
+
+  @override
   String get printerUnreachable => 'Printer unreachable';
 
   @override

--- a/mobile/lib/l10n/app_localizations_es.dart
+++ b/mobile/lib/l10n/app_localizations_es.dart
@@ -1407,6 +1407,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get customCameraDownNotice => 'Cámara personalizada inaccesible';
 
   @override
+  String get configuredCameraDownNotice => 'Cámara configurada inaccesible';
+
+  @override
   String get printerUnreachable => 'Impresora inaccesible';
 
   @override

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -1409,6 +1409,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get customCameraDownNotice => 'Caméra personnalisée injoignable';
 
   @override
+  String get configuredCameraDownNotice => 'Caméra configurée injoignable';
+
+  @override
   String get printerUnreachable => 'Imprimante injoignable';
 
   @override

--- a/mobile/lib/l10n/app_localizations_it.dart
+++ b/mobile/lib/l10n/app_localizations_it.dart
@@ -1403,6 +1403,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Telecamera personalizzata irraggiungibile';
 
   @override
+  String get configuredCameraDownNotice =>
+      'Telecamera configurata irraggiungibile';
+
+  @override
   String get printerUnreachable => 'Stampante irraggiungibile';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pl.dart
+++ b/mobile/lib/l10n/app_localizations_pl.dart
@@ -1395,6 +1395,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get customCameraDownNotice => 'Kamera niestandardowa nieosiągalna';
 
   @override
+  String get configuredCameraDownNotice => 'Skonfigurowana kamera nieosiągalna';
+
+  @override
   String get printerUnreachable => 'Drukarka nieosiągalna';
 
   @override

--- a/mobile/lib/l10n/app_localizations_pt.dart
+++ b/mobile/lib/l10n/app_localizations_pt.dart
@@ -1400,6 +1400,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get customCameraDownNotice => 'Câmera personalizada inacessível';
 
   @override
+  String get configuredCameraDownNotice => 'Câmera configurada inacessível';
+
+  @override
   String get printerUnreachable => 'Impressora inacessível';
 
   @override

--- a/mobile/lib/l10n/app_localizations_ru.dart
+++ b/mobile/lib/l10n/app_localizations_ru.dart
@@ -1395,6 +1395,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get customCameraDownNotice => 'Пользовательская камера недоступна';
 
   @override
+  String get configuredCameraDownNotice => 'Настроенная камера недоступна';
+
+  @override
   String get printerUnreachable => 'Принтер недоступен';
 
   @override

--- a/mobile/lib/l10n/app_localizations_zh.dart
+++ b/mobile/lib/l10n/app_localizations_zh.dart
@@ -1319,6 +1319,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get customCameraDownNotice => '无法连接自定义摄像头';
 
   @override
+  String get configuredCameraDownNotice => '无法连接已配置的摄像头';
+
+  @override
   String get printerUnreachable => '无法连接打印机';
 
   @override

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "Kamera nieosiągalna, sprawdź jej adres",
   "webcamUnreachableOldPlugin": "Kamera nieosiągalna. Wtyczka drukarki jest nieaktualna, aktualizacja może naprawić kamerę.",
   "customCameraDownNotice": "Kamera niestandardowa nieosiągalna",
+  "configuredCameraDownNotice": "Skonfigurowana kamera nieosiągalna",
   "printerUnreachable": "Drukarka nieosiągalna",
   "printerUseTunnel": "Użyj tunelu",
   "printerAddressInvalid": "Spróbuj np. 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -421,6 +421,7 @@
   "webcamUnreachable": "Câmera inacessível, verifique o endereço",
   "webcamUnreachableOldPlugin": "Câmera inacessível. O plugin da impressora está desatualizado, atualizá-lo pode corrigir a câmera.",
   "customCameraDownNotice": "Câmera personalizada inacessível",
+  "configuredCameraDownNotice": "Câmera configurada inacessível",
   "printerUnreachable": "Impressora inacessível",
   "printerUseTunnel": "Usar túnel",
   "printerAddressInvalid": "Tente p. ex., 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_ru.arb
+++ b/mobile/lib/l10n/app_ru.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "Камера недоступна, проверьте её адрес",
   "webcamUnreachableOldPlugin": "Камера недоступна. Плагин принтера устарел, обновление может исправить камеру.",
   "customCameraDownNotice": "Пользовательская камера недоступна",
+  "configuredCameraDownNotice": "Настроенная камера недоступна",
   "printerUnreachable": "Принтер недоступен",
   "printerUseTunnel": "Использовать туннель",
   "printerAddressInvalid": "Попробуйте, например, 192.168.1.50:7125",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -433,6 +433,7 @@
   "webcamUnreachable": "无法连接摄像头，请检查其地址",
   "webcamUnreachableOldPlugin": "无法连接摄像头。打印机插件已过时，更新插件可能可以修复。",
   "customCameraDownNotice": "无法连接自定义摄像头",
+  "configuredCameraDownNotice": "无法连接已配置的摄像头",
   "printerUnreachable": "无法连接打印机",
   "printerUseTunnel": "使用隧道",
   "printerAddressInvalid": "请尝试例如 192.168.1.50:7125",

--- a/mobile/lib/models/printer_config.dart
+++ b/mobile/lib/models/printer_config.dart
@@ -533,6 +533,15 @@ class PrinterStatus {
   /// user edits it (see resolveWebcamSource in PrinterStatusService).
   final bool customCameraDown;
 
+  /// True when this poll set the printer's own reported camera aside because
+  /// its address kept hard-failing - a webcam entry left pointing at a
+  /// dismantled camera service - and [webcamSnapshotUrl] is the default
+  /// snapshot path instead. Same tappable-notice contract as
+  /// [customCameraDown]; the entry itself stays Mainsail's to fix, and
+  /// fixing it re-arms the selection on the next poll (see
+  /// resolveWebcamSource in PrinterStatusService).
+  final bool configuredCameraDown;
+
   const PrinterStatus({
     required this.state,
     required this.progress,
@@ -562,6 +571,7 @@ class PrinterStatus {
     this.pluginVersion,
     this.pluginCanSelfUpdate = false,
     this.customCameraDown = false,
+    this.configuredCameraDown = false,
   });
 
   bool get isPrinting => state == 'printing' || state == 'paused';
@@ -599,6 +609,7 @@ class PrinterStatus {
     String? pluginVersion,
     bool? pluginCanSelfUpdate,
     bool? customCameraDown,
+    bool? configuredCameraDown,
   }) {
     return PrinterStatus(
       state:            state ?? this.state,
@@ -629,6 +640,7 @@ class PrinterStatus {
       pluginVersion:    pluginVersion ?? this.pluginVersion,
       pluginCanSelfUpdate: pluginCanSelfUpdate ?? this.pluginCanSelfUpdate,
       customCameraDown: customCameraDown ?? this.customCameraDown,
+      configuredCameraDown: configuredCameraDown ?? this.configuredCameraDown,
     );
   }
 

--- a/mobile/lib/services/printer_status_service.dart
+++ b/mobile/lib/services/printer_status_service.dart
@@ -211,6 +211,14 @@ class PrinterStatusService {
   /// immediately. Session-only by design.
   String? _customDownForUrl;
 
+  /// The same latch for the printer's own reported camera: the webcam-entry
+  /// value (external URL, else snapshot path) the selection has set aside as
+  /// dead this session in favour of the default snapshot path (see
+  /// [resolveWebcamSource]). Fixing the entry in Mainsail changes the value
+  /// the very next poll reports, which re-arms it immediately. Session-only
+  /// by design.
+  String? _nativeDownForUrl;
+
   PrinterStatusService(this.config)
       : _currentLanUrl = config.lanUrl,
         _uiType        = config.uiType,
@@ -1231,6 +1239,32 @@ class PrinterStatusService {
     final customDead = customFetchProbe != null &&
         WebcamFetchDiag.consecutiveHardFailures(config.id, customFetchProbe) >=
             kDeadCameraThreshold;
+
+    // The same verdict for the printer's own reported camera (the external
+    // auto-detect if present, else its snapshot path). A webcam entry can
+    // outlive the camera service it points at - the field case: go2rtc
+    // swapped for Crowsnest, the Mainsail entry never updated - and the
+    // plugin faithfully reports the dead address forever. The probe mirrors
+    // what WebcamView actually fetches for that camera on this transport.
+    String? nonEmpty(String? s) {
+      final t = s?.trim();
+      return (t == null || t.isEmpty) ? null : t;
+    }
+    final nativeExternal = nonEmpty(selected?.snapshotExternal) ??
+        nonEmpty(selected?.streamExternal);
+    final nativePath  = nonEmpty(selected?.snapshotPath);
+    final nativeValue = nativeExternal ?? nativePath;
+    final nativeFetchProbe = nativeExternal != null
+        ? (isLan
+            ? (go2rtcFrameUrl(nativeExternal) ?? nativeExternal)
+            : '$baseUrl/mg-extcam')
+        : nativePath != null
+            ? '$baseUrl$nativePath'
+            : null;
+    final nativeDead = nativeFetchProbe != null &&
+        WebcamFetchDiag.consecutiveHardFailures(config.id, nativeFetchProbe) >=
+            kDeadCameraThreshold;
+
     final source = resolveWebcamSource(
       customUrl:     customUrl,
       autoSnapshot:  selected?.snapshotExternal,
@@ -1241,8 +1275,11 @@ class PrinterStatusService {
       accessToken:   accessToken,
       customDead:    customDead,
       customLatched: _customDownForUrl != null && _customDownForUrl == customUrl,
+      nativeDead:    nativeDead,
+      nativeLatched: _nativeDownForUrl != null && _nativeDownForUrl == nativeValue,
     );
-    _customDownForUrl = source.customCameraDown ? customUrl : null;
+    _customDownForUrl = source.customCameraDown     ? customUrl   : null;
+    _nativeDownForUrl = source.configuredCameraDown ? nativeValue : null;
     final webcamSnapshotUrl = source.url;
     final webcamIsExternal  = source.isExternal;
 
@@ -1320,6 +1357,7 @@ class PrinterStatusService {
       pluginCanSelfUpdate:
           (moongateResult?['plugin_can_self_update'] as bool?) ?? false,
       customCameraDown: source.customCameraDown,
+      configuredCameraDown: source.configuredCameraDown,
     );
   }
 }
@@ -1327,7 +1365,7 @@ class PrinterStatusService {
 // ── Webcam source selection ───────────────────────────────────────────────────
 //
 // Which camera should the tile fetch this poll? Pure and top-level so the
-// precedence - and especially the dead-override fallback - is unit-testable
+// precedence - and especially the dead-camera fallbacks - is unit-testable
 // without a service or network. Precedence: a healthy user override (the tile
 // gear) > a camera auto-detected from Mainsail's webcam config > the plain Pi
 // snapshot path. A custom override whose address keeps hard-failing
@@ -1338,6 +1376,26 @@ class PrinterStatusService {
 // forgotten phone-webcam experiment left in the gear dialog). With nothing to
 // fall back to, the override stays and the tile's plain unreachable state
 // tells the truth as before. The override itself is never modified.
+//
+// The printer's own reported camera gets the same treatment ([nativeDead] /
+// [nativeLatched]): a webcam entry can outlive the camera service it points
+// at (the field case: go2rtc swapped for Crowsnest, the Mainsail entry never
+// updated - both broke identically because Mainsail honours the same entry),
+// and the plugin faithfully reports the dead address forever. Once hard-dead
+// it yields ONE hop toward the default snapshot path - a dead auto-detect
+// falls to the Pi snapshot path (for an external-only entry the plugin
+// already fills that with the default), a dead non-default path falls to
+// [kDefaultWebcamPath] itself - and never further: when the hop lands on
+// another dead address the unreachable state tells the truth as before.
+// Visible via [PrinterStatus.configuredCameraDown]; the entry stays the
+// user's (Mainsail's) to fix, and fixing it re-arms the selection on the
+// next poll because the reported value changes.
+
+/// The snapshot path every standard Crowsnest / mjpg-streamer install
+/// answers on - the plugin's own no-entry default (`_default_path` in
+/// klipper-plugin/moongate_standalone.py), used here as the one-hop fallback
+/// guess when the configured camera is dead.
+const String kDefaultWebcamPath = '/webcam/?action=snapshot';
 
 class WebcamSource {
   /// Absolute, ready-to-fetch URL (mg_token included when tunnelled), or
@@ -1352,8 +1410,15 @@ class WebcamSource {
   /// camera - drives the tile's tappable notice.
   final bool customCameraDown;
 
+  /// True when the printer's own reported camera was set aside as dead and
+  /// [url] is the default-path fallback - drives the tile's sibling notice.
+  final bool configuredCameraDown;
+
   const WebcamSource(
-      {this.url, this.isExternal = false, this.customCameraDown = false});
+      {this.url,
+      this.isExternal = false,
+      this.customCameraDown = false,
+      this.configuredCameraDown = false});
 }
 
 WebcamSource resolveWebcamSource({
@@ -1366,22 +1431,24 @@ WebcamSource resolveWebcamSource({
   required String  accessToken,
   required bool    customDead,
   required bool    customLatched,
+  required bool    nativeDead,
+  required bool    nativeLatched,
 }) {
-  // The plain Pi snapshot URL from the path the Pi reported. Tunnel-side
-  // carries the EdDSA token in the query string because Image.network can't
-  // set headers or cookies - the auth proxy accepts mg_token via query as a
-  // documented fallback (see klipper-plugin/moongate_authproxy.py). LAN-side
-  // needs no auth because Moonraker / nginx trust the subnet.
+  // A Pi-served snapshot URL from a relative path. Tunnel-side carries the
+  // EdDSA token in the query string because Image.network can't set headers
+  // or cookies - the auth proxy accepts mg_token via query as a documented
+  // fallback (see klipper-plugin/moongate_authproxy.py). LAN-side needs no
+  // auth because Moonraker / nginx trust the subnet.
+  String buildPathUrl(String path) {
+    if (isLan) return '$baseUrl$path';
+    final sep = path.contains('?') ? '&' : '?';
+    return '$baseUrl$path${sep}mg_token=${Uri.encodeComponent(accessToken)}';
+  }
+
   String? pathUrl;
   final path = snapshotPath;
   if (path != null && path.isNotEmpty) {
-    if (isLan) {
-      pathUrl = '$baseUrl$path';
-    } else {
-      final sep = path.contains('?') ? '&' : '?';
-      pathUrl =
-          '$baseUrl$path${sep}mg_token=${Uri.encodeComponent(accessToken)}';
-    }
+    pathUrl = buildPathUrl(path);
   }
 
   // Candidate external URLs, each normalised through the go2rtc player-page
@@ -1393,8 +1460,8 @@ WebcamSource resolveWebcamSource({
     return PrinterStatusService.go2rtcFrameUrl(t) ?? t;
   }
 
-  var   custom = normalise(customUrl);
-  final auto   = normalise(autoSnapshot) ?? normalise(autoStream);
+  var custom = normalise(customUrl);
+  var auto   = normalise(autoSnapshot) ?? normalise(autoStream);
 
   // A dead (or already set-aside) override yields to the printer's own
   // camera - but only when there IS one to yield to.
@@ -1404,6 +1471,21 @@ WebcamSource resolveWebcamSource({
       (auto != null || pathUrl != null)) {
     custom = null;
     customCameraDown = true;
+  }
+
+  // With no healthy override in charge, a dead (or already set-aside)
+  // printer camera takes its one hop toward the default snapshot path.
+  var configuredCameraDown = false;
+  if (custom == null && (nativeDead || nativeLatched)) {
+    if (auto != null) {
+      if (pathUrl != null) {
+        auto = null;
+        configuredCameraDown = true;
+      }
+    } else if (path != null && path.isNotEmpty && path != kDefaultWebcamPath) {
+      pathUrl = buildPathUrl(kDefaultWebcamPath);
+      configuredCameraDown = true;
+    }
   }
 
   // External cameras are absolute LAN URLs - typically an MJPEG stream from
@@ -1417,7 +1499,13 @@ WebcamSource resolveWebcamSource({
         : '$baseUrl/mg-extcam?u=${Uri.encodeComponent(external)}'
             '&mg_token=${Uri.encodeComponent(accessToken)}';
     return WebcamSource(
-        url: url, isExternal: true, customCameraDown: customCameraDown);
+        url: url,
+        isExternal: true,
+        customCameraDown: customCameraDown,
+        configuredCameraDown: configuredCameraDown);
   }
-  return WebcamSource(url: pathUrl, customCameraDown: customCameraDown);
+  return WebcamSource(
+      url: pathUrl,
+      customCameraDown: customCameraDown,
+      configuredCameraDown: configuredCameraDown);
 }

--- a/mobile/lib/services/webcam_fetch_diag.dart
+++ b/mobile/lib/services/webcam_fetch_diag.dart
@@ -1,8 +1,10 @@
 /// Consecutive HARD failures after which a camera is treated as dead rather
 /// than still waking: the wake window skips its optimistic spinner
-/// (WebcamView) and the status service sets a failing custom override aside
-/// in favour of the printer's own camera (resolveWebcamSource). One shared
-/// number so the two layers can never disagree about what "dead" means.
+/// (WebcamView) and the status service sets the failing camera aside - a
+/// custom override in favour of the printer's own camera, or the printer's
+/// configured camera in favour of the default snapshot path
+/// (resolveWebcamSource). One shared number so the layers can never
+/// disagree about what "dead" means.
 const int kDeadCameraThreshold = 6;
 
 /// In-memory per-printer record of how the webcam fetch loop is doing, for

--- a/mobile/test/webcam_source_selection_test.dart
+++ b/mobile/test/webcam_source_selection_test.dart
@@ -3,10 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:moongate/services/printer_status_service.dart';
 
 // resolveWebcamSource: the per-poll camera pick - override > auto-detected >
-// Pi snapshot path - and the dead-override fallback that sets a hard-failing
-// custom URL aside in favour of the printer's own camera (the field case: a
-// forgotten phone-webcam experiment masking a perfectly good camera). Pure
-// function, so the whole matrix runs without a service, registry, or network.
+// Pi snapshot path - and the dead-camera fallbacks: a hard-failing custom
+// URL set aside in favour of the printer's own camera (the field case: a
+// forgotten phone-webcam experiment masking a perfectly good camera), and a
+// hard-failing printer camera set aside for the default snapshot path (the
+// field case: a Mainsail webcam entry still pointing at go2rtc after a
+// switch to Crowsnest). Pure function, so the whole matrix runs without a
+// service, registry, or network.
 
 void main() {
   WebcamSource pick({
@@ -17,6 +20,8 @@ void main() {
     bool isLan = true,
     bool dead = false,
     bool latched = false,
+    bool nativeDead = false,
+    bool nativeLatched = false,
   }) =>
       resolveWebcamSource(
         customUrl:     custom,
@@ -28,6 +33,8 @@ void main() {
         accessToken:   'tok en', // space keeps the encoding visible
         customDead:    dead,
         customLatched: latched,
+        nativeDead:    nativeDead,
+        nativeLatched: nativeLatched,
       );
 
   test('healthy override outranks the auto camera and the snapshot path', () {
@@ -118,5 +125,84 @@ void main() {
         'http://h:1984/api/frame.jpeg?src=cam');
     expect(pick(autoStream: 'http://h:1984/stream.html?src=cam').url,
         'http://h:1984/api/frame.jpeg?src=cam');
+  });
+
+  // ── The stale-entry fallback (dead printer camera → default path) ──────────
+
+  test('dead auto camera falls back to the snapshot path, visibly', () {
+    // The Schlonky case: the entry's go2rtc URL outlived go2rtc itself; the
+    // plugin fills snapshot_path with the default for external-only entries.
+    final s = pick(
+        autoSnapshot: 'http://192.168.1.50:1984/api/frame.jpeg?src=cam',
+        path: '/webcam/?action=snapshot',
+        nativeDead: true);
+    expect(s.url, 'http://192.168.1.50/webcam/?action=snapshot');
+    expect(s.isExternal, isFalse);
+    expect(s.configuredCameraDown, isTrue);
+    expect(s.customCameraDown, isFalse);
+  });
+
+  test('the native latch keeps that fallback after the counters reset', () {
+    final s = pick(
+        autoSnapshot: 'http://192.168.1.50:1984/api/frame.jpeg?src=cam',
+        path: '/webcam/?action=snapshot',
+        nativeLatched: true);
+    expect(s.url, 'http://192.168.1.50/webcam/?action=snapshot');
+    expect(s.configuredCameraDown, isTrue);
+  });
+
+  test('dead non-default snapshot path falls back to the default path', () {
+    final s = pick(path: '/webcam2/?action=snapshot', nativeDead: true);
+    expect(s.url, 'http://192.168.1.50/webcam/?action=snapshot');
+    expect(s.configuredCameraDown, isTrue);
+  });
+
+  test('dead DEFAULT snapshot path has nowhere to hop and stays put', () {
+    final s = pick(path: '/webcam/?action=snapshot', nativeDead: true);
+    expect(s.url, 'http://192.168.1.50/webcam/?action=snapshot');
+    expect(s.configuredCameraDown, isFalse);
+  });
+
+  test('dead auto camera with no snapshot path stays put', () {
+    final s = pick(
+        autoSnapshot: 'http://192.168.1.50:1984/api/frame.jpeg?src=cam',
+        nativeDead: true);
+    expect(s.url, 'http://192.168.1.50:1984/api/frame.jpeg?src=cam');
+    expect(s.configuredCameraDown, isFalse);
+  });
+
+  test('a healthy override stays in charge whatever the native verdict', () {
+    final s = pick(
+        custom: 'http://192.168.1.84:8080/video',
+        autoSnapshot: 'http://192.168.1.50:1984/api/frame.jpeg?src=cam',
+        path: '/webcam/?action=snapshot',
+        nativeDead: true);
+    expect(s.url, 'http://192.168.1.84:8080/video');
+    expect(s.customCameraDown, isFalse);
+    expect(s.configuredCameraDown, isFalse);
+  });
+
+  test('dead override then dead auto cascade down to the snapshot path', () {
+    final s = pick(
+        custom: 'http://192.168.1.84:8080/video',
+        autoSnapshot: 'http://192.168.1.50:1984/api/frame.jpeg?src=cam',
+        path: '/webcam/?action=snapshot',
+        dead: true,
+        nativeDead: true);
+    expect(s.url, 'http://192.168.1.50/webcam/?action=snapshot');
+    expect(s.isExternal, isFalse);
+    expect(s.customCameraDown, isTrue);
+    expect(s.configuredCameraDown, isTrue);
+  });
+
+  test('tunnel mode: the stale-entry fallback carries the token', () {
+    final s = pick(
+        autoSnapshot: 'http://192.168.1.85:1984/api/frame.jpeg?src=cam',
+        path: '/webcam/?action=snapshot',
+        isLan: false,
+        nativeDead: true);
+    expect(s.url,
+        'https://pi.example/webcam/?action=snapshot&mg_token=tok%20en');
+    expect(s.configuredCameraDown, isTrue);
   });
 }


### PR DESCRIPTION
## What will this PR change?

When the camera address in the printer's own webcam config (the Mainsail Settings -> Webcams entry) keeps hard-failing, the app now falls back to the printer's default camera path (`/webcam/?action=snapshot`) instead of showing "Camera unreachable" forever, with a tappable amber notice on the tile saying "Configured camera unreachable" so the swap is never silent.

**In plain English:** if you switch camera backends (say go2rtc to Crowsnest) and forget to update the webcam entry in Mainsail, your Moongate tile keeps working anyway, and tells you why.

## Why

Tonight's field case (Schlonky on Discord): he switched his V2 from go2rtc to Crowsnest, the Mainsail webcam entry kept pointing at the dead go2rtc address, and both Moongate and his tunneled Mainsail sat on "Camera unreachable" while a perfectly good camera answered on `/webcam/` the whole time. The plugin was doing its job (it reports whatever the entry says, live), the app was doing its job (the address really was dead), and the user still ended up manually pinning an IP as a workaround.

This is the missing sibling of #269: that PR set aside a dead *custom override* in favour of the printer's camera; this one sets aside a dead *printer camera* in favour of the default path.

## How

- `resolveWebcamSource` (the pure per-poll camera pick from #269) gains `nativeDead` / `nativeLatched` inputs and ONE fallback hop: a dead auto-detected external camera falls to the Pi snapshot path (for external-only entries the plugin already fills that with the default), a dead non-default snapshot path falls to `/webcam/?action=snapshot` itself. Never a second hop: if the fallback is also dead, the honest unreachable state is unchanged from today.
- Deadness uses the same shared `kDeadCameraThreshold` (6 consecutive hard failures, soft timeouts never count) against what WebcamView actually fetched, and the same per-value latch pattern as #269, so the fallback cannot flap and fixing the entry in Mainsail re-arms the selection on the very next poll. The entry itself is never touched.
- A healthy custom override still outranks everything; a dead override cascades override -> auto -> path as before, one level further now.
- New `PrinterStatus.configuredCameraDown` drives the tile notice (the #269 notice widget generalised, tap still opens the camera dialog). New string `configuredCameraDownNotice` in all 9 locales.

## Testing

- `flutter analyze` clean; full suite 85/85 (was 77), including 8 new matrix cases: the Schlonky case (dead go2rtc auto -> default path, LAN and tunnel), the non-default -> default path hop, dead default path stays put (nowhere to hop), healthy override immunity, the override+native double cascade, and the latch holding after counters reset.
- No version bump: rides the next release (0.9.61) with its changelog.

PEEKYPAUL 10/08/2026
