### PR TITLE
Plugin 0.6.25: machine-error notifications + MOONGATE_NOTIFY custom pushes

### DIFF
--- a/klipper-plugin/install.sh
+++ b/klipper-plugin/install.sh
@@ -610,6 +610,11 @@ gcode:
 description: Report Moongate cloud + tunnel health in the console
 gcode:
     {action_call_remote_method("moongate_status")}
+
+[gcode_macro MOONGATE_NOTIFY]
+description: Push a custom Moongate notification to your phone (MSG="text")
+gcode:
+    {action_call_remote_method("moongate_notify", message=params.MSG|default("")|string)}
 MACROS
 } > "$MOONGATE_CFG"
 

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -115,7 +115,7 @@ logger = logging.getLogger("moonraker.moongate")
 # Bumped on each release; surfaced in the /status response so the app's bug
 # reports show which plugin a Pi is actually running - the #1 triage blind spot
 # (an old plugin explains most "works on LAN / fails over tunnel" reports).
-MOONGATE_PLUGIN_VERSION = "0.6.24"
+MOONGATE_PLUGIN_VERSION = "0.6.25"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1332,11 +1332,37 @@ class HeartbeatLoop:
 # PrintEventWatcher - local print-state watch → push notifications
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# ── Notification text helpers (v0.6.25) ─────────────────────────────────────
+#
+# Pure so the stdlib tests can pin them; both feed the send-push "detail"
+# field, whose server cap is 200 chars.
+
+def _error_detail(state_message: Any) -> str:
+    """Reduce Klipper's multi-line shutdown message to its useful first line.
+    The boilerplate tail ("Once the underlying issue is corrected...") never
+    says anything the first line doesn't, and a push body wants one line."""
+    for line in str(state_message or "").splitlines():
+        line = re.sub(r"[\x00-\x1f\x7f]", " ", line).strip()
+        if line:
+            return line[:180]
+    return ""
+
+
+def _notify_text(raw: Any) -> str:
+    """Sanitise a MOONGATE_NOTIFY message: control chars become spaces,
+    whitespace collapses, and the result is capped at the server's detail
+    limit. Returns "" when nothing displayable is left."""
+    text = re.sub(r"[\x00-\x1f\x7f]", " ", str(raw or ""))
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:200]
+
+
 class PrintEventWatcher:
-    """Polls Moonraker's print_stats locally and, on a meaningful state change
-    (a print starting, finishing, or failing), sends a Pi-signed event to the
-    send-push Edge Function so the printer owner's iPhone gets a background
-    alert.
+    """Polls Moonraker's print_stats AND klippy_state locally and, on a
+    meaningful state change (a print starting, finishing, or failing; the
+    machine erroring out or shutting down - v0.6.25), sends a Pi-signed event
+    to the send-push Edge Function so the printer owner's iPhone gets a
+    background alert.
 
     Detection is entirely local - we poll our own Moonraker, never the cloud -
     so the only Supabase call is the one-shot send when an event actually fires
@@ -1364,6 +1390,12 @@ class PrintEventWatcher:
         # establishes a baseline - we never fire an event for whatever state
         # the printer happens to be in when the plugin loads.
         self._last_state: Optional[str] = None
+        # Ditto for klippy_state (v0.6.25 - machine errors).
+        self._last_klippy: Optional[str] = None
+        # monotonic of the last klippy-error push: the same incident often
+        # also drives print_stats to 'error', and one alert per disaster is
+        # enough (the klippy one carries the reason).
+        self._error_sent_at: Optional[float] = None
 
     def start(self) -> None:
         try:
@@ -1377,11 +1409,32 @@ class PrintEventWatcher:
         loop = asyncio.get_event_loop()
         while True:
             try:
+                # Klippy state first (v0.6.25): /server/info keeps answering
+                # while Klipper itself is down, so machine errors are seen
+                # exactly when the print_stats poll below goes blind.
+                k_state = await loop.run_in_executor(None, self._poll_klippy_state)
+                if k_state is not None and k_state != self._last_klippy:
+                    k_event = self._klippy_event_for(self._last_klippy, k_state)
+                    self._last_klippy = k_state
+                    if k_event and self._is_dormant is not None and self._is_dormant():
+                        logger.debug(
+                            "Push event '%s' skipped - cloud contact dormant", k_event)
+                    elif k_event:
+                        reason = await loop.run_in_executor(None, self._shutdown_reason)
+                        self._error_sent_at = time.monotonic()
+                        await loop.run_in_executor(None, self._send_event, k_event, reason)
+
                 state, filename = await loop.run_in_executor(None, self._poll_print_state)
                 if state is not None and state != self._last_state:
                     event = self._event_for(self._last_state, state)
                     self._last_state = state
