### PR TITLE
iOS: printer page connects first time on the home LAN (mDNS hostnames resolve to IPv4) [skip ci]

### DIFF
--- a/mobile/lib/services/lan_discovery_service.dart
+++ b/mobile/lib/services/lan_discovery_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer' as dev;
+import 'dart:io';
 
 import 'package:bonsoir/bonsoir.dart';
 
@@ -30,6 +31,12 @@ class LanDiscoveryService {
   /// the longer window covers stale Avahi caches, congested WiFi, and
   /// the bonsoir-on-Android cold-start delay.
   static const _browseDuration = Duration(seconds: 5);
+
+  /// How long to wait for the OS resolver when a browse answers with a
+  /// hostname instead of an address (the iOS/bonsoir behaviour). The name
+  /// was just advertised so it is almost always in the mDNS cache; a hung
+  /// lookup must not outlive the browse window it runs inside.
+  static const _lookupTimeout = Duration(seconds: 2);
 
   /// printer_id → discovered LAN URL.
   final Map<String, String> _discovered = {};
@@ -107,7 +114,7 @@ class LanDiscoveryService {
         break;
       case BonsoirDiscoveryEventType.discoveryServiceResolved:
         if (service is ResolvedBonsoirService) {
-          _onResolved(service);
+          await _onResolved(service);
         }
         break;
       // Lost / started / stopped / resolve-failed all no-op per §7.5 -
@@ -120,7 +127,7 @@ class LanDiscoveryService {
     }
   }
 
-  void _onResolved(ResolvedBonsoirService service) {
+  Future<void> _onResolved(ResolvedBonsoirService service) async {
     final attrs = service.attributes;
     final printerId = attrs['printer_id'];
     if (printerId == null || printerId.isEmpty) {
@@ -136,7 +143,7 @@ class LanDiscoveryService {
       _log('Resolved service has no host, ignoring: ${service.name}');
       return;
     }
-    final url = urlForHost(host, port);
+    final url = urlForHost(await _numericHostFor(host), port);
     if (url == null) {
       // Never store it: everything that consults this map treats a hit as
       // better than the persisted lanUrl, so one bad answer would strand the
@@ -150,6 +157,48 @@ class LanDiscoveryService {
       _log('Discovered ${printerId.substring(0, 8)}... → $url');
       _discovered[printerId] = url;
     }
+  }
+
+  /// Numeric host for a resolved mDNS answer. Android's resolver hands back
+  /// addresses already (they pass through untouched via the tryParse gate);
+  /// iOS/bonsoir hands back the advertised *hostname* (`voron24.local.`),
+  /// which must not enter the map as-is: inside WKWebView, Mainsail's
+  /// Moonraker websocket resolves such names AAAA-first with no IPv4
+  /// fallback, and MainsailOS nginx listens on IPv4 only, so the first
+  /// printer-page open dies on a perfectly healthy LAN (#268). Resolving
+  /// here - the single point where discovered hosts enter the map - fixes
+  /// every consumer at once. On lookup failure or timeout the hostname is
+  /// kept: the pre-fix behaviour, and still the right last resort on
+  /// networks where names do work end to end.
+  Future<String> _numericHostFor(String host) async {
+    if (InternetAddress.tryParse(host) != null) return host;
+    try {
+      final addresses =
+          await InternetAddress.lookup(host).timeout(_lookupTimeout);
+      return pickResolvedHost(host, addresses);
+    } catch (_) {
+      return host;
+    }
+  }
+
+  /// Address pick order for a hostname the OS resolver expanded: the first
+  /// IPv4, else the first IPv6 that would survive [urlForHost]'s gates
+  /// (zone-indexed and fe80::/10 link-local never win), else the hostname
+  /// itself. IPv4 outranks IPv6 because Pi-class rigs serve nginx on
+  /// `0.0.0.0` only - a routable AAAA that beats the A record is exactly
+  /// the #268 failure. Static and pure for tests.
+  static String pickResolvedHost(
+      String host, List<InternetAddress> addresses) {
+    for (final a in addresses) {
+      if (a.type == InternetAddressType.IPv4) return a.address;
+    }
+    for (final a in addresses) {
+      if (a.type == InternetAddressType.IPv6 &&
+          urlForHost(a.address, 80) != null) {
+        return a.address;
+      }
+    }
+    return host;
   }
 
   /// LAN URL for a resolved mDNS host, or null when the host can never work

--- a/mobile/test/lan_discovery_host_test.dart
+++ b/mobile/test/lan_discovery_host_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:moongate/services/lan_discovery_service.dart';
@@ -49,5 +51,56 @@ void main() {
     // "fe" in the first hextet but outside fe80::/10 is NOT link-local.
     expect(LanDiscoveryService.urlForHost('fec0::1', 80),
         'http://[fec0::1]');
+  });
+
+  // The resolved-address pick order (#268). iOS/bonsoir answers a browse
+  // with the advertised hostname (`voron24.local.`, trailing dot) rather
+  // than an address; stored verbatim it strands the printer page - inside
+  // WKWebView, Mainsail's Moonraker websocket resolves the name AAAA-first
+  // with no IPv4 fallback while MainsailOS nginx listens on IPv4 only. The
+  // service now resolves the name and stores a concrete address instead.
+
+  test('pick order: IPv4 wins even when the resolver lists AAAA first', () {
+    // The field case verified on the Voron 2.4: the name resolved to a
+    // unique-local IPv6 AND an IPv4; the websocket died on the IPv6.
+    expect(
+        LanDiscoveryService.pickResolvedHost('voron24.local.', [
+          InternetAddress('fde4:8dba:82e1::c4'),
+          InternetAddress('192.168.1.251'),
+        ]),
+        '192.168.1.251');
+  });
+
+  test('pick order: first IPv4 wins among several', () {
+    expect(
+        LanDiscoveryService.pickResolvedHost('mainsailos.local', [
+          InternetAddress('192.168.1.10'),
+          InternetAddress('10.0.0.4'),
+        ]),
+        '192.168.1.10');
+  });
+
+  test('pick order: routable IPv6 when no IPv4 exists', () {
+    expect(
+        LanDiscoveryService.pickResolvedHost('voron24.local.', [
+          InternetAddress('fe80::1'),
+          InternetAddress('fde4:8dba:82e1::c4'),
+        ]),
+        'fde4:8dba:82e1::c4');
+  });
+
+  test('pick order: link-local-only resolution keeps the hostname', () {
+    // A name that only resolves to fe80::/10 must not enter the map as an
+    // address - the hostname is the last resort that can still work.
+    expect(
+        LanDiscoveryService.pickResolvedHost('voron24.local.', [
+          InternetAddress('fe80::4684:2651:1a53:50f6'),
+        ]),
+        'voron24.local.');
+  });
+
+  test('pick order: empty resolution keeps the hostname', () {
+    expect(LanDiscoveryService.pickResolvedHost('voron24.local.', []),
+        'voron24.local.');
   });
 }


### PR DESCRIPTION
## What will this PR change?

An iPhone on the same WiFi as its printer will connect on the **first** open of the printer page, instead of showing Mainsail's "Cannot connect to Moonraker (voron24.local.)" until you tap retry. Fixes https://github.com/PEEKYPAUL/Moongate/issues/268.

**The gist in plain English:** on iPhone, the local-network discovery hands the app the printer's *name* rather than its *address*. The app now looks the name up itself the moment it arrives and keeps the plain IPv4 address instead, which is the address the printer's web server actually listens on. Android already behaved this way because its discovery answers with addresses in the first place.

## Why

Verified live on the Voron 2.4 (2026-08-07, iOS build 133), root-cause chain on the issue:

- bonsoir/iOS resolves the `_moongate._tcp` advert to `voron24.local.` (a hostname); the fe80 gate from https://github.com/PEEKYPAUL/Moongate/pull/246 passes hostnames through, and a discovered URL outranks the persisted `lanUrl` everywhere.
- The name resolves to both an A (`192.168.1.251`) and a routable AAAA (`fde4:...`). Plain HTTP survives via happy-eyeballs fallback (tile green, Mainsail shell renders), but Mainsail's Moonraker **websocket** inside WKWebView resolves AAAA-first with no fallback, and MainsailOS nginx listens on `0.0.0.0:80` only, so the socket is refused on a healthy LAN. The manual retry lands on IPv4, which is why it always worked.

## How

One mechanism, at the single point where discovered hosts enter the map (`lan_discovery_service.dart`):

- `_onResolved` now passes the answer through a resolver step before the existing `urlForHost()` gate. Numeric answers (the Android path) short-circuit via `InternetAddress.tryParse` and behave exactly as before.
- Hostname answers get an `InternetAddress.lookup` (2 s timeout, inside the 5 s browse window) and a pure pick: **first IPv4 → else first IPv6 that survives the existing `urlForHost()` gates (no zone index, no fe80::/10) → else the raw hostname** as the last resort. Lookup failure or timeout also keeps the hostname, so the worst case is exactly today's behaviour.
- Every consumer inherits the fix for free (printer page, WebView pre-warm, status/control services, the pairing-time `lanUrl` seed), and existing installs heal on their next browse because the discovered map outranks the persisted `lanUrl`; `/status` polls also refresh the persisted copy.

Deliberately **not** included: the "one-shot websocket auto-retry" idea from the issue comment. The failure happens inside Mainsail's own JS (the page itself loads fine), so the app can't observe it without injecting script into Mainsail - fragile, and unnecessary once no `.local` name reaches the WebView from discovery. A user-typed `.local` address in Direct mode keeps its documented retry workaround.

## Testing

- 5 new unit tests in `lan_discovery_host_test.dart` lock the pick order, including the exact field case (AAAA listed before A → the IPv4 wins) and the last-resort fallbacks (link-local-only and empty resolutions keep the hostname). Full suite 90/90, `flutter analyze` clean.
- No version bump; rides the next release (0.9.61) with its changelog.

PEEKYPAUL 11/08/2026
