### PR TITLE
File System: filter timestamped updater backups + open them as text

### DIFF
--- a/mobile/lib/services/print_control_service.dart
+++ b/mobile/lib/services/print_control_service.dart
@@ -1015,12 +1015,15 @@ class ConfigFileEntry {
   /// user's `[include *.cfg]` glob can never pull a backup in.
   bool get isMoongateBackup => path.endsWith('.moongate-bak');
 
-  /// Klipper's SAVE_CONFIG snapshots (`printer-20260829_101530.cfg`) and
-  /// generic backup suffixes. The date pattern is exact - a real
-  /// `printer-macros.cfg` must never match.
+  /// Klipper's SAVE_CONFIG snapshots (`printer-20260829_101530.cfg`),
+  /// updater copies that bolt a timestamp after the extension
+  /// (crowsnest's `crowsnest.conf.2024-12-22-1121`), and generic backup
+  /// suffixes. The date patterns are exact - a real `printer-macros.cfg`
+  /// must never match.
   bool get isBackup {
     if (_saveConfigSnapshot.hasMatch(name)) return true;
     final n = name.toLowerCase();
+    if (_timestampedBackup.hasMatch(n)) return true;
     return n.endsWith('.bak') || n.endsWith('.bkp') || n.endsWith('~');
   }
 
@@ -1031,12 +1034,21 @@ class ConfigFileEntry {
   static final RegExp _saveConfigSnapshot =
       RegExp(r'^printer-\d{8}_\d{6}\.cfg$');
 
+  /// A config extension followed by a `YYYY-MM-DD[-HHMM]` tail. Matched
+  /// against the lowercased name by [isBackup] and [isEditable]: such a
+  /// file is a backup, but it is still config text, so with backups shown
+  /// it must open like the file it was copied from.
+  static final RegExp _timestampedBackup =
+      RegExp(r'\.(cfg|conf)\.\d{4}-\d{2}-\d{2}(-\d{4,6})?$');
+
   /// Text formats the structured editor opens. Everything else (images,
   /// binaries someone dropped in the folder) stays listed but read-only.
+  /// Timestamped backups pass: the extension sits mid-name, but the
+  /// content is the config text it was copied from.
   bool get isEditable {
     final n = name.toLowerCase();
     const exts = ['.cfg', '.conf', '.txt', '.ini', '.md', '.json', '.yaml', '.yml'];
-    return exts.any(n.endsWith);
+    return exts.any(n.endsWith) || _timestampedBackup.hasMatch(n);
   }
 
   DateTime? get modifiedAt => modified > 0

--- a/mobile/test/config_file_entry_test.dart
+++ b/mobile/test/config_file_entry_test.dart
@@ -32,6 +32,36 @@ void main() {
     test('a snapshot inside a folder still counts', () {
       expect(_entry('old/printer-20250101_000000.cfg').isBackup, isTrue);
     });
+
+    test('a timestamped updater copy is a backup (crowsnest style)', () {
+      expect(_entry('crowsnest.conf.2024-12-22-1121').isBackup, isTrue);
+      expect(_entry('printer.cfg.2026-01-03').isBackup, isTrue);
+      expect(_entry('sub/crowsnest.conf.2024-12-22-1121').isBackup, isTrue);
+    });
+
+    test('the timestamp tail is exact - lookalikes are NOT backups', () {
+      expect(_entry('crowsnest.conf').isBackup, isFalse);
+      expect(_entry('crowsnest.conf.d').isBackup, isFalse);
+      expect(_entry('probe.cfg.202-12-22-1121').isBackup, isFalse);
+      expect(_entry('notes.txt.2024-12-22-1121').isBackup, isFalse);
+    });
+  });
+
+  group('ConfigFileEntry.isEditable', () {
+    test('a timestamped backup opens as the config text it is', () {
+      expect(_entry('crowsnest.conf.2024-12-22-1121').isEditable, isTrue);
+      expect(_entry('printer.cfg.2026-01-03').isEditable, isTrue);
+    });
+
+    test('unknown extensions stay read-only', () {
+      expect(_entry('photo.png').isEditable, isFalse);
+      expect(_entry('crowsnest.conf.d').isEditable, isFalse);
+    });
+
+    test('plain config files are editable', () {
+      expect(_entry('printer.cfg').isEditable, isTrue);
+      expect(_entry('crowsnest.conf').isEditable, isTrue);
+    });
   });
 
   group('ConfigFileEntry.isHidden', () {


### PR DESCRIPTION
## What will this PR change?

The File System browser's "Hide backups & hidden files" checkbox now also hides timestamped updater backups such as crowsnest's `crowsnest.conf.2024-12-22-1121`, and when backups are shown, those files open in the editor instead of being stuck read-only.

## The gist

A Discord report (HitLuca) showed two things wrong with crowsnest's backup files:

1. They were not filtered by the hide-backups checkbox. The backup matcher only knew Klipper's `printer-YYYYMMDD_HHMMSS.cfg` snapshots and the `.bak`/`.bkp`/`~` suffixes. Crowsnest bolts a `YYYY-MM-DD-HHMM` timestamp on **after** the extension, a fourth shape.
2. They could not be opened at all. The editor only opens names **ending** in a known text extension, so a name ending in digits fell into the binary-file read-only guard, even though the content is plain config text.

One new exact-shape regex (`.cfg`/`.conf` followed by a date-like tail) fixes both: `isBackup` uses it to hide them, `isEditable` uses it to open them when the checkbox is unticked. Lookalikes such as `crowsnest.conf.d` deliberately do not match.

No plugin, cloud, or preference-key changes. No version bump, rides the next release.

## Tests

Six new cases in `config_file_entry_test.dart` (the reported filename verbatim, a date-only tail, in-folder, and the non-match lookalikes). Full suite passes.

PEEKYPAUL 01/09/2026