-                    if event and self._is_dormant is not None and self._is_dormant():
+                    if event == "failed" and self._error_sent_at is not None \
+                            and time.monotonic() - self._error_sent_at < 60.0:
+                        # The klippy watcher already reported this incident,
+                        # with the richer reason - one alert per disaster.
+                        logger.debug(
+                            "Push event 'failed' suppressed - klippy error already reported")
+                    elif event and self._is_dormant is not None and self._is_dormant():
                         logger.debug(
                             "Push event '%s' skipped - cloud contact dormant", event)
                     elif event:
@@ -1411,6 +1464,50 @@ class PrintEventWatcher:
             return "failed"
         return None
 
+    @staticmethod
+    def _klippy_event_for(prev: Optional[str], state: str) -> Optional[str]:
+        """Map a klippy_state transition to a push event (v0.6.25). Fires on
+        ARRIVAL in an error state only - shutdown<->error shuffles don't
+        refire, and recovery back to ready is deliberately silent in v1.
+        prev is None on the first poll (baseline: never alert for whatever
+        state the printer was already in when the plugin loaded)."""
+        bad = ("shutdown", "error")
+        if prev is None:
+            return None
+        if state in bad and prev not in bad:
+            return "error"
+        return None
+
+    def _poll_klippy_state(self) -> Optional[str]:
+        """Read klippy_state from the local Moonraker. /server/info keeps
+        answering while Klipper itself is shut down or disconnected - the
+        whole point: the print_stats poll goes blind exactly when the machine
+        errors out (field report 2026-08-24, a shutdown that mobileraker
+        caught and we missed). None on failure = skip the tick, baseline
+        undisturbed."""
+        try:
+            url = f"http://127.0.0.1:{self.port}/server/info"
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                data = json.loads(resp.read().decode())
+            return data["result"].get("klippy_state") or None
+        except Exception as exc:
+            logger.debug("server/info poll failed: %s", exc)
+            return None
+
+    def _shutdown_reason(self) -> str:
+        """Best-effort fetch of Klipper's shutdown reason for the push body.
+        /printer/info still answers while klippy sits in shutdown (Moonraker
+        proxies its cached state); a failure just means a reason-less
+        notification, never a missed one."""
+        try:
+            url = f"http://127.0.0.1:{self.port}/printer/info"
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                data = json.loads(resp.read().decode())
+            return _error_detail(data["result"].get("state_message"))
+        except Exception as exc:
+            logger.debug("printer/info poll failed: %s", exc)
+            return ""
+
     def _poll_print_state(self) -> tuple[Optional[str], str]:
         """Read print_stats.state and .filename from the local Moonraker.
         Returns (None, "") on any failure so the loop simply skips this tick
@@ -1425,20 +1522,24 @@ class PrintEventWatcher:
             logger.debug("print_stats poll failed: %s", exc)
             return None, ""
 
-    def _send_event(self, event: str, filename: str) -> None:
+    def _send_event(self, event: str, detail: str) -> bool:
+        """Sign + send one push event. Returns True when the server accepted
+        it (v0.6.25: MOONGATE_NOTIFY acks the outcome in the console)."""
         ts        = int(time.time())
         pk_b64    = self.device.public_key_b64
-        detail    = (filename or "")[:200]
+        detail    = (detail or "")[:200]
         canonical = f"moongate-push\n{pk_b64}\n{event}\n{detail}\n{ts}".encode()
         sig_b64   = self.device.sign_b64(canonical)
 
         status, body = self.sb.send_push(pk_b64, event, detail, ts, sig_b64)
         if status in (200, 204):
             logger.info("Push event '%s' sent", event)
+            return True
         elif status == 404:
             logger.debug("Push event '%s' skipped - printer not paired server-side", event)
         else:
             logger.warning("Push event '%s' failed: HTTP %s %s", event, status, body)
+        return False
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1604,6 +1705,7 @@ class MoongatePlugin:
         self._has_toolchanger                  = False  # klipper-toolchanger printer
         self._can_self_update: Optional[bool]  = None   # update_manager manages us? None = not probed yet
         self._self_update_probe_at             = 0.0    # monotonic; retry gap for indeterminate probes
+        self._notify_last: Optional[float]     = None   # monotonic; MOONGATE_NOTIFY rate limit
 
         # HTTP endpoints
         self.server.register_endpoint("/server/moongate/pair",        ["POST"], self._handle_pair)
@@ -1617,6 +1719,7 @@ class MoongatePlugin:
         self.server.register_remote_method("moongate_generate_pair_code", self._klipper_pair)
         self.server.register_remote_method("moongate_reset_owner",        self._klipper_reset_owner)
         self.server.register_remote_method("moongate_status",             self._klipper_status)
+        self.server.register_remote_method("moongate_notify",             self._klipper_notify)
 
         # Bootstrap JWKS (best effort) and start the heartbeat + print-watch loops.
         # LAN-only mode has no cloud: skip all of it so the plugin makes zero
@@ -2062,6 +2165,42 @@ class MoongatePlugin:
             report.append(f"M118 {COOKED_LINE}")
         report.append(banner)
         await _say("\n".join(report))
+
+    async def _klipper_notify(self, message: str = "") -> None:
+        """MOONGATE_NOTIFY macro entry point (v0.6.25, a user ask): push a
+        custom notification to the owner's phone(s) from any gcode - slicer
+        end-gcode, filament-runout handlers, timelapse hooks. The text is the
+        macro's MSG param, sanitised and capped; sends are rate-limited so a
+        macro stuck in a loop can't hose the phone (or the meter)."""
+        klippy_apis: Any = self.server.lookup_component("klippy_apis")
+
+        async def _say(line: str) -> None:
+            try:
+                await klippy_apis.run_gcode(f"M118 {line}")
+            except Exception as exc:
+                logger.error("run_gcode failed: %s", exc)
+
+        if self.watcher is None:
+            why = ("LAN-only mode has no cloud push path"
+                   if self.lan_only else
+                   "cloud machinery unavailable (see moonraker.log)")
+            await _say(f"Moongate: can't send - {why}.")
+            return
+        text = _notify_text(message)
+        if not text:
+            await _say('Moongate: nothing to send - use MOONGATE_NOTIFY MSG="your text".')
+            return
+        now = time.monotonic()
+        if self._notify_last is not None and now - self._notify_last < 10.0:
+            await _say("Moongate: notification skipped - at most one send per 10 s.")
+            return
+        self._notify_last = now
+        loop = asyncio.get_event_loop()
+        ok = await loop.run_in_executor(
+            None, self.watcher._send_event, "custom", text)
+        await _say("Moongate: notification sent."
+                   if ok else
+                   "Moongate: notification NOT sent - see moonraker.log.")
 
     async def _do_factory_reset(self) -> tuple[bool, int]:
         """Shared reset path used by the macro and the HTTP endpoint:

--- a/klipper-plugin/moongate_standalone.py
+++ b/klipper-plugin/moongate_standalone.py
@@ -1424,10 +1424,15 @@ class PrintEventWatcher:
                         self._error_sent_at = time.monotonic()
                         await loop.run_in_executor(None, self._send_event, k_event, reason)
 
-                state, filename = await loop.run_in_executor(None, self._poll_print_state)
+                state, filename, message = await loop.run_in_executor(
+                    None, self._poll_print_state)
                 if state is not None and state != self._last_state:
                     event = self._event_for(self._last_state, state)
                     self._last_state = state
+                    # A failed print's push carries WHY when Klipper says
+                    # (print_stats.message), falling back to the filename.
+                    detail = (_error_detail(message) or filename
+                              if event == "failed" else filename)
                     if event == "failed" and self._error_sent_at is not None \
                             and time.monotonic() - self._error_sent_at < 60.0:
                         # The klippy watcher already reported this incident,
@@ -1438,7 +1443,7 @@ class PrintEventWatcher:
                         logger.debug(
                             "Push event '%s' skipped - cloud contact dormant", event)
                     elif event:
-                        await loop.run_in_executor(None, self._send_event, event, filename)
+                        await loop.run_in_executor(None, self._send_event, event, detail)
             except asyncio.CancelledError:
                 return
             except Exception as exc:
@@ -1458,6 +1463,10 @@ class PrintEventWatcher:
             return None
         if state == "printing" and prev != "paused":
             return "started"
+        if state == "paused" and prev == "printing":
+            # v0.6.25: filament-runout macros and manual pauses alike - a
+            # paused print wants eyes on it either way.
+            return "paused"
         if state == "complete":
             return "completed"
         if state == "error":
@@ -1508,19 +1517,23 @@ class PrintEventWatcher:
             logger.debug("printer/info poll failed: %s", exc)
             return ""
 
-    def _poll_print_state(self) -> tuple[Optional[str], str]:
-        """Read print_stats.state and .filename from the local Moonraker.
-        Returns (None, "") on any failure so the loop simply skips this tick
+    def _poll_print_state(self) -> tuple[Optional[str], str, str]:
+        """Read print_stats.state, .filename and .message from the local
+        Moonraker. message carries the gcode-level failure reason ("Move out
+        of range ...", "Must home axis first") when state is error - v0.6.25
+        surfaces it in the push instead of just the filename. Returns
+        (None, "", "") on any failure so the loop simply skips this tick
         without disturbing the baseline."""
         try:
             url = f"http://127.0.0.1:{self.port}/printer/objects/query?print_stats"
             with urllib.request.urlopen(url, timeout=5) as resp:
                 data = json.loads(resp.read().decode())
             ps = data["result"]["status"]["print_stats"]
