### PR TITLE
docs: Ko-fi and PayPal sponsor links (GitHub sidebar + README)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Powers the "Sponsor this project" box in the GitHub sidebar.
+# Ko-fi is the preferred route; the PayPal link is the same tip jar the app
+# and README already use.
+ko_fi: peekypaul
+custom: ["https://www.paypal.com/donate/?hosted_button_id=WCWAZKQ7WKQB4"]

--- a/README.md
+++ b/README.md
@@ -239,13 +239,16 @@ Direct mode isn't picky about the host, either: from plugin 0.6.17 it needs **ze
 
 ## Buy me a coffee
 
-Moongate is free, source available, and built in my spare time for the Klipper community - no ads, no subscriptions, no data harvesting. If it's earned a spot on your phone, you can buy me a coffee to say thanks. Every contribution goes straight back into the project: test hardware, the cloud service that keeps remote access working, and the time to keep shipping features.
+Moongate is free, source available, and built in my spare time for the Klipper community - no ads, no subscriptions, no data harvesting. If it's earned a spot on your phone, you can buy me a coffee on [Ko-fi](https://ko-fi.com/peekypaul) (or tip via PayPal) to say thanks. Every contribution goes straight back into the project: test hardware, the cloud service that keeps remote access working, and the time to keep shipping features.
 
 Thank you for being part of it 💜
 
 <p align="center">
+  <a href="https://ko-fi.com/peekypaul">
+    <img src="https://img.shields.io/badge/%E2%98%95%20Buy%20me%20a%20coffee%20on%20Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Buy me a coffee on Ko-fi"/>
+  </a>
   <a href="https://www.paypal.com/donate/?hosted_button_id=WCWAZKQ7WKQB4">
-    <img src="https://img.shields.io/badge/%E2%98%95%20Buy%20me%20a%20coffee-Donate-FFDD00?style=for-the-badge" alt="Buy me a coffee"/>
+    <img src="https://img.shields.io/badge/Donate%20with%20PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white" alt="Donate with PayPal"/>
   </a>
 </p>
 


### PR DESCRIPTION
## What will this PR change?

1. **GitHub "Sponsor this project" box.** Adds `.github/FUNDING.yml` with the Ko-fi page (https://ko-fi.com/peekypaul) and the existing PayPal tip jar, so the repo sidebar gets the sponsor box and the Sponsor button appears at the top, the same way https://github.com/dw-0/kiauh does it.
2. **README "Buy me a coffee" section.** Ko-fi becomes the headline button, next to a restyled PayPal button in the same badge style (both with their logos), and the paragraph now links Ko-fi directly.

## Why

Ko-fi is the friendlier tip route (no account needed, keeps the whole tip). GitHub renders the sidebar box itself from the funding file, so nothing else in the repo changes.

## Testing

- Both badges fetched from shields.io and confirmed to render with their Ko-fi / PayPal logos.
- The funding file uses GitHub's documented keys (`ko_fi` username, `custom` URL list), same shape as kiauh's.
- Docs-only on the app side: no Dart, plugin, or version changes.

## Merge note

`.github/FUNDING.yml` is not covered by the docs `paths-ignore`, so a plain merge would trigger the master APK build and re-publish v0.9.65. Merge with the token in the subject:

```
gh pr merge <N> --squash --subject "docs: Ko-fi and PayPal sponsor links (#<N>) [skip ci]" --delete-branch
```

PEEKYPAUL 07/09/2026
