### PR TITLE
docs: heat-soak alert conditions + at-temperature macro in TROUBLESHOOTING, archived ZeroTier link [skip ci]

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -117,6 +117,26 @@ Loud Android alerts for these moments arrived in **v0.9.61** - older versions on
 
 Direct (LAN/VPN) printers are the documented exception: no notifications in cloud-free mode.
 
+## The heat-soak alert never arrived (and how to be told when a heater is actually at temperature)
+
+The **heat-soak timer** in a tile's Preheat sheet (long-press the temperatures while the printer is idle, v0.9.30+) is a **countdown, not a thermometer**: enter minutes and Moongate posts a "Heat-soak complete" alert when they elapse, whatever the heaters are doing. The alert is delivered by the same Android background monitoring as the alerts above, so the same rules apply:
+
+1. **Android only.** iPhones get their alerts from the printer's push, which has no heat-soak event, so a timer set on an iPhone never fires - use the macro below instead.
+2. **Print notifications on and not paused** when the timer runs out. The sheet warns (with a one-tap "Turn on") if they're off; the timer is still armed, so switching them on within the hour lets it fire.
+3. **The "Heat soak timer" category isn't muted.** It's a separate notification category so it can buzz on its own.
+4. It fires on the next background check after the deadline, so allow up to your refresh interval (default 30 seconds). A deadline that passed more than an hour ago is dropped quietly rather than buzzing late.
+
+**Want an alert on the real temperature, for any heater or sensor?** Klipper can wait for it and the `MOONGATE_NOTIFY` macro can tell you (plugin 0.6.25+ for iPhone, 0.6.26+ for Android with print notifications on):
+
+```
+[gcode_macro BED_READY]
+gcode:
+    TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM=100
+    MOONGATE_NOTIFY MSG="Bed is at 100"
+```
+
+For a chamber or other sensor use `SENSOR="temperature_sensor chamber"`. `TEMPERATURE_WAIT` holds the print queue until the temperature is reached, so use it in a "heat up, then tell me" macro or at the start of a print, not as a background watcher.
+
 ## Chamber temperature missing on the dashboard
 
 If a printer's chamber temperature doesn't appear on its tile even though it shows in Mainsail, update to **v0.9.32 or newer**. That release made chamber detection robust for combined chamber sensors (`temperature_combined`) and sensors named with capital letters, especially over the remote tunnel.

--- a/docs/v0.4-secure-remote-access-design.md
+++ b/docs/v0.4-secure-remote-access-design.md
@@ -1035,7 +1035,7 @@ WireGuard / mobile VPN landscape:
 - [Tailscale Peer Relays](https://tailscale.com/docs/features/peer-relay)
 - [Headscale GitHub](https://github.com/juanfont/headscale)
 - [Issue #7240 - embed Tailscale](https://github.com/tailscale/tailscale/issues/7240)
-- [ZeroTier - on the GPL→BSL transition](https://www.zerotier.com/news/on-the-gpl-to-bsl-transition/)
+- [ZeroTier - on the GPL→BSL transition](https://web.archive.org/web/20251111042146/https://www.zerotier.com/news/on-the-gpl-to-bsl-transition/)
 - [Slack/Nebula GitHub](https://github.com/slackhq/nebula)
 - [NetBird GitHub](https://github.com/netbirdio/netbird)
 


### PR DESCRIPTION
## What will this PR change?

Docs only, the end-of-session sweep for 12/09/2026. Nothing in the app or plugin changes.

Plain-English gist: a Discord user asked for an alert when a heater reaches temperature, which surfaced that the heat-soak timer is a countdown (it never reads a thermistor) and only fires through the Android monitoring service. The troubleshooting guide now says so, lists the reasons the alert may not arrive, and gives the Klipper macro that does the real at-temperature alert today.

## What's in it

- **TROUBLESHOOTING.md**: new section "The heat-soak alert never arrived (and how to be told when a heater is actually at temperature)" under the notifications entries: Android only (an iPhone timer never fires), print notifications on and not paused, the "Heat soak timer" category unmuted, poll-interval latency, the one-hour stale drop, then the `TEMPERATURE_WAIT` + `MOONGATE_NOTIFY MSG=` macro (plugin 0.6.25+ iPhone, 0.6.26+ Android) with the queue-blocking caveat.
- **docs/v0.4-secure-remote-access-design.md**: the ZeroTier "GPL to BSL transition" reference had gone 404 on zerotier.com; it now points at the Wayback Machine copy.
- Link audit this session: 19 Markdown files, 120 internal links, 0 broken; every external link answers 200 except ko-fi.com (403 to non-browser clients, renders fine in the README).
- README, ARCHITECTURE, DEVELOPMENT, SECURITY and both changelogs are unaffected (no code shipped this session; v0.9.66 already carries its changelog pair).

## Notes

- Markdown only, so the build workflows skip it via `paths-ignore`; merge with `gh pr merge <N> --squash --subject "docs: heat-soak alert conditions + at-temperature macro in TROUBLESHOOTING, archived ZeroTier link (#<N>) [skip ci]" --delete-branch`.

PEEKYPAUL 12/09/2026