-            return ps.get("state"), (ps.get("filename") or "")
+            return (ps.get("state"), (ps.get("filename") or ""),
+                    (ps.get("message") or ""))
         except Exception as exc:
             logger.debug("print_stats poll failed: %s", exc)
-            return None, ""
+            return None, "", ""
 
     def _send_event(self, event: str, detail: str) -> bool:
         """Sign + send one push event. Returns True when the server accepted

--- a/klipper-plugin/tests/test_notifications.py
+++ b/klipper-plugin/tests/test_notifications.py
@@ -39,6 +39,7 @@ def _load(name):
 
 mod    = _load("moongate_notifications")
 kevent = mod.PrintEventWatcher._klippy_event_for
+pevent = mod.PrintEventWatcher._event_for
 
 PASS = 0
 FAIL = 0
@@ -77,6 +78,17 @@ check("shutdown -> ready silent",   kevent("shutdown", "ready"),   None)
 check("ready -> startup silent",    kevent("ready", "startup"),    None)
 check("startup -> ready silent",    kevent("startup", "ready"),    None)
 check("ready -> disconnected silent", kevent("ready", "disconnected"), None)
+
+# ── _event_for: the paused addition (v0.6.25) ───────────────────────────────
+
+# A pause wants eyes on it whether a filament-runout macro or a human caused
+# it; a resume is not a fresh start; cancelled stays deliberately silent.
+check("printing -> paused fires",   pevent("printing", "paused"),    "paused")
+check("paused -> printing silent (resume)", pevent("paused", "printing"), None)
+check("baseline into paused silent", pevent(None, "paused"),         None)
+check("printing -> cancelled silent", pevent("printing", "cancelled"), None)
+check("paused -> complete still completes", pevent("paused", "complete"), "completed")
+check("standby -> printing still starts", pevent("standby", "printing"), "started")
 
 # ── _error_detail: shutdown reason -> one push line ─────────────────────────
 

--- a/klipper-plugin/tests/test_notifications.py
+++ b/klipper-plugin/tests/test_notifications.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""v0.6.25 regression tests: machine-error push + MOONGATE_NOTIFY text.
+
+The field report behind the feature (2026-08-24, Discord): a printer errored
+out, mobileraker notified, Moongate stayed silent. The old watcher only saw
+print_stats transitions, and a real Klipper error/shutdown knocks out the
+print_stats query itself - blind exactly when it matters. The fix watches
+klippy_state (via /server/info, which keeps answering) alongside.
+
+Three pure functions carry the behaviour and are pinned here:
+  - PrintEventWatcher._klippy_event_for: the transition -> event matrix
+  - _error_detail: shutdown reason -> one clean push line
+  - _notify_text: MOONGATE_NOTIFY MSG -> sanitised, capped text
+
+Stdlib-only on purpose, same loader as test_lan_only_no_deps.py:
+
+    python3 klipper-plugin/tests/test_notifications.py
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "moongate_standalone.py"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_PATH)
+    mod  = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass looks its module up in sys.modules.
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+mod    = _load("moongate_notifications")
+kevent = mod.PrintEventWatcher._klippy_event_for
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, got, want):
+    global PASS, FAIL
+    if got == want:
+        PASS += 1
+        print(f"  ok: {label}")
+    else:
+        FAIL += 1
+        print(f"FAIL: {label}: got {got!r}, want {want!r}")
+
+
+# ── _klippy_event_for: the transition matrix ────────────────────────────────
+
+# Baseline: never alert for the state the printer was already in at load -
+# a plugin update on an already-dead printer must not fire a stale alert.
+check("baseline into shutdown -> no event", kevent(None, "shutdown"), None)
+check("baseline into ready -> no event",    kevent(None, "ready"),    None)
+
+# Arrival in an error state fires, whatever healthy state preceded it.
+check("ready -> shutdown fires",        kevent("ready", "shutdown"),        "error")
+check("ready -> error fires",           kevent("ready", "error"),           "error")
+check("printing -> shutdown fires",     kevent("printing", "shutdown"),     "error")
+check("startup -> error fires",         kevent("startup", "error"),         "error")
+check("disconnected -> shutdown fires", kevent("disconnected", "shutdown"), "error")
+
+# Shuffles between the two error states never refire - one alert per disaster.
+check("shutdown -> error silent", kevent("shutdown", "error"),    None)
+check("error -> shutdown silent", kevent("error", "shutdown"),    None)
+
+# Recovery and healthy churn are silent in v1.
+check("shutdown -> ready silent",   kevent("shutdown", "ready"),   None)
+check("ready -> startup silent",    kevent("ready", "startup"),    None)
+check("startup -> ready silent",    kevent("startup", "ready"),    None)
+check("ready -> disconnected silent", kevent("ready", "disconnected"), None)
+
+# ── _error_detail: shutdown reason -> one push line ─────────────────────────
+
+klipper_msg = ("Heater extruder not heating at expected rate\n"
+               "See the 'verify_heater' section in docs/Config_Reference.md\n"
+               "Once the underlying issue is corrected, use the\n"
+               "FIRMWARE_RESTART command to reset the firmware...")
+check("multi-line reason -> first line",
+      mod._error_detail(klipper_msg),
+      "Heater extruder not heating at expected rate")
+check("leading blank lines skipped",
+      mod._error_detail("\n\n  MCU 'mcu' shutdown: Timer too close\nrest"),
+      "MCU 'mcu' shutdown: Timer too close")
+check("empty reason -> empty", mod._error_detail(""),   "")
+check("None reason -> empty",  mod._error_detail(None), "")
+check("long first line capped at 180",
+      len(mod._error_detail("x" * 500)), 180)
+check("control chars scrubbed",
+      mod._error_detail("bad\x07bell\x1b[31m line"),
+      "bad bell [31m line")
+
+# ── _notify_text: MOONGATE_NOTIFY MSG sanitiser ─────────────────────────────
+
+check("plain text passes", mod._notify_text("Spool nearly empty"),
+      "Spool nearly empty")
+check("whitespace collapses",
+      mod._notify_text("  filament   \n  swap\ttime  "),
+      "filament swap time")
+check("control chars stripped then collapsed",
+      mod._notify_text("ding\x00\x01dong"), "ding dong")
+check("empty stays empty",     mod._notify_text(""),   "")
+check("None stays empty",      mod._notify_text(None), "")
+check("capped at 200", len(mod._notify_text("y" * 300)), 200)
+check("non-string input coerced", mod._notify_text(42), "42")
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/klipper-plugin/update.sh
+++ b/klipper-plugin/update.sh
@@ -117,4 +117,21 @@ MACRO
     fi
 done
 
+# ── 6. Migration: add the MOONGATE_NOTIFY macro to existing installs ─────────
+# New in plugin 0.6.25 - same pattern (and same caveats) as MOONGATE_STATUS
+# above: appended once, loads on the box's next Klipper restart.
+for cfg in "$PRINTER_DATA/config/moongate.cfg" \
+           "$HOME/klipper_config/moongate.cfg"; do
+    if [[ -f "$cfg" ]] && ! grep -q 'MOONGATE_NOTIFY' "$cfg"; then
+        cat >> "$cfg" << 'MACRO'
+
+[gcode_macro MOONGATE_NOTIFY]
+description: Push a custom Moongate notification to your phone (MSG="text")
+gcode:
+    {action_call_remote_method("moongate_notify", message=params.MSG|default("")|string)}
+MACRO
+        ok "MOONGATE_NOTIFY macro added to $cfg (loads on the next Klipper restart)"
+    fi
+done
+
 ok "Update complete."

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -13,8 +13,9 @@
 // Request body:
 //   {
 //     "pi_public_key": "<base64 Ed25519 pubkey>",
-//     "event":         "started" | "completed" | "failed",
-//     "detail":        "<optional, e.g. the gcode filename>",
+//     "event":         "started" | "completed" | "failed" | "error" | "custom",
+//     "detail":        "<optional - gcode filename, shutdown reason, or for
+//                       "custom" the whole message (plugin 0.6.25+)>",
 //     "timestamp":     <unix seconds>,
 //     "signature":     "<base64 Ed25519 signature over canonical payload>"
 //   }
@@ -36,15 +37,22 @@ import { sendApns, ApnsAlert } from "./apns.ts";
 
 const REPLAY_WINDOW_SECONDS = 60;
 const MAX_DETAIL = 200;
-const EVENTS = new Set(["started", "completed", "failed"]);
+const EVENTS = new Set(["started", "completed", "failed", "error", "custom"]);
 
 // Server-side message text. English for v1; APNs loc-keys can localise this
 // later against the app's iOS strings without changing the signed contract.
 function buildAlert(event: string, printerName: string, detail: string): ApnsAlert {
+  // "custom" (plugin 0.6.25+, the MOONGATE_NOTIFY macro): the detail IS the
+  // message, already sanitised and capped on the Pi (and re-capped here).
+  if (event === "custom") {
+    return { title: printerName, body: detail || "Notification" };
+  }
   const base = event === "started"
     ? "Print started"
     : event === "completed"
     ? "Print finished"
+    : event === "error"
+    ? "Printer error"
     : "Print failed";
   return { title: printerName, body: detail ? `${base}: ${detail}` : base };
 }
@@ -72,12 +80,14 @@ Deno.serve(async (req) => {
   const timestamp = body.timestamp;
   const signature = body.signature;
   // detail is optional; normalise to a capped string (also part of the signed
-  // payload, so "" must be signed when absent).
-  const detail = typeof body.detail === "string" ? body.detail.slice(0, MAX_DETAIL) : "";
+  // payload, so "" must be signed when absent, and the signature must be
+  // checked over the text AS SIGNED - sanitising waits until after
+  // verification, for display only.
+  const detailRaw = typeof body.detail === "string" ? body.detail.slice(0, MAX_DETAIL) : "";
 
   if (typeof piPubKey !== "string") return badRequest("pi_public_key required");
   if (typeof event !== "string" || !EVENTS.has(event)) {
-    return badRequest("event must be started, completed, or failed");
+    return badRequest("event must be started, completed, failed, error, or custom");
   }
   if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
     return badRequest("timestamp required (unix seconds)");
@@ -95,9 +105,13 @@ Deno.serve(async (req) => {
   const now = Math.floor(Date.now() / 1000);
   if (Math.abs(now - timestamp) > REPLAY_WINDOW_SECONDS) return unauthorized();
 
-  const canonical = `moongate-push\n${piPubKey}\n${event}\n${detail}\n${timestamp}`;
+  const canonical = `moongate-push\n${piPubKey}\n${event}\n${detailRaw}\n${timestamp}`;
   const message   = new TextEncoder().encode(canonical);
   if (!(await verifyEd25519(piPubKey, signature, message))) return unauthorized();
+
+  // Verified - now scrub control chars for display. The 0.6.25 Pi sanitises
+  // before signing anyway; this is the backstop for whatever else signs.
+  const detail = detailRaw.replace(/[\u0000-\u001f\u007f]/g, " ");
 
   const db = adminClient();
 

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -13,7 +13,7 @@
 // Request body:
 //   {
 //     "pi_public_key": "<base64 Ed25519 pubkey>",
-//     "event":         "started" | "completed" | "failed" | "error" | "custom",
+//     "event":         "started" | "completed" | "failed" | "paused" | "error" | "custom",
 //     "detail":        "<optional - gcode filename, shutdown reason, or for
 //                       "custom" the whole message (plugin 0.6.25+)>",
 //     "timestamp":     <unix seconds>,
@@ -37,7 +37,7 @@ import { sendApns, ApnsAlert } from "./apns.ts";
 
 const REPLAY_WINDOW_SECONDS = 60;
 const MAX_DETAIL = 200;
-const EVENTS = new Set(["started", "completed", "failed", "error", "custom"]);
+const EVENTS = new Set(["started", "completed", "failed", "paused", "error", "custom"]);
 
 // Server-side message text. English for v1; APNs loc-keys can localise this
 // later against the app's iOS strings without changing the signed contract.
@@ -51,6 +51,8 @@ function buildAlert(event: string, printerName: string, detail: string): ApnsAle
     ? "Print started"
     : event === "completed"
     ? "Print finished"
+    : event === "paused"
+    ? "Print paused"
     : event === "error"
     ? "Printer error"
     : "Print failed";
@@ -87,7 +89,7 @@ Deno.serve(async (req) => {
 
   if (typeof piPubKey !== "string") return badRequest("pi_public_key required");
   if (typeof event !== "string" || !EVENTS.has(event)) {
-    return badRequest("event must be started, completed, failed, error, or custom");
+    return badRequest("event must be one of: started, completed, failed, paused, error, custom");
   }
   if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
     return badRequest("timestamp required (unix seconds)");


### PR DESCRIPTION
## What will this PR change?

Two things iPhone (and later Android) users asked for in the same Discord thread:

1. **You'll get a notification when the machine errors out.** Today the "Print failed" push only catches gcode-level failures; a real Klipper error or shutdown (thermal runaway, MCU error, the "needs restarting" kind) actually knocks out the API the watcher polls, so it goes blind right when it matters, whether mid-print or idle. The watcher now also polls `klippy_state` via `/server/info`, which keeps answering while Klipper is down, and pushes a "Printer error" alert with the shutdown reason in it (e.g. "Heater extruder not heating at expected rate").
2. **A new `MOONGATE_NOTIFY MSG="your text"` macro** pushes a custom notification to your phone from any gcode: slicer end-gcode, filament-runout handlers, timelapse hooks, whatever.

## How

- Plugin: klippy-state watch rides the existing 20s poll loop and the existing Pi-signed send-push path. Baseline rules mirror print events (no alert for whatever state the plugin loaded into), shutdown/error shuffles never refire, and a `print_stats` "failed" within 60s of a klippy error is suppressed, one alert per disaster with the richer reason. `MOONGATE_NOTIFY` sanitises + caps the text, rate-limits to one send per 10s, and acks the outcome in the console, including honest refusals on LAN-only installs (no cloud push path).
- `send-push` edge function: two new event types, `error` and `custom`. Signature verification now runs over the detail exactly as the Pi signed it, with display sanitising moved after verification (sanitising first would have rejected any signer whose raw text differed from the cleaned text).
- `install.sh` writes the macro for fresh installs; `update.sh` migrates existing managed installs (grep-guarded, loads on the next Klipper restart), same pattern as MOONGATE_STATUS in 0.6.23.
- iOS needs **zero app changes**, alert text is built server-side. Android parity (its notifications come from the app's foreground service, not push) is app-side Dart work and deliberately rides 0.9.61 instead of this PR.

## Testing

- New `tests/test_notifications.py` (stdlib-only, same harness): 26 pins across the klippy transition matrix, the shutdown-reason reducer, and the notify sanitiser. All 7 plugin suites pass; ruff clean.
- Still owed before merge: edge-function deploy, then the live pass on a real rig + iPhone: trigger an idle shutdown (M112), expect the "Printer error" push with the reason; `MOONGATE_NOTIFY MSG="test"`, expect the custom push; confirm rate-limit and LAN-only refusal messages in the console.

Stacked on #282 (both bump the plugin version), merge order: #282 first, then this.

PEEKYPAUL 24/08/2026
