### PR TITLE
Plugin 0.6.24: only offer the one-tap update where Moonraker's update manager manages us

### DIFF
--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -115,7 +115,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.23"
+MOONGATE_PLUGIN_VERSION = "0.6.24"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1452,6 +1452,37 @@ class PendingPair:
     qr_payload: str
 
 
+# ── Self-update capability (v0.6.24) ────────────────────────────────────────
+#
+# 0.6.16's one-tap update advertised itself unconditionally, but it only works
+# where Moonraker's update manager actually manages a "moongate" client - the
+# installer writes that section, the manual installs of
+# docs/third-party-printers.md don't, and COSMOS has no update_manager at all.
+# There the app's "Update now" fired a background POST that died quietly on
+# the printer and the badge never cleared (field report: an Elegoo Centauri
+# Carbon, 2026-08-14). Decide from a real /machine/update/status answer
+# instead; pure so the stdlib tests can pin the matrix.
+
+def _self_update_decision(status: Optional[int], body: Any) -> Optional[bool]:
+    """True/False = definitive (cacheable: install kind can't change under a
+    running Moonraker); None = Moonraker wasn't ready to answer - probe again
+    on a later poll."""
+    if status == 404:
+        return False       # update_manager component not loaded at all
+    if status != 200:
+        return None        # startup 503, transport 599, ...
+    try:
+        data = json.loads(body)
+    except (ValueError, TypeError):
+        return None        # the COSMOS startup race: 200 with the UI's HTML
+    if not isinstance(data, dict):
+        return None
+    info = (data.get("result") or {}).get("version_info")
+    if not isinstance(info, dict):
+        return None        # 200 JSON but not update-manager shaped
+    return "moongate" in info
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Plugin entry point
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1571,6 +1602,8 @@ class MoongatePlugin:
         self._chamber_key_checked: bool        = False
         self._extra_extruders                  = []     # extruder1, extruder2, ... (multi-toolhead)
         self._has_toolchanger                  = False  # klipper-toolchanger printer
+        self._can_self_update: Optional[bool]  = None   # update_manager manages us? None = not probed yet
+        self._self_update_probe_at             = 0.0    # monotonic; retry gap for indeterminate probes
 
         # HTTP endpoints
         self.server.register_endpoint("/server/moongate/pair",        ["POST"], self._handle_pair)
@@ -2412,8 +2445,12 @@ class MoongatePlugin:
         result["plugin_version"] = MOONGATE_PLUGIN_VERSION
         # v0.6.16: advertises the remote self-update action, so the app's
         # update dialog knows to offer one-tap "Update now" instead of the
-        # Mainsail instructions it shows for older plugins.
-        result["plugin_can_self_update"] = True
+        # Mainsail instructions it shows for older plugins. v0.6.24: only
+        # advertised where Moonraker's update manager really manages us -
+        # a manual install used to get a button whose update died quietly
+        # on the printer.
+        await self._probe_self_update()
+        result["plugin_can_self_update"] = self._can_self_update is True
         # v0.6.23: tunnel-watchdog heal history, so support can read "has this
         # tunnel been self-healing?" from the app's diagnostics without SSH.
         # None when disabled or LAN-only (no tunnel to watch).
@@ -2481,6 +2518,35 @@ class MoongatePlugin:
             )
         return {"action": action, "ok": True}
 
+    async def _probe_self_update(self) -> None:
+        """Resolve _can_self_update once, from Moonraker's own answer.
+
+        A definitive answer is cached for the process lifetime; indeterminate
+        ones (Moonraker still starting, transport blip) retry on later polls,
+        at most once a minute, so a slow boot never wedges the field at a
+        guess. Runs on the /status path, so by the time a human opens the
+        update dialog the answer has long settled."""
+        if self._can_self_update is not None:
+            return
+        now = time.monotonic()
+        if now - self._self_update_probe_at < 60.0:
+            return
+        self._self_update_probe_at = now
+        from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+        try:
+            resp = await AsyncHTTPClient().fetch(HTTPRequest(
+                f"http://127.0.0.1:{self._moonraker_port}/machine/update/status?refresh=false",
+                method="GET", request_timeout=3.0,
+            ), raise_error=False)
+            self._can_self_update = _self_update_decision(resp.code, resp.body)
+        except Exception as exc:
+            logger.debug("Self-update probe failed: %s", exc)
+        if self._can_self_update is False:
+            logger.info(
+                "Moongate is not managed by Moonraker's update manager - "
+                "one-tap update disabled. Manual installs update by "
+                "re-copying the plugin file (docs/third-party-printers.md).")
+
     async def _handle_update_plugin(self) -> dict:
         """One-tap plugin self-update (v0.6.16, driven by the app's dashboard
         update badge; caller already authenticated by _handle_control).
@@ -2495,8 +2561,21 @@ class MoongatePlugin:
         404s on Moonraker v0.10) - and returns immediately: waiting would be
         pointless because the restart kills the connection anyway. The app
         watches plugin_version on its normal /status polls to see the update
-        land, which is also what clears its badge."""
+        land, which is also what clears its badge.
+
+        v0.6.24: refuses cleanly when the update manager doesn't manage us
+        (manual install) - /status no longer advertises the action there, but
+        an app that cached an old answer deserves an honest error rather than
+        a fire-and-forget POST that dies quietly on the printer. An
+        indeterminate probe proceeds: the POST logs its own outcome and can't
+        hurt an idle stack."""
         from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+        await self._probe_self_update()
+        if self._can_self_update is False:
+            raise self.server.error(
+                "This install isn't managed by Moonraker's update manager - "
+                "update it manually (docs/third-party-printers.md)", 409)
 
         state = None
         try:

--- a/klipper-plugin/tests/test_self_update_gate.py
+++ b/klipper-plugin/tests/test_self_update_gate.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""v0.6.24 regression test: the one-tap update must only be advertised where
+Moonraker's update manager actually manages a "moongate" client.
+
+0.6.16 hardcoded plugin_can_self_update = True, so a manual install
+(docs/third-party-printers.md - no [update_manager moongate] section, and on
+COSMOS no update_manager component at all) showed the app an "Update now"
+button whose background POST died quietly on the printer and whose badge
+never cleared (field report: an Elegoo Centauri Carbon, 2026-08-14).
+
+The decision now lives in the pure module-level _self_update_decision(),
+fed by a real /machine/update/status answer; each branch of its matrix is
+what this suite pins. True/False are definitive and cached for the process
+lifetime; None means "Moonraker wasn't ready, probe again later" - so the
+startup races must map to None, never to a cached wrong answer.
+
+Stdlib-only on purpose, same loader as test_lan_only_no_deps.py:
+
+    python3 klipper-plugin/tests/test_self_update_gate.py
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "moongate_standalone.py"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_PATH)
+    mod  = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass looks its module up in sys.modules.
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+mod    = _load("moongate_self_update_gate")
+decide = mod._self_update_decision
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, got, want):
+    global PASS, FAIL
+    if got is want:
+        PASS += 1
+        print(f"  ok: {label}")
+    else:
+        FAIL += 1
+        print(f"FAIL: {label}: got {got!r}, want {want!r}")
+
+
+def body(version_info):
+    return json.dumps({"result": {"version_info": version_info}})
+
+
+# ── Definitive answers (cacheable) ──────────────────────────────────────────
+
+# The installer-written world: update_manager manages moongate alongside the
+# usual system/moonraker/klipper entries.
+check("managed install -> True",
+      decide(200, body({"system": {}, "moonraker": {}, "klipper": {},
+                        "moongate": {"version": "v0.6.23"}})),
+      True)
+
+# update_manager runs but nobody registered moongate (manual copy on a
+# normal Pi, or the section was removed).
+check("update_manager without moongate -> False",
+      decide(200, body({"system": {}, "moonraker": {}, "klipper": {}})),
+      False)
+
+# No update_manager component at all (COSMOS): Moonraker 404s the route.
+check("no update_manager component (404) -> False",
+      decide(404, b"Not Found"),
+      False)
+
+# ── Indeterminate answers (must NOT cache a guess) ──────────────────────────
+
+# Moonraker still starting: 503 from our own startup guard, or tornado's
+# transport-error pseudo-status.
+check("startup 503 -> None",          decide(503, b""),        None)
+check("transport error (599) -> None", decide(599, b""),       None)
+check("no status at all -> None",      decide(None, b""),      None)
+
+# The COSMOS startup race: a file-serving Moonraker answers 200 with the web
+# UI's HTML for a moment before the API routes register.
+check("200 with HTML body -> None",
+      decide(200, b"<!DOCTYPE html><html>...</html>"),
+      None)
+
+# 200 with JSON that isn't update-manager shaped.
+check("200 with JSON list -> None",    decide(200, b"[1, 2]"), None)
+check("200 without version_info -> None",
+      decide(200, json.dumps({"result": {"busy": False}})),
+      None)
+check("200 with non-dict version_info -> None",
+      decide(200, json.dumps({"result": {"version_info": None}})),
+      None)
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## What will this PR change?

The app's one-tap "Update now" button will only appear on printers where it can actually work. On manual installs (the third-party machines in [docs/third-party-printers.md](https://github.com/PEEKYPAUL/Moongate/blob/master/docs/third-party-printers.md), first field report an Elegoo Centauri Carbon) the button used to fire an update request that died quietly on the printer, so tapping it looked like it did nothing and the amber badge never cleared. Those installs will now get the dialog's manual-update text instead, and the plugin refuses the action with an honest error if an app asks anyway.

## Why

The one-tap update works by asking Moonraker's update manager to update the `moongate` client. `install.sh` registers that client, so every installer-based setup is fine, but manual installs don't have the entry, and COSMOS machines have no update_manager at all. Since 0.6.16 the plugin advertised the capability unconditionally, which broke the promise the third-party docs already made ("no update badge / one-tap update on these machines").

## How

- `/status` now resolves `plugin_can_self_update` from a real `/machine/update/status` answer: `moongate` present in `version_info` = yes; absent, or the route 404ing = no; anything indeterminate (Moonraker still starting, the COSMOS 200-with-HTML race, transport errors) is retried on a later poll, at most once a minute, and never cached as a guess. Definitive answers cache for the process lifetime.
- `_handle_update_plugin` performs the same check and returns a clean 409 for manual installs, instead of the old fire-and-forget POST.
- The decision matrix is a pure module-level function, `_self_update_decision()`.

The app-side half (manual-install wording in the update dialog instead of the Mainsail instructions) rides 0.9.61 with the `kCurrentPluginVersion` badge bump; changelog entries ride that release PR as usual.

## Testing

- New `tests/test_self_update_gate.py` (stdlib-only, same harness as the existing suites) pins all 10 branches of the decision matrix: managed install, unmanaged install, missing update_manager, and every indeterminate shape.
- All 6 plugin suites pass locally; ruff clean.
- Release gate still owed before merge: a live cloud-mode pass on a real rig (the field verify: /status keeps advertising the capability on a managed install, and one-tap update still works there).

PEEKYPAUL 24/08/2026
